### PR TITLE
CI: Do not fail if yamllint is not installed.

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -169,7 +169,9 @@ check_versions()
 	[ ! -e "$db" ] && return
 
 	cmd="yamllint"
-	[ -n "$(command -v $cmd)" ] && eval "$cmd" "$db"
+	if [ -n "$(command -v $cmd)" ]; then
+		eval "$cmd" "$db"
+	fi
 }
 
 check_commits


### PR DESCRIPTION
If yamllint is not installed, the static-checks.sh
fails. Change the way we verify it is installed.

Fixes #180

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>