### PR TITLE
CI: Support KATA_DEV_MODE to enable lenient linters

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -41,9 +41,9 @@ linter_args+=" --tests"
 # run locally, all linters should be run to allow the developer to review any
 # failures (and potentially decide whether we need to explicitly enable a new
 # linter in the CI).
-if [ "$CI" = true ]; then
-	linter_args+=" --disable-all"
-fi
+#
+# Developers may set KATA_DEV_MODE to any value for the same behaviour.
+[ "$CI" = true -o -n "$KATA_DEV_MODE" ] && linter_args+=" --disable-all"
 
 linter_args+=" --enable=misspell"
 linter_args+=" --enable=vet"


### PR DESCRIPTION
The static checks script currently only runs a subset of linters under
the CI, but all linters by default otherwise.

Added a `KATA_DEV_MODE` variable that, if set, will run the same subset.
This is useful and crucially does not require the developer to pretend
to be running under a CI (which could be dangerous).

Fixes #24.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>