### PR TITLE
tests: Add CRI-O tests.

### DIFF
--- a/.ci/data/crio.service
+++ b/.ci/data/crio.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CRI-O daemon
+Documentation=https://github.com/kubernetes-incubator/cri-o
+
+[Service]
+ExecStart=/usr/local/bin/crio --log-level debug
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/.ci/install_bats.sh
+++ b/.ci/install_bats.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+which bats && exit
+
+echo "Install BATS from sources"
+go get -d github.com/sstephenson/bats || true
+pushd $GOPATH/src/github.com/sstephenson/bats
+sudo -E PATH=$PATH sh -c "./install.sh /usr"
+popd

--- a/.ci/install_cni_plugins.sh
+++ b/.ci/install_cni_plugins.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cni_version="0.3.0"
+
+echo "Retrieve CNI plugins repository"
+go get -d github.com/containernetworking/plugins || true
+pushd $GOPATH/src/github.com/containernetworking/plugins
+
+echo "Build CNI plugins"
+./build.sh
+
+echo "Install CNI binaries"
+cni_bin_path="/opt/cni"
+sudo mkdir -p ${cni_bin_path}
+sudo cp -a bin ${cni_bin_path}
+
+echo "Configure CNI"
+cni_net_config_path="/etc/cni/net.d"
+sudo mkdir -p ${cni_net_config_path}
+
+sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
+{
+	"cniVersion": ${cni_version},
+	"name": "mynet",
+	"type": "bridge",
+	"bridge": "cni0",
+	"isGateway": true,
+	"ipMasq": true,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.88.0.0/16",
+		"routes": [
+			{ "dst": "0.0.0.0/0"  }
+		]
+	}
+}
+EOF'
+
+sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
+{
+	"cniVersion": ${cni_version},
+	"type": "loopback"
+}
+EOF'
+
+popd

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+get_cc_versions
+
+echo "Get CRI-O sources"
+crio_repo="github.com/kubernetes-incubator/cri-o"
+go get -d "$crio_repo" || true
+pushd "${GOPATH}/src/${crio_repo}"
+git fetch
+git checkout "${crio_version}"
+
+# Add link of go-md2man to $GOPATH/bin
+GOBIN="$GOPATH/bin"
+if [ ! -d "$GOBIN" ]
+then
+        mkdir -p "$GOBIN"
+fi
+ln -s $(command -v go-md2man) "$GOBIN"
+
+echo "Get CRI Tools"
+critools_repo="github.com/kubernetes-incubator/cri-tools"
+go get "$critools_repo" || true
+pushd "${GOPATH}/src/${critools_repo}"
+crictl_commit=$(grep "ENV CRICTL_COMMIT" "${GOPATH}/src/${crio_repo}/Dockerfile" | cut -d " " -f3)
+git checkout "${crictl_commit}"
+go install ./cmd/crictl
+sudo install "${GOPATH}/bin/crictl" /usr/bin
+popd
+
+echo "Installing CRI-O"
+make clean
+make install.tools
+make
+make test-binaries
+sudo -E PATH=$PATH sh -c "make install"
+sudo -E PATH=$PATH sh -c "make install.config"
+
+containers_config_path="/etc/containers"
+echo "Copy containers policy from CRI-O repo to $containers_config_path"
+sudo mkdir -p "$containers_config_path"
+sudo install -m0444 test/policy.json "$containers_config_path"
+popd
+
+echo "Install runc for CRI-O"
+go get -d github.com/opencontainers/runc
+pushd "${GOPATH}/src/github.com/opencontainers/runc"
+git checkout "$runc_version"
+make
+sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
+popd
+
+crio_config_file="/etc/crio/crio.conf"
+echo "Set runc as default runtime in CRI-O for trusted workloads"
+sudo sed -i 's/^runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
+
+echo "Add docker.io registry to pull images"
+sudo sed -i 's/^registries = \[/registries = \[ "docker.io"/' /etc/crio/crio.conf
+
+echo "Set Kata containers as default runtime in CRI-O for untrusted workloads"
+sudo sed -i 's/default_workload_trust = "trusted"/default_workload_trust = "untrusted"/' "$crio_config_file"
+sudo sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/kata-runtime"/' "$crio_config_file"
+
+service_path="/etc/systemd/system"
+crio_service_file="${cidir}/data/crio.service"
+
+echo "Install crio service (${crio_service_file})"
+sudo install -m0444 "${crio_service_file}" "${service_path}"
+
+echo "Reload systemd services"
+sudo systemctl daemon-reload

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -42,6 +42,12 @@ bash -f ${cidir}/install_proxy.sh
 echo "Install runtime"
 bash -f ${cidir}/install_runtime.sh
 
+echo "Install CNI plugins"
+bash -f ${cidir}/install_cni_plugins.sh
+
+echo "Install CRI-O"
+bash -f ${cidir}/install_crio.sh
+
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -32,7 +32,7 @@ echo "Install kata-containers image"
 "${cidir}/install_kata_image.sh"
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
-chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev
+chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev go-md2man
 
 echo "Install bison binary"
 chronic sudo -E apt install -y bison

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ else
 	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 endif
 
+crio:
+	bash .ci/install_bats.sh
+	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
+
 log-parser:
 	make -C cmd/log-parser
 

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/crio_skip_tests.sh"
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
+get_cc_versions
+
+crio_repository="github.com/kubernetes-incubator/cri-o"
+check_crio_repository="$GOPATH/src/${crio_repository}"
+
+if [ -d ${check_crio_repository} ]; then
+	pushd ${check_crio_repository}
+	check_version=$(git status | grep "${crio_version}")
+	if [ $? -ne 0 ]; then
+		git fetch
+		git checkout "${crio_version}"
+	fi
+	popd
+else
+	echo "Obtain CRI-O repository"
+	go get -d "${crio_repository}" || true
+	pushd ${check_crio_repository}
+	git fetch
+	git checkout "${crio_version}"
+	popd
+fi
+
+OLD_IFS=$IFS
+IFS=''
+
+# Skip CRI-O tests that currently are not working
+pushd $GOPATH/src/${crio_repository}/test/
+for i in ${skipCRIOTests[@]}
+do
+	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/agent/issues/138)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
+done
+
+IFS=$OLD_IFS
+
+bats ctr.bats
+popd

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Currently these are the CRI-O tests that are not working
+
+declare -a skipCRIOTests=(
+'test "ctr termination reason Completed"'
+'test "ctr termination reason Error"'
+'test "ctr remove"'
+'test "ctr lifecycle"'
+'test "ctr logging"'
+'test "ctr logging \[tty=true\]"'
+'test "ctr log max"'
+'test "ctr partial line logging"'
+'test "ctrs status for a pod"'
+'test "ctr list filtering"'
+'test "ctr list label filtering"'
+'test "ctr metadata in list & status"'
+'test "ctr execsync conflicting with conmon flags parsing"'
+'test "ctr execsync"'
+'test "ctr device add"'
+'test "ctr hostname env"'
+'test "ctr execsync failure"'
+'test "ctr execsync exit code"'
+'test "ctr execsync std{out,err}"'
+'test "ctr stop idempotent"'
+'test "ctr caps drop"'
+'test "run ctr with image with Config.Volumes"'
+'test "ctr oom"'
+'test "ctr create with non-existent command"'
+'test "ctr create with non-existent command \[tty\]"'
+'test "ctr update resources"'
+'test "ctr correctly setup working directory"'
+'test "ctr execsync conflicting with conmon env"'
+'test "ctr resources"'
+'test "ctr \/etc\/resolv.conf rw\/ro mode"'
+);


### PR DESCRIPTION
This will enable that is possible to run CRI-O tests as
well it adds the CI dependencies to install CRI-O.

Fixes #117

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>