### PR TITLE
ci: increase timeout in unit tests

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -11,7 +11,7 @@ set -e
 #
 # KATA_GO_TEST_TIMEOUT can be set to any value accepted by
 # "go test -timeout X"
-timeout_value=${KATA_GO_TEST_TIMEOUT:-10s}
+timeout_value=${KATA_GO_TEST_TIMEOUT:-30s}
 
 # -race flag is supported only on amd64/x86_64 arch , hence 
 # enabling the flag depending on the arch.


### PR DESCRIPTION
Increase timeout in `go test` to avoid panics while running
virtcontainers unit tests.
Panic occurs randomly and can be reproduced easily on systems running
low on resources. This patch sets the timeout in 30 seconds, after
having run all unit tests N times with the new timeout, the issues
could not be reproduced.

fixes #225

Signed-off-by: Julio Montes <julio.montes@intel.com>