### PR TITLE
integration: crio: Enable more tests from ctr.bats

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,18 +9,10 @@
 
 declare -a skipCRIOTests=(
 'test "ctr hostname env"'
-'test "ctr execsync failure"'
-'test "ctr execsync exit code"'
-'test "ctr execsync std{out,err}"'
-'test "ctr stop idempotent"'
-'test "ctr caps drop"'
-'test "run ctr with image with Config.Volumes"'
 'test "ctr oom"'
+'test "ctr \/etc\/resolv.conf rw\/ro mode"'
 'test "ctr create with non-existent command"'
 'test "ctr create with non-existent command \[tty\]"'
 'test "ctr update resources"'
-'test "ctr correctly setup working directory"'
-'test "ctr execsync conflicting with conmon env"'
 'test "ctr resources"'
-'test "ctr \/etc\/resolv.conf rw\/ro mode"'
 );


### PR DESCRIPTION
Kata Containers actually pass more tests than what is tested right
now. This commit removes those tests from the skip list.

Fixes #171

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>