### PR TITLE
ci: specify ROOTFS_DIR in install_kata_image script

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -17,6 +17,7 @@ TEST_INITRD=${TEST_INITRD:-no}
 bash -f ${cidir}/install_agent.sh
 
 osbuilder_repo="github.com/kata-containers/osbuilder"
+export ROOTFS_DIR="${GOPATH}/src/${osbuilder_repo}/rootfs-builder/rootfs"
 
 # Clone os-builder repository
 go get -d ${osbuilder_repo} || true
@@ -28,11 +29,11 @@ popd
 # Build the image
 if [ x"${TEST_INITRD}" == x"yes" ]; then
     pushd "${GOPATH}/src/${osbuilder_repo}/initrd-builder"
-    sudo -E AGENT_INIT=${AGENT_INIT} USE_DOCKER=true ./initrd_builder.sh ../rootfs-builder/rootfs
+    sudo -E AGENT_INIT=${AGENT_INIT} USE_DOCKER=true ./initrd_builder.sh "$ROOTFS_DIR"
     image_name="kata-containers-initrd.img"
 else
     pushd "${GOPATH}/src/${osbuilder_repo}/image-builder"
-    sudo -E AGENT_INIT=${AGENT_INIT} USE_DOCKER=true ./image_builder.sh ../rootfs-builder/rootfs
+    sudo -E AGENT_INIT=${AGENT_INIT} USE_DOCKER=true ./image_builder.sh "$ROOTFS_DIR"
     image_name="kata-containers.img"
 fi
 


### PR DESCRIPTION
We need to specify the ROOTFS_DIR that will be used to
build the image. If it is not specified, it will create
a directory with a name based on the distribution that
was used for creating the rootfs.

Fixes #211.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>