### PR TITLE
integration: crio: Enable more tests for ctr.bats

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -8,11 +8,8 @@
 # Currently these are the CRI-O tests that are not working
 
 declare -a skipCRIOTests=(
-'test "ctr hostname env"'
 'test "ctr oom"'
 'test "ctr \/etc\/resolv.conf rw\/ro mode"'
-'test "ctr create with non-existent command"'
-'test "ctr create with non-existent command \[tty\]"'
 'test "ctr update resources"'
 'test "ctr resources"'
 );


### PR DESCRIPTION
Based on recent patches merged into Kata Containers, this patch
unskip 3 tests from ctr.bats, allowing for a better testing of
CRI-O on Kata Containers.

Fixes #200

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>