### PR TITLE
Fix tests for dev mode

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -84,7 +84,7 @@ test_coverage()
 		warn "As a result, only a subset of tests will be run"
 		warn "(run this script as a non-privileged to ensure all tests are run)."
 	else
-		if [ -n "$KATA_DEV_MODE" ]; then
+		if [ "$CI" = true ] && [ -n "$KATA_DEV_MODE" ]; then
 			warn "Dangerous to set CI and KATA_DEV_MODE together."
 			warn "NOT running tests as root."
 		else
@@ -128,11 +128,16 @@ test_local()
 
 main()
 {
+	run_coverage=no
+	if [ "$CI" = true ] || [ -n "$KATA_DEV_MODE" ]; then
+		run_coverage=yes
+	fi
+
 	[ -z "$test_packages" ] && echo "INFO: no golang code to test" && exit 0
 
 	if [ "$1" = "html-coverage" ]; then
 		test_html_coverage
-	elif [ "$CI" = "true" ]; then
+	elif [ "$run_coverage" = yes ]; then
 		test_coverage
 	else
 		test_local

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -121,7 +121,9 @@ test_coverage()
 # Run the tests locally
 test_local()
 {
-	eval go test "$go_test_flags" "$test_packages"
+	for pkg in $test_packages; do
+		eval go test "$go_test_flags" "$pkg"
+	done
 }
 
 main()


### PR DESCRIPTION
Ensure go test script runs `test_coverage()` function, not
`test_local()` when dev mode is enabled.

Fixed `test_local()` to consider each golang package
separately which was previously causing the function to fail.
Fixes #134.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>