### PR TITLE
CI: move static checks after setup is executed

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -38,7 +38,6 @@ popd
 
 echo "Installing CRI-O"
 make clean
-make install.tools
 make
 make test-binaries
 sudo -E PATH=$PATH sh -c "make install"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -72,9 +72,6 @@ else
 	git fetch origin && git checkout master && git reset --hard origin/master
 fi
 
-# Run the static analysis tools
-.ci/static-checks.sh
-
 # Setup Kata Containers Environment
 #
 # - If the repo is "tests", this will call the script living in that repo
@@ -82,6 +79,9 @@ fi
 # - If the repo is not "tests", call the repo-specific script (which is
 #   expected to call the script of the same name in the "tests" repo).
 .ci/setup.sh
+
+# Run the static analysis tools
+.ci/static-checks.sh
 
 if [ -n "$pr_number" ]
 then


### PR DESCRIPTION
running static checks, including gometalinter fails because
it requires generated files to be present in the system.
We need to run .ci/static-checks.sh after the .ci/setup.sh
is executed, since it builds the kata containers components.

Fixes #152.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>