### PR TITLE
CI: Only run go linters for golang projects

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -21,6 +21,9 @@ checkcommits \
 	--need-sign-offs \
 	--verbose
 
+go_packages=$(go list ./... 2>/dev/null || true)
+[ -z "$go_packages" ] && exit 0
+
 # Run golang checks
 if [ ! $(command -v gometalinter) ]
 then


### PR DESCRIPTION
Stop `.ci/static-checks.sh` from calling `gometalinter` unconditionally.
That tool is clever enough to not error if there are no golang files to
check, but by having the script detect that scenario, the static checks
can been speeded up.

Fixes #18.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>