### PR TITLE
Initial k8s tests

### DIFF
--- a/.ci/install_cni_plugins.sh
+++ b/.ci/install_cni_plugins.sh
@@ -7,8 +7,6 @@
 
 set -e
 
-cni_version="0.3.0"
-
 echo "Retrieve CNI plugins repository"
 go get -d github.com/containernetworking/plugins || true
 pushd $GOPATH/src/github.com/containernetworking/plugins
@@ -27,7 +25,7 @@ sudo mkdir -p ${cni_net_config_path}
 
 sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
 {
-	"cniVersion": ${cni_version},
+	"cniVersion": "0.3.0",
 	"name": "mynet",
 	"type": "bridge",
 	"bridge": "cni0",
@@ -45,7 +43,7 @@ EOF'
 
 sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
 {
-	"cniVersion": ${cni_version},
+	"cniVersion": "0.3.0",
 	"type": "loopback"
 }
 EOF'

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -8,10 +8,11 @@
 set -e
 
 cidir=$(dirname "$0")
-source "${cidir}/../integration/cri-o/versions.txt"
+source "${cidir}/lib.sh"
 
 echo "Get CRI-O sources"
 crio_repo="github.com/kubernetes-incubator/cri-o"
+crio_version=$(get_version "externals.crio.version")
 go get -d "$crio_repo" || true
 pushd "${GOPATH}/src/${crio_repo}"
 git fetch
@@ -29,6 +30,7 @@ echo "Get CRI Tools"
 critools_repo="github.com/kubernetes-incubator/cri-tools"
 go get "$critools_repo" || true
 pushd "${GOPATH}/src/${critools_repo}"
+critools_version=$(grep "ENV CRICTL_COMMIT" "${GOPATH}/src/${crio_repo}/Dockerfile" | cut -d " " -f3)
 git checkout "${critools_version}"
 go install ./cmd/crictl
 sudo install "${GOPATH}/bin/crictl" /usr/bin

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+echo "Install Kubernetes components"
+
+cidir=$(dirname "$0")
+source /etc/os-release
+kubernetes_version="1.9.3-00"
+
+if [ "$ID" != "ubuntu" ]; then
+        echo "Currently this script only works for Ubuntu. Skipped Kubernetes Setup"
+        exit
+fi
+
+sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
+EOF"
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+sudo -E apt update
+sudo -E apt install -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
+
+echo "Modify kubelet systemd configuration to use CRI-O"
+k8s_systemd_file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+sudo sed -i '/KUBELET_AUTHZ_ARGS=/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --runtime-request-timeout=30m"' "$k8s_systemd_file"
+sudo systemctl daemon-reload

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -7,11 +7,14 @@
 
 set -e
 
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
 echo "Install Kubernetes components"
 
 cidir=$(dirname "$0")
 source /etc/os-release
-kubernetes_version="1.9.3-00"
+kubernetes_version=$(get_version "externals.kubernetes.version")
 
 if [ "$ID" != "ubuntu" ]; then
         echo "Currently this script only works for Ubuntu. Skipped Kubernetes Setup"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -98,3 +98,18 @@ function apply_depends_on() {
 
 	popd
 }
+
+function waitForProcess(){
+        wait_time="$1"
+        sleep_time="$2"
+        cmd="$3"
+        while [ "$wait_time" -gt 0 ]; do
+                if eval "$cmd"; then
+                        return 0
+                else
+                        sleep "$sleep_time"
+                        wait_time=$((wait_time-sleep_time))
+                fi
+        done
+        return 1
+}

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -7,10 +7,6 @@
 
 set -e
 
-_runtime_repo="github.com/kata-containers/runtime"
-# FIXME: Issue https://github.com/kata-containers/packaging/issues/1
-_versions_file="$GOPATH/src/github.com/clearcontainers/runtime/versions.txt"
-
 export KATA_RUNTIME=${KATA_RUNTIME:-cc}
 
 # If we fail for any reason a message will be displayed
@@ -52,12 +48,15 @@ function clone_build_and_install() {
 	popd
 }
 
-function get_cc_versions(){
+function get_version(){
+	dependency="$1"
 	# This is needed in order to retrieve the version for qemu-lite
-	cc_runtime_repo="github.com/clearcontainers/runtime"
-	go get -d -u -v "$cc_runtime_repo" || true
-	[ ! -f "$_versions_file" ] && { echo >&2 "ERROR: cannot find $_versions_file"; exit 1; }
-	source "$_versions_file"
+	go get -v github.com/mikefarah/yq
+	runtime_repo="github.com/kata-containers/runtime"
+	versions_file="$GOPATH/src/github.com/kata-containers/runtime/versions.yaml"
+	go get -d -u -v "$runtime_repo" || true
+	[ ! -f "$versions_file" ] && { echo >&2 "ERROR: cannot find $versions_file"; exit 1; }
+	yq read "$versions_file" "$dependency"
 }
 
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -53,6 +53,9 @@ bash -f ${cidir}/install_cni_plugins.sh
 echo "Install CRI-O"
 bash -f ${cidir}/install_crio.sh
 
+echo "Install Kubernetes"
+bash -f ${cidir}/install_kubernetes.sh
+
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -10,7 +10,6 @@ set -e
 cidir=$(dirname "$0")
 source /etc/os-release
 source "${cidir}/lib.sh"
-get_cc_versions
 
 echo "Install chronic"
 sudo -E dnf -y install moreutils

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -10,7 +10,6 @@ set -e
 cidir=$(dirname "$0")
 source "/etc/os-release"
 source "${cidir}/lib.sh"
-get_cc_versions
 
 echo "Update apt repositories"
 sudo -E apt update

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -31,6 +31,10 @@ collect_data_filename="kata-collect-data.log"
 collect_data_log_path="${log_copy_dest}/${collect_data_filename}"
 collect_data_log_prefix="kata-collect-data_"
 
+kubelet_log_filename="kubelet.log"
+kubelet_log_path="${log_copy_dest}/${kubelet_log_filename}"
+kubelet_log_prefix="kubelet_"
+
 # Copy log files if a destination path is provided, otherwise simply
 # display them.
 if [ "${log_copy_dest}" ]; then
@@ -40,6 +44,7 @@ if [ "${log_copy_dest}" ]; then
 	journalctl --no-pager -t kata-shim > "${shim_log_path}"
 	journalctl --no-pager -u crio > "${crio_log_path}"
 	journalctl --no-pager -u docker > "${docker_log_path}"
+	journalctl --no-pager -u kubelet > "${kubelet_log_path}"
 
 	sudo kata-collect-data.sh > "${collect_data_log_path}"
 
@@ -51,6 +56,7 @@ if [ "${log_copy_dest}" ]; then
 	split -b "${subfile_size}" -d "${shim_log_path}" "${shim_log_prefix}"
 	split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
 	split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
+	split -b "${subfile_size}" -d "${kubelet_log_path}" "${kubelet_log_prefix}"
 	split -b "${subfile_size}" -d "${collect_data_log_path}" "${collect_data_log_prefix}"
 
 	for prefix in \
@@ -59,6 +65,7 @@ if [ "${log_copy_dest}" ]; then
 		"${shim_log_prefix}" \
 		"${crio_log_prefix}" \
 		"${docker_log_prefix}" \
+		"${kubelet_log_prefix}" \
 		"${collect_data_log_prefix}"
 	do
 		gzip -9 "$prefix"*
@@ -80,6 +87,9 @@ else
 
 	echo "Docker Log:"
 	journalctl --no-pager -u docker
+
+	echo "Kubelet Log:"
+	journalctl --no-pager -u kubelet
 
 	echo "Kata Collect Data script output"
 	sudo kata-collect-data.sh

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,15 @@ docker-compose:
 	cd integration/docker-compose && \
 	bats docker-compose.bats
 
+kubernetes:
+	bash -f .ci/install_bats.sh
+	bash -f integration/kubernetes/run_kubernetes_tests.sh
+
 log-parser:
 	make -C cmd/log-parser
 
-test: functional integration crio docker-compose
+test: functional integration crio docker-compose kubernetes
 
 check: checkcommits log-parser
 
-.PHONY: check checkcommits integration ginkgo log-parser test crio functional docker-compose
+.PHONY: check checkcommits integration ginkgo log-parser test crio functional docker-compose kubernetes

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -17,8 +17,6 @@ subcommand=""
 runtime=""
 tag=""
 
-get_cc_versions > /dev/null 2>&1
-
 usage(){
 	cat << EOF
 This script helps you install the correct version of docker
@@ -94,6 +92,7 @@ install_docker(){
 
 	if [ -z "$tag" ] || [ "$tag" == "latest" ] ; then
 		# If no tag is recevied, install latest compatible version
+		docker_version=$(get_version "externals.docker.version")
 		log_message "Installing docker $docker_version"
 		docker_version=${docker_version/v}
 		docker_version=${docker_version/-*}

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -16,7 +16,7 @@ check_crio_repository="$GOPATH/src/${crio_repository}"
 
 if [ -d ${check_crio_repository} ]; then
 	pushd ${check_crio_repository}
-	check_version=$(git log -1 --pretty=format:"%H" | grep "${crio_version}")
+	check_version=$(git log -1 | grep "${crio_version}")
 	if [ $? -ne 0 ]; then
 		git fetch
 		git checkout "${crio_version}"

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -8,10 +8,11 @@
 set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/crio_skip_tests.sh"
-source "${SCRIPT_PATH}/versions.txt"
 
 crio_repository="github.com/kubernetes-incubator/cri-o"
+crio_version=$(get_version "externals.crio.version")
 check_crio_repository="$GOPATH/src/${crio_repository}"
 
 if [ -d ${check_crio_repository} ]; then

--- a/integration/cri-o/versions.txt
+++ b/integration/cri-o/versions.txt
@@ -1,6 +1,6 @@
 # These versions should be removed from here and moved to the correct
 # place once https://github.com/kata-containers/runtime/issues/11 gets
 # resolved. See issue: https://github.com/kata-containers/tests/issues/157
-crio_version="beab61dca4c751174aa2f929907ecb4e3c5245c4"
-critools_version="207e773f72fde8d8aed1447692d8f800a6686d6c"
+crio_version="v1.9.9"
+critools_version="b42fc3f364dd48f649d55926c34492beeb9b2e99"
 runc_version="v1.0.0-rc5"

--- a/integration/cri-o/versions.txt
+++ b/integration/cri-o/versions.txt
@@ -1,6 +1,0 @@
-# These versions should be removed from here and moved to the correct
-# place once https://github.com/kata-containers/runtime/issues/11 gets
-# resolved. See issue: https://github.com/kata-containers/tests/issues/157
-crio_version="v1.9.9"
-critools_version="b42fc3f364dd48f649d55926c34492beeb9b2e99"
-runc_version="v1.0.0-rc5"

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+export KUBECONFIG=/etc/kubernetes/admin.conf
+sudo -E kubeadm reset --cri-socket=/var/run/crio/crio.sock
+sudo systemctl stop kubelet
+sudo systemctl stop docker
+for ctr in $(sudo crictl ps --quiet); do
+	sudo crictl stop "$ctr"
+	sudo crictl rm "$ctr"
+done
+for pod in $(sudo crictl sandboxes --quiet); do
+	sudo crictl stops "$pod"
+	sudo crictl rms "$pod"
+done
+
+sudo systemctl stop crio
+sudo rm -rf /var/lib/cni/*
+sudo rm -rf /var/run/crio/*
+sudo rm -rf /var/log/crio/*
+sudo rm -rf /var/lib/kubelet/*
+sudo rm -rf /run/flannel/*
+sudo rm -rf /etc/cni/net.d/*
+
+sudo umount /tmp/hyper/shared/pods/*/*/rootfs \
+			/tmp/tmp*/crio/overlay2/*/merged \
+			/tmp/hyper/shared/pods/*/*/rootfs \
+			/run/netns/cni-* \
+			/tmp/tmp*/crio-run/overlay2-containers/*/userdata/shm \
+			/tmp/tmp*/crio/overlay2 \
+			/tmp/hyper/shared/pods/*/*-resolv.conf \
+			/var/lib/containers/storage/overlay2
+
+sudo rm -rf /var/lib/virtcontainers/pods/*
+sudo rm -rf /var/run/virtcontainers/pods/*
+sudo rm -rf /var/lib/containers/storage/*
+sudo rm -rf /var/run/containers/storage/*
+
+sudo ip link set dev cni0 down
+sudo ip link set dev cbr0 down
+sudo ip link set dev flannel.1 down
+sudo ip link set dev docker0 down
+sudo ip link del cni0
+sudo ip link del cbr0
+sudo ip link del flannel.1
+sudo ip link del docker0
+
+sudo systemctl start docker
+sudo systemctl start crio

--- a/integration/kubernetes/data/kube-flannel-rbac.yml
+++ b/integration/kubernetes/data/kube-flannel-rbac.yml
@@ -1,0 +1,40 @@
+# This file was pulled from:
+# https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378)
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system

--- a/integration/kubernetes/data/kube-flannel.yml
+++ b/integration/kubernetes/data/kube-flannel.yml
@@ -1,0 +1,95 @@
+# This file was pulled from:
+# https://github.com/coreos/flannel (HEAD at time of pull was 4973e02e539378)
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.8.0-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.8.0-amd64
+        command: [ "/bin/sh", "-c", "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done" ]
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
+
+# The next workaround is to be able to communicate between pods
+# Issue: https://github.com/kubernetes/kubernetes/issues/40182
+# Fix is ready for K8s 1.9, but still need to investigate why it does not
+# work by default.
+# FIXME: Issue: https://github.com/clearcontainers/tests/issues/934
+sudo iptables -P FORWARD ACCEPT
+
+echo "Start crio service"
+sudo systemctl start crio
+
+sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket=/var/run/crio/crio.sock
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+sudo -E kubectl get nodes
+sudo -E kubectl get pods
+sudo -E kubectl create -f "${SCRIPT_PATH}/data/kube-flannel-rbac.yml"
+sudo -E kubectl create --namespace kube-system -f "${SCRIPT_PATH}/data/kube-flannel.yml"
+
+# The kube-dns pod usually takes around 30 seconds to get ready
+# This instruction will wait until it is up and running, so we can
+# start creating our containers.
+dns_wait_time=180
+sleep_time=5
+cmd="sudo -E kubectl get pods --all-namespaces | grep dns | grep Running"
+waitForProcess "$dns_wait_time" "$sleep_time" "$cmd"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	nginx_image="nginx"
+	busybox_image="busybox"
+	service_name="nginx-service"
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+	master=$(hostname)
+	sudo -E kubectl taint nodes "$master" node-role.kubernetes.io/master:NoSchedule-
+	# Pull the images before launching workload. This is mainly because we use
+	# a timeout and in slow networks it may result in not been able to pull the image
+	# successfully.
+	sudo -E crictl pull "$busybox_image"
+	sudo -E crictl pull "$nginx_image"
+}
+
+@test "Verify nginx connectivity between pods" {
+	wait_time=30
+	sleep_time=5
+	cmd="sudo -E kubectl get pods | grep $service_name | grep Running"
+	sudo -E kubectl run "$service_name" --image="$nginx_image" --replicas=2
+	sudo -E kubectl expose deployment "$service_name" --port=80
+	sudo -E kubectl get svc,pod
+	# Wait for nginx service to come up
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	busybox_pod="test-nginx"
+	sudo -E kubectl run $busybox_pod --restart=Never --image="$busybox_image" \
+		-- wget --timeout=5 "$service_name"
+	cmd="sudo -E kubectl get pods -a | grep $busybox_pod | grep Completed"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	sudo -E kubectl logs "$busybox_pod" | grep "index.html"
+}
+
+teardown() {
+	sudo -E kubectl delete deployment "$service_name"
+	sudo -E kubectl delete service "$service_name"
+	sudo -E kubectl delete pod "$busybox_pod"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+source /etc/os-release
+kubernetes_dir=$(dirname $0)
+
+# Currently, Kubernetes tests only work on Ubuntu.
+# We should delete this condition, when it works for other Distros.
+if [ "$ID" != ubuntu  ]; then
+    echo "Skip - kubernetes tests on $ID aren't supported yet"
+    exit
+fi
+
+pushd "$kubernetes_dir"
+./init.sh
+bats nginx.bats
+./cleanup_env.sh
+popd


### PR DESCRIPTION
tests: Add initial tests for kubernetes

This commit adds scripts to:
- install kubernetes v1.9.3
- Add cri-o as the runtime interfaces for running pods
- start kubelet service using kubeadm
- Run an nginx service pod
- Run a buxybox pod and communicate with the nginx pod.

Fixes: #161.
