### PR TITLE
CI: add support for new cri-o job

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -13,11 +13,15 @@ source /etc/os-release
 
 echo "Get CRI-O sources"
 crio_repo="github.com/kubernetes-incubator/cri-o"
-crio_version=$(get_version "externals.crio.version")
 go get -d "$crio_repo" || true
 pushd "${GOPATH}/src/${crio_repo}"
-git fetch
-git checkout "${crio_version}"
+
+if [ "$ghprbGhRepository" != "${crio_repo/github.com\/}" ]
+then
+	crio_version=$(get_version "externals.crio.version")
+	git fetch
+	git checkout "${crio_version}"
+fi
 
 # Add link of go-md2man to $GOPATH/bin
 GOBIN="$GOPATH/bin"


### PR DESCRIPTION
This change is needed because now that we plan to test
the changes in the cri-o repository, the CI needs to know
if the change being tested comes from the cri-o repository
or from our kata-containers repos. If it comes from the cri-o
repository, we should not use the version we support on our
versions.yaml. We should stick to the changes in the PR.

Fixes: #230.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>