### PR TITLE
CI: run virtcontainers unit tests only as root

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -102,9 +102,14 @@ test_coverage()
 	fi
 
 	echo "INFO: Currently running as user '$(id -un)'"
-
 	for pkg in $test_packages; do
 		for user in $users; do
+			# Run virtcontainers tests only if user is root.
+			if [[ "$user" != "root" ]] && [[ "$pkg" = *"virtcontainers"* ]]; then
+				echo "Skip testing $pkg with user $user"
+				continue
+			fi
+
 			printf "INFO: Running 'go test' as %s user on package '%s' with flags '%s'\n" \
 				"$user" "$pkg" "$go_test_flags"
 


### PR DESCRIPTION
Virtcontainers unit tests only work if they are executed
using the root user.

Fixes #218.

Depends-on: github.com/kata-containers/runtime#193

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>