### PR TITLE
CI: Look for fatal errors

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -30,6 +30,27 @@ check_log_files()
 	logs=$(ls "$(pwd)"/*.log)
 	{ kata-log-parser --debug --check-only --error-if-no-records $logs; ret=$?; } || true
 
+	errors=0
+
+	for log in $logs
+	do
+		# Display *all* errors caused by runtime exceptions and fatal
+		# signals.
+		for pattern in "fatal error" "fatal signal"
+		do
+			# Search for pattern and print all subsequent lines with specified log
+			# level.
+			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true | grep "level=\"*error\"*")
+			if [ -n "$results" ]
+			then
+				errors=1
+				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}" || true
+			fi
+		done
+	done
+
+	[ "$errors" -ne 0 ] && exit 1
+
 	# Always remove logs since:
 	#
 	# - We don't want to waste disk-space.


### PR DESCRIPTION
Look for evidence of panics and fatal signals in the component logs
and fail the CI run if found.

Fixes #115.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>