### PR TITLE
ci: installers: add force install to symlinks

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -23,7 +23,7 @@ if [ ! -d "$GOBIN" ]
 then
         mkdir -p "$GOBIN"
 fi
-ln -s $(command -v go-md2man) "$GOBIN"
+ln -sf $(command -v go-md2man) "$GOBIN"
 
 echo "Get CRI Tools"
 critools_repo="github.com/kubernetes-incubator/cri-tools"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -35,6 +35,6 @@ date=$(date +%Y-%m-%d-%T.%N%z)
 image="kata-containers-${date}-osbuilder-${commit}-agent-${agent_commit}"
 
 sudo install -o root -g root -m 0640 -D ${image_name} "/usr/share/kata-containers/${image}"
-(cd /usr/share/kata-containers && sudo rm -f ${image_name} && sudo ln -s "$image" ${image_name})
+(cd /usr/share/kata-containers && sudo ln -sf "$image" ${image_name})
 
 popd

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -88,5 +88,5 @@ download_kernel "${cc_kernel_version}"
 
 # Make symbolic link to kata-containers
 # FIXME: see https://github.com/kata-containers/packaging/issues/1
-sudo ln -s /usr/share/clear-containers/vmlinux.container /usr/share/kata-containers/
-sudo ln -s /usr/share/clear-containers/vmlinuz.container /usr/share/kata-containers/
+sudo ln -sf /usr/share/clear-containers/vmlinux.container /usr/share/kata-containers/
+sudo ln -sf /usr/share/clear-containers/vmlinuz.container /usr/share/kata-containers/


### PR DESCRIPTION
Some symlink installs did not use the `-f` force flag, which meant
they failed if we were installing over an already installed system.

Add the `-f` flag, and in the instance of the image code, replace
an explicit `rm -f` with the `-f` on the following `ln`.

Fixes: #150

Signed-off-by: Graham whaley <graham.whaley@intel.com>