### PR TITLE
CI: Make linters really ignore vendored code

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -29,7 +29,9 @@ then
 fi
 
 # Ignore vendor directories
-linter_args="--vendor"
+# Note: There is also a "--vendor" flag which claims to do what we want, but
+# it doesn't work :(
+linter_args="--exclude=\"\\bvendor/.*\""
 
 # Check test code too
 linter_args+=" --tests"


### PR DESCRIPTION
`gometalinter` has a `--vendor` flag, but it doesn't appear to work so
exclude vendored code instead.

Fixes #20.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>