### PR TITLE
CI: Add varcheck and unconvert linters

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -102,6 +102,8 @@ check_go()
 	linter_args+=" --enable=unused"
 	linter_args+=" --enable=staticcheck"
 	linter_args+=" --enable=maligned"
+	linter_args+=" --enable=varcheck"
+	linter_args+=" --enable=unconvert"
 
 	eval gometalinter "${linter_args}" ./...
 }


### PR DESCRIPTION
Add two additional linters, `varcheck` and `unconvert`, that check for
unused globals and unnecessary conversions respectively.

Fixes #124.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>