### PR TITLE
CI: Add more golang linters

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -97,6 +97,9 @@ check_go()
 	linter_args+=" --cyclo-over=15"
 	linter_args+=" --enable=golint"
 	linter_args+=" --deadline=600s"
+	linter_args+=" --enable=structcheck"
+	linter_args+=" --enable=unused"
+	linter_args+=" --enable=staticcheck"
 
 	eval gometalinter "${linter_args}" ./...
 }


### PR DESCRIPTION
Add the following golang linters to the static checks script for stricter
checking:

- `staticcheck`
- `structcheck`
- `unused`

Fixes #72.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>