### PR TITLE
CI: Fix proxy log selector in teardown script

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -70,7 +70,7 @@ else
 	echo "Kata Containers Runtime (Runv) Log:"
 	journalctl --no-pager -t kata-runtime-runv
 	echo "Kata Containers Proxy Log:"
-	journalctl --no-pager -u kata-proxy
+	journalctl --no-pager -t kata-proxy
 	echo "Kata Containers Shim Log:"
 	journalctl --no-pager -t kata-shim
 	echo "CRI-O Log:"


### PR DESCRIPTION
The proxy is no longer a system service so don't select by systemd unit
if no log copy location is passed to `.ci/teardown.sh`.

Fixes #94.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>