### PR TITLE
CI: Update logs name to match kata-runtime log

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -17,7 +17,7 @@ check_log_files()
 	# XXX: hence specify by name (rather than using $RUNTIME).
 	for component in \
 		kata-proxy \
-		kata-runtime-cc \
+		kata-runtime \
 		kata-shim
 	do
 		file="${component}.log"

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -7,13 +7,9 @@
 
 log_copy_dest="$1"
 
-kata_runtime_cc_log_filename="kata-runtime-cc.log"
-kata_runtime_cc_log_path="${log_copy_dest}/${kata_runtime_cc_log_filename}"
-kata_runtime_cc_log_prefix="kata-runtime-cc_"
-
-kata_runtime_runv_log_filename="kata-runtime-runv.log"
-kata_runtime_runv_log_path="${log_copy_dest}/${kata_runtime_runv_log_filename}"
-kata_runtime_runv_log_prefix="kata-runtime-runv_"
+kata_runtime_log_filename="kata-runtime.log"
+kata_runtime_log_path="${log_copy_dest}/${kata_runtime_log_filename}"
+kata_runtime_log_prefix="kata-runtime_"
 
 proxy_log_filename="kata-proxy.log"
 proxy_log_path="${log_copy_dest}/${proxy_log_filename}"
@@ -35,8 +31,7 @@ docker_log_prefix="docker_"
 # display them.
 if [ "${log_copy_dest}" ]; then
 	# Create the log files
-	journalctl --no-pager -t kata-runtime-cc > "${kata_runtime_cc_log_path}"
-	journalctl --no-pager -t kata-runtime-runv > "${kata_runtime_runv_log_path}"
+	journalctl --no-pager -t kata-runtime > "${kata_runtime_log_path}"
 	journalctl --no-pager -t kata-proxy > "${proxy_log_path}"
 	journalctl --no-pager -t kata-shim > "${shim_log_path}"
 	journalctl --no-pager -u crio > "${crio_log_path}"
@@ -45,16 +40,14 @@ if [ "${log_copy_dest}" ]; then
 	# Split them in 5 MiB subfiles to avoid too large files.
 	subfile_size=5242880
 	pushd "${log_copy_dest}"
-	split -b "${subfile_size}" -d "${kata_runtime_cc_log_path}" "${kata_runtime_cc_log_prefix}"
-	split -b "${subfile_size}" -d "${kata_runtime_runv_log_path}" "${kata_runtime_runv_log_prefix}"
+	split -b "${subfile_size}" -d "${kata_runtime_log_path}" "${kata_runtime_log_prefix}"
 	split -b "${subfile_size}" -d "${proxy_log_path}" "${proxy_log_prefix}"
 	split -b "${subfile_size}" -d "${shim_log_path}" "${shim_log_prefix}"
 	split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
 	split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
 
 	for prefix in \
-		"${kata_runtime_cc_log_prefix}" \
-		"${kata_runtime_runv_log_prefix}" \
+		"${kata_runtime_log_prefix}" \
 		"${proxy_log_prefix}" \
 		"${shim_log_prefix}" \
 		"${crio_log_prefix}" \
@@ -65,10 +58,8 @@ if [ "${log_copy_dest}" ]; then
 
 	popd
 else
-	echo "Kata Containers Runtime (CC) Log:"
-	journalctl --no-pager -t kata-runtime-cc
-	echo "Kata Containers Runtime (Runv) Log:"
-	journalctl --no-pager -t kata-runtime-runv
+	echo "Kata Containers Runtime Log:"
+	journalctl --no-pager -t kata-runtime
 	echo "Kata Containers Proxy Log:"
 	journalctl --no-pager -t kata-proxy
 	echo "Kata Containers Shim Log:"


### PR DESCRIPTION
Now that we have a merged runtime, we should update the
name of the logs collected in the CI to kata-runtime.log

Fixes: #188.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>