### PR TITLE
CI: Enable CRI-O tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ crio:
 log-parser:
 	make -C cmd/log-parser
 
-test: functional integration
+test: functional integration crio
 
 check: checkcommits log-parser
 
-.PHONY: check checkcommits integration ginkgo log-parser test
+.PHONY: check checkcommits integration ginkgo log-parser test crio

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -9,15 +9,14 @@ set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/crio_skip_tests.sh"
-source "${SCRIPT_PATH}/../../.ci/lib.sh"
-get_cc_versions
+source "${SCRIPT_PATH}/versions.txt"
 
 crio_repository="github.com/kubernetes-incubator/cri-o"
 check_crio_repository="$GOPATH/src/${crio_repository}"
 
 if [ -d ${check_crio_repository} ]; then
 	pushd ${check_crio_repository}
-	check_version=$(git status | grep "${crio_version}")
+	check_version=$(git log -1 --pretty=format:"%H" | grep "${crio_version}")
 	if [ $? -ne 0 ]; then
 		git fetch
 		git checkout "${crio_version}"
@@ -44,5 +43,6 @@ done
 
 IFS=$OLD_IFS
 
-bats ctr.bats
+export STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.use_deferred_removal=false"
+./test_runner.sh ctr.bats
 popd

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -8,21 +8,6 @@
 # Currently these are the CRI-O tests that are not working
 
 declare -a skipCRIOTests=(
-'test "ctr termination reason Completed"'
-'test "ctr termination reason Error"'
-'test "ctr remove"'
-'test "ctr lifecycle"'
-'test "ctr logging"'
-'test "ctr logging \[tty=true\]"'
-'test "ctr log max"'
-'test "ctr partial line logging"'
-'test "ctrs status for a pod"'
-'test "ctr list filtering"'
-'test "ctr list label filtering"'
-'test "ctr metadata in list & status"'
-'test "ctr execsync conflicting with conmon flags parsing"'
-'test "ctr execsync"'
-'test "ctr device add"'
 'test "ctr hostname env"'
 'test "ctr execsync failure"'
 'test "ctr execsync exit code"'

--- a/integration/cri-o/versions.txt
+++ b/integration/cri-o/versions.txt
@@ -1,0 +1,6 @@
+# These versions should be removed from here and moved to the correct
+# place once https://github.com/kata-containers/runtime/issues/11 gets
+# resolved. See issue: https://github.com/kata-containers/tests/issues/157
+crio_version="beab61dca4c751174aa2f929907ecb4e3c5245c4"
+critools_version="207e773f72fde8d8aed1447692d8f800a6686d6c"
+runc_version="v1.0.0-rc5"


### PR DESCRIPTION
This PR unskips the tests from CRI-O and adds the
crio tests to the `make tests` target.
As we now support a different version than CC does, a
temporal integration/cri-o/versions.txt was added.

Fixes #158.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>