### PR TITLE
CI: Use virtio-scsi

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -50,9 +50,6 @@ fi
 echo "Enabling all debug options in file ${runtime_config_path}"
 sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
 
-echo "Set virtio-blk as the block device driver"
-sudo sed -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
-
 echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
 docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
 


### PR DESCRIPTION
Now that kata containers has proper scsi support, we
should use virtio-scsi instead of virtio-blk.

Fixes: #167.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>