### PR TITLE
ci: Add CentOS setup script.

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -20,6 +20,8 @@ if [ "$ID" == ubuntu ];then
 	bash -f "${cidir}/setup_env_ubuntu.sh"
 elif [ "$ID" == fedora ];then
 	bash -f "${cidir}/setup_env_fedora.sh"
+elif [ "$ID" == centos ];then
+	bash -f "${cidir}/setup_env_centos.sh"
 else
 	die "ERROR: Unrecognised distribution."
 	exit 1

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "/etc/os-release"
+source "${cidir}/lib.sh"
+
+# Obtain CentOS version
+centos_version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f2)
+
+# Check EPEL repository is enabled on CentOS
+yum -v repolist | grep epel
+if [ $? -ne 0 ]; then
+	echo >&2 "ERROR: EPEL repository is not enabled on CentOS."
+	# Enable EPEL repository on CentOS
+	sudo -E yum install -y wget rpm
+	wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-${centos_version}.noarch.rpm
+	rpm -ivh epel-release-latest-${centos_version}.noarch.rpm
+fi
+
+echo "Update repositories"
+sudo -E yum -y update
+
+echo "Install chronic"
+sudo -E yum install -y moreutils
+
+echo "Install kata containers dependencies"
+chronic sudo -E yum install -y libtool libtool-ltdl-devel libtool-ltdl bzip2 m4 gettext-devel automake alien autoconf bc pixman-devel coreutils
+
+if ! command -v docker > /dev/null; then
+        "${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
+fi
+
+echo "Install qemu dependencies"
+chronic sudo -E yum install -y libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex
+
+echo "Install kata-containers image"
+"${cidir}/install_kata_image.sh"
+
+echo "Install CRI-O dependencies for CentOS"
+chronic sudo -E yum install -y glibc-static libglib2.0-devel libseccomp-devel libassuan-devel libgpg-error-devel go-md2man device-mapper-libs btrfs-progs-devel util-linux gpgme-devel
+
+echo "Install bison binary"
+chronic sudo -E yum install -y bison
+
+echo "Install libgudev1-devel"
+chronic sudo -E yum install -y libgudev1-devel
+
+echo "Install Build Tools"
+sudo -E yum install -y python pkgconfig zlib-devel
+
+echo "Install Kata Containers Kernel"
+"${cidir}/install_kata_kernel.sh" "latest"
+
+sudo -E yum install -y ostree-devel
+
+echo "Install YAML validator"
+sudo -E yum install -y yamllint

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -112,6 +112,12 @@ install_docker(){
 			sudo -E dnf makecache
 			docker_version_full=$(dnf --showduplicate list "$pkg_name" | grep "$docker_version" | awk '{print $2}' | tail -1)
 			sudo -E dnf -y install "${pkg_name}-${docker_version_full}"
+		elif [ "$ID" == "centos" ]; then
+			sudo -E yum install -y yum-utils
+			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"
+			sudo yum-config-manager --add-repo "$repo_url"
+			sudo -E yum -y install docker-ce
+			sudo -E yum update
 		fi
 	elif [ "$tag" == "swarm" ]; then
 		# If tag is swarm, install docker 1.12.1
@@ -245,7 +251,7 @@ configure_docker(){
 		if [ "$runtime" == "kata-runtime" ]  ; then
 			# Try to find kata-runtime in $PATH, if it is not present
 			# then the default location will be /usr/local/bin/kata-runtime
-			if [ "$ID" == "fedora" ]; then
+			if [ "$ID" == "fedora" ] || [ "$ID" == "centos" ]; then
 				kata_runtime_bin="$(whereis $runtime | cut -f2 -d':' | tr -d "[:space:]")" || \
 					die "$runtime cannot be found in $PATH, please make sure it is installed"
 			else


### PR DESCRIPTION
This will enable to setup and run kata-runtime in CentOS.

Fixes #197

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>