### PR TITLE
log-parser: ignore badly formed agent messages by default

### DIFF
--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -312,11 +312,11 @@ func TestCheckCommitsDetails(t *testing.T) {
 	for _, d := range data {
 		err := checkCommitsDetails(d.config, d.commits)
 		if d.expectFail {
-			assert.Error(err, "config: %+v, commits: %+v", d.config, d.commits)
+			assert.Errorf(err, "config: %+v, commits: %+v", d.config, d.commits)
 			continue
 		}
 
-		assert.NoError(err, "config: %+v, commits: %+v", d.config, d.commits)
+		assert.NoErrorf(err, "config: %+v, commits: %+v", d.config, d.commits)
 	}
 }
 

--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -1,16 +1,7 @@
 // Copyright (c) 2017-2018 Intel Corporation
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: Apache-2.0
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package main
 

--- a/cmd/log-parser/parse.go
+++ b/cmd/log-parser/parse.go
@@ -283,12 +283,19 @@ func createLogEntry(filename string, line uint64, pairs kvPairs) (LogEntry, erro
 	if !disableAgentUnpack && agentLogEntry(l) {
 		agent, err := unpackAgentLogEntry(l)
 		if err != nil {
-			return LogEntry{}, err
-		}
+			// allow the user to see that the unpack failed
+			l.Data[agentUnpackFailTag] = "true"
 
-		// the agent log entry totally replaces the proxy log entry
-		// that encapsulated it.
-		l = agent
+			if strict {
+				return LogEntry{}, err
+			}
+
+			logger.Warnf("failed to unpack agent log entry: %v", l)
+		} else {
+			// the agent log entry totally replaces the proxy log entry
+			// that encapsulated it.
+			l = agent
+		}
 	}
 
 	return l, nil


### PR DESCRIPTION
Both the agent and the kernel write to the console. The log parser
expects all writes to the console *by the agent* to be structured and
well-formed. However, if the kernel writes to the console at the same
time the agent is writing to it, the resulting log entry will appear to
the log parser as "corrupt".

Make the log parser warn if such issues are found rather than failing.
For the original behaviour, run the log parser with the new `--strict`
option. To hide warnings, specify the new `--quiet` option.

Fixes #228.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>