### PR TITLE
integration/docker: Skip CPU hotplug tests

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU period and quota",
 		func(quota, period int, fail bool) {
+			Skip("Issue: https://github.com/kata-containers/tests/issues/250")
 			args = append(args, "--cpu-quota", fmt.Sprintf("%d", quota),
 				"--cpu-period", fmt.Sprintf("%d", period), Image, "sh", "-c", "sleep 5; nproc")
 			vCPUs = (quota + period - 1) / period
@@ -98,6 +99,7 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU constraint",
 		func(cpus int, fail bool) {
+			Skip("Issue: https://github.com/kata-containers/tests/issues/250")
 			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "sh", "-c", "sleep 5; nproc")
 			stdout, _, exitCode := dockerRun(args...)
 			if fail {


### PR DESCRIPTION
when the container is created, it is placed inside a CPU cgroup
with the actual number of vCPUs, hence not all vCPU will be available
for the containers when they are created. For more info see #250.

fixes #252

Signed-off-by: Julio Montes <julio.montes@intel.com>