### PR TITLE
CI: Fix linter errors for checkcommits

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -72,6 +72,7 @@ func init() {
 	var err error
 	gitPath, err = exec.LookPath("git")
 	if err != nil {
+		// #nosec
 		fmt.Fprintf(os.Stderr, "ERROR: cannot find git in PATH\n")
 		os.Exit(1)
 	}
@@ -458,6 +459,7 @@ func preChecks(config *CommitConfig, commit, branch string) error {
 func runCommand(args []string) (stdout []string, err error) {
 	var outBytes, errBytes bytes.Buffer
 
+	// #nosec
 	cmd := exec.Command(args[0], args[1:]...)
 
 	cmdline := strings.Join(args, " ")
@@ -641,6 +643,7 @@ func main() {
 	app.UsageText += fmt.Sprintf("     to %q and branch to %q.", defaultCommit, defaultBranch)
 
 	cli.VersionPrinter = func(c *cli.Context) {
+		// #nosec
 		fmt.Fprintf(os.Stdout, "%s version %s %s\n",
 			c.App.Name,
 			c.App.Version,
@@ -726,6 +729,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
+		// #nosec
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -179,7 +179,7 @@ func clearCIVariables() {
 	}
 
 	for _, envVar := range envVars {
-		os.Unsetenv(envVar)
+		_ = os.Unsetenv(envVar)
 	}
 }
 
@@ -570,15 +570,15 @@ func TestDetectCIEnvironment(t *testing.T) {
 		commit, dstBranch, srcBranch := detectCIEnvironment()
 
 		if commit != d.expectedCommit {
-			t.Fatalf("Unexpected commit %v (%+v)", commit, d)
+			t.Fatalf("Unexpected commit %v (%v: %+v)", commit, d.name, d)
 		}
 
 		if dstBranch != d.expectedDstBranch {
-			t.Fatalf("Unexpected destination branch %v (%+v)", dstBranch, d)
+			t.Fatalf("Unexpected destination branch %v (%v: %+v)", dstBranch, d.name, d)
 		}
 
 		if srcBranch != d.expectedSrcBranch {
-			t.Fatalf("Unexpected source branch %v (%+v)", srcBranch, d)
+			t.Fatalf("Unexpected source branch %v (%v: %+v)", srcBranch, d.name, d)
 		}
 
 		// Crudely undo the changes (it'll be fully undone later
@@ -654,11 +654,11 @@ func TestGetCommitAndBranch(t *testing.T) {
 		}
 
 		if commit != d.expectedCommit {
-			t.Fatalf("Unexpected commit %v (%+v)", commit, d)
+			t.Fatalf("Unexpected commit %v (%v: %+v)", commit, d.name, d)
 		}
 
 		if dstBranch != d.expectedDstBranch {
-			t.Fatalf("Unexpected destination branch %v (%+v)", dstBranch, d)
+			t.Fatalf("Unexpected destination branch %v (%v: %+v)", dstBranch, d.name, d)
 		}
 
 		// Crudely undo the changes (it'll be fully undone later


### PR DESCRIPTION
Resolve issues reported by the gas and structcheck linters .

Fixes #12.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>