### PR TITLE
CI: Ignore lint warnings on auto-generated code

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -34,6 +34,12 @@ linter_args="--vendor"
 # Check test code too
 linter_args+=" --tests"
 
+# Ignore auto-generated protobuf code.
+#
+# Note that "--exclude=" patterns are *not* anchored meaning this will apply
+# anywhere in the tree.
+linter_args+=" --exclude=\"protocols/grpc/.*\.pb\.go\""
+
 # When running the linters in a CI environment we need to disable them all
 # by default and then explicitly enable the ones we are care about. This is
 # necessary since *if* gometalinter adds a new linter, that linter may cause


### PR DESCRIPTION
Protobuf-generated code cannot be changed by us so ignore lint warnings
on it.

Fixes #22.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>