### PR TITLE
ci: Enable CRI-O tests in centos

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -9,6 +9,7 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+source /etc/os-release
 
 echo "Get CRI-O sources"
 crio_repo="github.com/kubernetes-incubator/cri-o"
@@ -38,7 +39,13 @@ popd
 
 echo "Installing CRI-O"
 make clean
-make
+if [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
+	# This is necessary to avoid crashing `make` with `No package devmapper found`
+	# by disabling the devmapper driver when the library it requires is not installed
+	make BUILDTAGS='exclude_graphdriver_devicemapper libdm_no_deferred_remove'
+else
+	make
+fi
 make test-binaries
 sudo -E PATH=$PATH sh -c "make install"
 sudo -E PATH=$PATH sh -c "make install.config"

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -16,11 +16,6 @@ crio_repository="github.com/kubernetes-incubator/cri-o"
 crio_version=$(get_version "externals.crio.version")
 check_crio_repository="$GOPATH/src/${crio_repository}"
 
-if [ "$ID" == "centos" ]; then
-	echo "Skip - CRI-O tests are not supported yet (Issue: https://github.com/kata-containers/tests/issues/227)"
-	exit
-fi
-
 if [ -d ${check_crio_repository} ]; then
 	pushd ${check_crio_repository}
 	check_version=$(git log -1 | grep "${crio_version}")
@@ -52,7 +47,9 @@ IFS=$OLD_IFS
 
 # By default run CRI-O tests using devicemapper
 MAJOR=$(echo "$VERSION_ID"|cut -d\. -f1)
-export STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.use_deferred_removal=false"
+if [ "$ID" == "ubuntu" ]; then
+	export STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.use_deferred_removal=false"
+fi
 
 # But if on ubuntu 17.10 or newer, test using overlay
 # This will allow us to run tests with at least 2 different


### PR DESCRIPTION
Avoid the error of `No package devmapper found` while doing the `make` of
CRI-O. This will disable the devmapper driver when the library it requires
is not installed.

Fixes #227

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>