### PR TITLE
CI: Add maligned linter

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -101,6 +101,7 @@ check_go()
 	linter_args+=" --enable=structcheck"
 	linter_args+=" --enable=unused"
 	linter_args+=" --enable=staticcheck"
+	linter_args+=" --enable=maligned"
 
 	eval gometalinter "${linter_args}" ./...
 }


### PR DESCRIPTION
Add the `maligned` linter to the CI static checks to minimise
struct space.

Fixes #122.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>