### PR TITLE
CI: Set CI variable for Jenkins

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -7,6 +7,9 @@
 
 set -e
 
+# Signify to all scripts that they are running in a CI environment
+[ -z "${KATA_DEV_MODE}" ] && export CI=true
+
 # Need the repo to know which tests to run.
 kata_repo="$1"
 


### PR DESCRIPTION
The scripts called by the Jenkins script need to know they are running
in a CI environment.

Fixes #105.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>