### PR TITLE
integration/docker: skip CPU tests

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -231,6 +231,7 @@ var _ = Describe("run", func() {
 
 	DescribeTable("container with CPU period and quota",
 		func(quota, period int, fail bool) {
+			Skip("Issue: https://github.com/kata-containers/agent/issues/174")
 			args = append(args, "--cpu-quota", fmt.Sprintf("%d", quota),
 				"--cpu-period", fmt.Sprintf("%d", period), Image, "nproc")
 			vCPUs = (quota + period - 1) / period
@@ -250,6 +251,7 @@ var _ = Describe("run", func() {
 
 	DescribeTable("container with CPU constraint",
 		func(cpus int, fail bool) {
+			Skip("Issue: https://github.com/kata-containers/agent/issues/174")
 			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "nproc")
 			stdout, _, exitCode := dockerRun(args...)
 			if fail {


### PR DESCRIPTION
currently kata agent does not have support for CPU hot plug,
CPU tests should be skipped until CPU hotplug support is added
in the agent

fixes #128

Signed-off-by: Julio Montes <julio.montes@intel.com>