### PR TITLE
Skip failing tests

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -180,6 +180,7 @@ var _ = Describe("run", func() {
 
 	Context("hot plug block devices", func() {
 		It("should be attached", func() {
+			Skip("Issue: https://github.com/kata-containers/kata-containers/issues/5")
 			_, _, exitCode := dockerRun(dockerArgs...)
 			Expect(exitCode).To(BeZero())
 		})

--- a/integration/docker/user_test.go
+++ b/integration/docker/user_test.go
@@ -45,6 +45,7 @@ var _ = Describe("users and groups", func() {
 
 	DescribeTable("running container",
 		func(user string, additionalGroups []string, fail bool) {
+			Skip("Issue: https://github.com/kata-containers/shim/issues/46")
 			cmd := []string{"--name", id, "--rm"}
 			for _, ag := range additionalGroups {
 				cmd = append(cmd, "--group-add", ag)


### PR DESCRIPTION
Failing tests that already have opened issues, should be skipped
until the issues are fixed.
This will help us have a stable CI.

Fixes #81

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>