### PR TITLE
CI: Rename coverage file for codecov.io

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -32,11 +32,11 @@ test_packages=$(go list ./... 2>/dev/null |\
 
 # The "master" coverage file that contains the coverage results for
 # all packages run under all scenarios.
-test_coverage_file="profile.cov"
+test_coverage_file="coverage.txt"
 
 # Temporary coverage file created for a single package. The results in this
 # file will be added to the master coverage file.
-tmp_coverage_file="profile-tmp.cov"
+tmp_coverage_file="${test_coverage_file}.tmp"
 
 # Permissions to create coverage files with
 coverage_file_mode=0644

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -74,7 +74,6 @@ test_html_coverage()
 	test_coverage
 
 	go tool cover -html="${test_coverage_file}" -o "${html_report_file}"
-	rm -f "${test_coverage_file}"
 
 	run_as_user "current" chmod "${coverage_file_mode}" "${html_report_file}"
 }


### PR DESCRIPTION
The https://codecov.io service seems to require the coverage file be
named `coverage.txt`.

Fixes #186.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>