### PR TITLE
CI: Ignore golang checks on runtime submodules

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -46,6 +46,14 @@ check_go()
 
 	go_packages=$(go list ./... 2>/dev/null || true)
 
+	# Ignore the runtime repo which uses submodules. The runtimes it
+	# imports are assumed to be tested independently so do not (and should
+	# not) need to be re-tested here.
+	local runtime_repo="github.com/kata-containers/runtime"
+
+	[ -e ".gitmodules" ] && go_packages=$(echo "$go_packages" |\
+		grep -v "$runtime_repo" || true)
+
 	[ -z "$go_packages" ] && return
 
 	# Run golang checks

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -46,7 +46,7 @@ check_go()
 
 	go_packages=$(go list ./... 2>/dev/null || true)
 
-	[ -z "$go_packages" ] && exit 0
+	[ -z "$go_packages" ] && return
 
 	# Run golang checks
 	if [ ! "$(command -v gometalinter)" ]


### PR DESCRIPTION
Stopped the static checks script from running golang checks on the
runtime repos submodules. The runtimes this repo imports are assumed to
be tested independently so do not (and should not) need to be (re-)tested
here.

Fixes #60.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
