### PR TITLE
log-parser: Support reading from stdin

### DIFF
--- a/cmd/log-parser/hexbytes.go
+++ b/cmd/log-parser/hexbytes.go
@@ -33,7 +33,7 @@ func NewHexByteReader(file string) *HexByteReader {
 	return &HexByteReader{file: file}
 }
 
-// Reader that converts "\x" to "\\x"
+// Read is a Reader that converts "\x" to "\\x"
 func (r *HexByteReader) Read(p []byte) (n int, err error) {
 	size := len(p)
 

--- a/cmd/log-parser/hexbytes.go
+++ b/cmd/log-parser/hexbytes.go
@@ -30,17 +30,29 @@ type HexByteReader struct {
 // NewHexByteReader returns a new hex byte reader that escapes all
 // hex-encoded characters.
 func NewHexByteReader(file string) *HexByteReader {
-	return &HexByteReader{file: file}
+	var f *os.File
+
+	// treat dash as an alias for standard input
+	if file == stdinFile {
+		f = os.Stdin
+	}
+
+	return &HexByteReader{
+		file: file,
+		f:    f,
+	}
 }
 
 // Read is a Reader that converts "\x" to "\\x"
 func (r *HexByteReader) Read(p []byte) (n int, err error) {
 	size := len(p)
 
-	if r.f == nil {
-		r.f, err = os.Open(r.file)
-		if err != nil {
-			return 0, err
+	if r.data == nil {
+		if r.f == nil {
+			r.f, err = os.Open(r.file)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		// read the entire file

--- a/cmd/log-parser/hexbytes_test.go
+++ b/cmd/log-parser/hexbytes_test.go
@@ -21,6 +21,16 @@ func TestNewHexByteReader(t *testing.T) {
 	file := "/tmp/foo.txt"
 	r := NewHexByteReader(file)
 	assert.Equal(r.file, file)
+	assert.Nil(r.f)
+}
+
+func TestNewHexByteReaderStdin(t *testing.T) {
+	assert := assert.New(t)
+
+	file := "-"
+	r := NewHexByteReader(file)
+	assert.Equal(r.file, file)
+	assert.Equal(r.f, os.Stdin)
 }
 
 func TestHexByteReaderRead(t *testing.T) {

--- a/cmd/log-parser/logentry.go
+++ b/cmd/log-parser/logentry.go
@@ -97,8 +97,10 @@ func (le LogEntry) Check() error {
 		return fmt.Errorf("missing filename: %+v", le)
 	}
 
-	if !strings.HasPrefix(le.Filename, "/") {
-		return fmt.Errorf("filename not absolute: %+v", le)
+	if le.Filename != stdinFile {
+		if !strings.HasPrefix(le.Filename, "/") {
+			return fmt.Errorf("filename not absolute: %+v", le)
+		}
 	}
 
 	if le.Line == 0 {

--- a/cmd/log-parser/logentry_test.go
+++ b/cmd/log-parser/logentry_test.go
@@ -150,6 +150,19 @@ func TestLogEntryCheck(t *testing.T) {
 			},
 			true,
 		},
+
+		{
+			LogEntry{
+				Filename: "-",
+				Line:     1,
+				Time:     time.Now().UTC(),
+				Pid:      123,
+				Level:    "debug",
+				Source:   "source",
+				Name:     "name",
+			},
+			true,
+		},
 	}
 
 	for i, d := range data {


### PR DESCRIPTION
Allow the `file` argument to be specified as "`-`" meaning
"read from standard input".

Fixes #111.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
