### PR TITLE
CI: Enable "set -e" harder

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright (c) 2017-2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+set -e
 
 # Set default test run timeout value.
 #


### PR DESCRIPTION
Change the shebang `-e` to an explicit `set -e` to avoid the nasty shell
issue whereby the option can be defeated if the script is invoked by
calling it as:

```
  # "set -e" no longer applies!
  bash .ci/go-test.sh
```

Fixes #130.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>