### PR TITLE
CI: Ignore vendor tests

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -18,7 +18,8 @@ timeout_value=${KATA_GO_TEST_TIMEOUT:-10s}
 # KATA_GO_TEST_FLAGS can be set to change the flags passed to "go test".
 go_test_flags=${KATA_GO_TEST_FLAGS:-"-v $race -timeout $timeout_value"}
 
-test_packages=$(go list ./... 2>/dev/null || true)
+# Note: the vendor filtering is required for versions of go older than 1.9
+test_packages=$(go list ./... 2>/dev/null | grep -v "/vendor/" || true)
 
 # The "master" coverage file that contains the coverage results for
 # all packages run under all scenarios.


### PR DESCRIPTION
Fix the `go test` script to manually filter out vendor packages. This
is required for golang 1.8 and older which don't "prune" the output of
`go list` to remove vendor packages as golang 1.9 does.

Fixes #88.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>