### PR TITLE
CI: Implements Depends-on

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -11,7 +11,7 @@ set -e
 [ -z "${KATA_DEV_MODE}" ] && export CI=true
 
 # Need the repo to know which tests to run.
-kata_repo="$1"
+export kata_repo="$1"
 
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 runtime_repo="${runtime_repo:-github.com/kata-containers/runtime}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -59,3 +59,42 @@ function get_cc_versions(){
 	[ ! -f "$_versions_file" ] && { echo >&2 "ERROR: cannot find $_versions_file"; exit 1; }
 	source "$_versions_file"
 }
+
+
+function apply_depends_on() {
+	pushd "${GOPATH}/src/${kata_repo}"
+	label_lines=$(git log --format=%s%b master.. | grep "Depends-on:" || true)
+	if [ "${label_lines}" == "" ]; then
+		popd
+		return 0
+	fi
+
+	nb_lines=$(echo "${label_lines}" | wc -l)
+
+	repos_found=()
+	for i in $(seq 1 "${nb_lines}")
+	do
+		label_line=$(echo "${label_lines}" | sed "${i}q;d")
+		label_str=$(echo "${label_line}" | awk '{print $2}')
+		repo=$(echo "${label_str}" | cut -d'#' -f1)
+		if [[ "${repos_found[@]}" =~ "${repo}" ]]; then
+			echo "Repository $repo was already defined in a 'Depends-on:' tag."
+			echo "Only one repository per tag is allowed."
+			return 1
+		fi
+		repos_found+=("$repo")
+		pr_id=$(echo "${label_str}" | cut -d'#' -f2)
+
+		echo "This PR depends on repository: ${repo} and pull request: ${pr_id}"
+		if [ ! -d "${GOPATH}/src/${repo}" ]; then
+			go get -d "$repo" || true
+		fi
+
+		pushd "${GOPATH}/src/${repo}"
+		echo "Fetching pull request: ${pr_id} for repository: ${repo}"
+		git fetch origin "pull/${pr_id}/head" && git checkout FETCH_HEAD && git rebase origin/master
+		popd
+	done
+
+	popd
+}

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,6 +11,8 @@ cidir=$(dirname "$0")
 source /etc/os-release
 source "${cidir}/lib.sh"
 
+apply_depends_on
+
 arch=$(arch)
 
 echo "Set up environment"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ else
 fi
 ```
 
+### Breaking Compatibility
+
+In case the patch you submit breaks the CI because it needs to be tested
+together with a patch from another `kata-containers` repository, you have to
+specify which repository and which pull request it depends on.
+
+Using a simple tag `Depends-on:` in your commit message will allow the CI to
+run properly. Notice that this tag is parsed from the latest commit of the
+pull request.
+
+For example:
+
+```
+	Subsystem: Change summary
+
+	Detailed explanation of your changes.
+
+	Fixes: #nnn
+
+	Depends-on:github.com/kata-containers/runtime#999
+
+	Signed-off-by: <contributor@foo.com>
+
+```
+
+In this example, we tell the CI to fetch the pull request 999 from the `runtime`
+repository and use that rather than the `master` branch when testing the changes
+contained in this pull request.
+
 ## Developer Mode
 
 Developers need a way to run as much test content as possible locally, but as


### PR DESCRIPTION
Depends-on will allow the CI to test a patch together with
another one from other `kata-containers` repository.
This will be useful when compatibility is broken because
changes need to be done in different repos.

Fixes: #126.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>