### PR TITLE
integration/docker: fix CPU hotplug test

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -65,10 +65,18 @@ var _ = Describe("Hot plug CPUs", func() {
 		id           string
 		vCPUs        int
 		defaultVCPUs = getDefaultVCPUs()
+		cpuSysPath   string
+		waitTime     int
+		maxTries     int
+		checkCpusCmd string
 	)
 
 	BeforeEach(func() {
 		id = RandID(30)
+		cpuSysPath = "/sys/devices/system/cpu"
+		checkCpusCmd = `c=0; while [[ "$(cat %s/cpu%d/online 2> /dev/null)" != "1" ]] && [[ $c < %d ]]; do sleep %d; ((c++)); done; nproc --all`
+		waitTime = 5
+		maxTries = 5
 		args = []string{"--rm", "--name", id}
 		Expect(defaultVCPUs).To(BeNumerically(">", 0))
 	})
@@ -79,16 +87,17 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU period and quota",
 		func(quota, period int, fail bool) {
+			vCPUs = ((quota + period - 1) / period) + defaultVCPUs
 			args = append(args, "--cpu-quota", fmt.Sprintf("%d", quota),
-				"--cpu-period", fmt.Sprintf("%d", period), Image, "sh", "-c", "sleep 5; nproc")
-			vCPUs = (quota + period - 1) / period
+				"--cpu-period", fmt.Sprintf("%d", period), Image, "sh", "-c",
+				fmt.Sprintf(checkCpusCmd, cpuSysPath, vCPUs-1, maxTries, waitTime))
 			stdout, _, exitCode := dockerRun(args...)
 			if fail {
 				Expect(exitCode).ToNot(BeZero())
 				return
 			}
 			Expect(exitCode).To(BeZero())
-			Expect(fmt.Sprintf("%d", vCPUs+defaultVCPUs)).To(Equal(strings.Trim(stdout, "\n\t ")))
+			Expect(fmt.Sprintf("%d", vCPUs)).To(Equal(strings.Trim(stdout, "\n\t ")))
 		},
 		withCPUPeriodAndQuota(30000, 20000, defaultVCPUs, false),
 		withCPUPeriodAndQuota(30000, 10000, defaultVCPUs, false),
@@ -98,7 +107,8 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU constraint",
 		func(cpus int, fail bool) {
-			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "sh", "-c", "sleep 5; nproc")
+			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "sh", "-c",
+				fmt.Sprintf(checkCpusCmd, cpuSysPath, vCPUs-1, maxTries, waitTime))
 			stdout, _, exitCode := dockerRun(args...)
 			if fail {
 				Expect(exitCode).ToNot(BeZero())


### PR DESCRIPTION
ensure `nproc` is executed until the last vCPU has been connected

fixes #250

Signed-off-by: Julio Montes <julio.montes@intel.com>