### PR TITLE
integration/docker: add cpuset-cpus test

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -119,23 +119,27 @@ var _ = Describe("Hot plug CPUs", func() {
 
 var _ = Describe("CPU constraints", func() {
 	var (
-		args          []string
-		id            string
-		shares        int
-		quota         int
-		period        int
-		sharesSysPath string
-		quotaSysPath  string
-		periodSysPath string
+		args              []string
+		id                string
+		shares            int
+		quota             int
+		period            int
+		cpusetCpus        int
+		sharesSysPath     string
+		quotaSysPath      string
+		periodSysPath     string
+		cpusetCpusSysPath string
 	)
 
 	BeforeEach(func() {
 		sharesSysPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.shares"
 		quotaSysPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
 		periodSysPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
+		cpusetCpusSysPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
 		shares = 300
 		quota = 2000
 		period = 1500
+		cpusetCpus = 0
 		id = RandID(30)
 		args = []string{"--rm", "--name", id}
 	})
@@ -169,6 +173,15 @@ var _ = Describe("CPU constraints", func() {
 				stdout, _, exitCode := dockerRun(args...)
 				Expect(exitCode).To(BeZero())
 				Expect(fmt.Sprintf("%d", quota)).To(Equal(strings.Trim(stdout, "\n\t ")))
+			})
+		})
+
+		Context(fmt.Sprintf("with cpuset-cpus to %d", cpusetCpus), func() {
+			It(fmt.Sprintf("%s should have %d", cpusetCpusSysPath, cpusetCpus), func() {
+				args = append(args, "--cpuset-cpus", fmt.Sprintf("%d", cpusetCpus), Image, "cat", cpusetCpusSysPath)
+				stdout, _, exitCode := dockerRun(args...)
+				Expect(exitCode).To(BeZero())
+				Expect(fmt.Sprintf("%d", cpusetCpus)).To(Equal(strings.Trim(stdout, "\n\t ")))
 			})
 		})
 	})

--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -125,10 +125,12 @@ var _ = Describe("CPU constraints", func() {
 		quota             int
 		period            int
 		cpusetCpus        int
+		cpusetMems        int
 		sharesSysPath     string
 		quotaSysPath      string
 		periodSysPath     string
 		cpusetCpusSysPath string
+		cpusetMemsSysPath string
 	)
 
 	BeforeEach(func() {
@@ -136,10 +138,12 @@ var _ = Describe("CPU constraints", func() {
 		quotaSysPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
 		periodSysPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
 		cpusetCpusSysPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+		cpusetMemsSysPath = "/sys/fs/cgroup/cpuset/cpuset.mems"
 		shares = 300
 		quota = 2000
 		period = 1500
 		cpusetCpus = 0
+		cpusetMems = 0
 		id = RandID(30)
 		args = []string{"--rm", "--name", id}
 	})
@@ -182,6 +186,15 @@ var _ = Describe("CPU constraints", func() {
 				stdout, _, exitCode := dockerRun(args...)
 				Expect(exitCode).To(BeZero())
 				Expect(fmt.Sprintf("%d", cpusetCpus)).To(Equal(strings.Trim(stdout, "\n\t ")))
+			})
+		})
+
+		Context(fmt.Sprintf("with cpuset-mems to %d", cpusetMems), func() {
+			It(fmt.Sprintf("%s should have %d", cpusetMemsSysPath, cpusetMems), func() {
+				args = append(args, "--cpuset-mems", fmt.Sprintf("%d", cpusetMems), Image, "cat", cpusetMemsSysPath)
+				stdout, _, exitCode := dockerRun(args...)
+				Expect(exitCode).To(BeZero())
+				Expect(fmt.Sprintf("%d", cpusetMems)).To(Equal(strings.Trim(stdout, "\n\t ")))
 			})
 		})
 	})


### PR DESCRIPTION
this test is to ensure `docker --cpuset-cpus=..` works properly

fixes #248

Depends-on: github.com/kata-containers/runtime#236

Signed-off-by: Julio Montes <julio.montes@intel.com>