### PR TITLE
CI: Check if yamllint is available before calling

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -168,7 +168,8 @@ check_versions()
 
 	[ ! -e "$db" ] && return
 
-	yamllint "$db"
+	cmd="yamllint"
+	[ -n "$(command -v $cmd)" ] && eval "$cmd" "$db"
 }
 
 check_commits


### PR DESCRIPTION
Don't call `yamllint` if it isn't installed.

Fixes #180.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>