### PR TITLE
ci: enable initrd testing support

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -51,6 +51,14 @@ echo "Enabling all debug options in file ${runtime_config_path}"
 sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
 sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${runtime_config_path}"
 
+if [ x"${TEST_INITRD}" == x"yes" ]; then
+	echo "Set to test initrd image"
+	sudo sed -i -e '/^image =/d' ${runtime_config_path}
+else
+	echo "Set to test rootfs image"
+	sudo sed -i -e '/^initrd =/d' ${runtime_config_path}
+fi
+
 echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
 docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
 


### PR DESCRIPTION
We can set TEST_INITRD=yes to enalbe it.

Fixes: #172

ref: kata-containers/runtime#98