### PR TITLE
ci: Update Fedora runtime installation

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -34,10 +34,7 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 clone_build_and_install "github.com/kata-containers/runtime"
 
 # Check system supports running Kata Containers
-# Fedora has issues with the symbolic link
-if [ "$ID" == "ubuntu" ]; then
-	kata-runtime kata-check
-fi
+kata-runtime kata-check
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -31,7 +31,7 @@ chronic sudo -E dnf -y install libtool automake autoconf bc pixman numactl-libs
 
 echo "Install qemu dependencies"
 chronic sudo -E dnf -y install libcap-devel libattr-devel \
-	libcap-ng-devel zlib-devel pixman-devel librbd-dev
+	libcap-ng-devel zlib-devel pixman-devel librbd-devel
 
 echo "Install kata containers image"
 "${cidir}/install_kata_image.sh"


### PR DESCRIPTION
Update Fedora runtime installation to enable to verify kata-runtime
and kata-check.

Fixes #192

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>