### PR TITLE
CI: Fix static checks script for callers

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -10,8 +10,12 @@
 
 set -e
 
+# Since this script is called from another repositories directory,
+# ensure the utility is built before running it.
+self="$GOPATH/src/github.com/kata-containers/tests"
+(cd "$self" && make checkcommits)
+
 # Check the commits in the branch
-make checkcommits
 checkcommits \
 	--need-fixes \
 	--need-sign-offs \


### PR DESCRIPTION
The static checks script was incorrectly assuming it was being run in
the tests repository. This "works", but then only runs the checks on the
`tests` repository, *not* those of the caller (which might actually be the
`tests` repository of course). Crucially, callers need to be able to
invoke the static check script without `cd`-ing to the `tests`
repository directory.

Fixes #13.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>