### PR TITLE
CI: Show package paths one / line in static check script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -153,7 +153,8 @@ check_go()
 	echo -e "INFO: Running $linter checks on the following packages:\n"
 	echo "$go_packages"
 	echo
-	echo "(package paths:$dirs)"
+	echo -e "INFO: Package paths:\n"
+	echo "$dirs" | sed 's/^ *//g' | tr ' ' '\n'
 
 	eval "$linter" "${linter_args}" "$dirs"
 }


### PR DESCRIPTION
Improve the output of the static checks script by displaying each package
path on its own line.

Fixes #184.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>