### PR TITLE
tests: Add test to check if a block device is passed as volume.

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -7,6 +7,8 @@ package docker
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -402,4 +404,58 @@ func dockerUnpause(args ...string) (string, string, int) {
 // dockerTop displays the running processes of a container
 func dockerTop(args ...string) (string, string, int) {
 	return runDockerCommand("top", args...)
+}
+
+// createLoopDevice creates a new disk file using 'dd' command, returns the path to disk file and
+// its loop device representation
+func createLoopDevice() (string, string, error) {
+	f, err := ioutil.TempFile("", "dd")
+	if err != nil {
+		return "", "", err
+	}
+	defer f.Close()
+
+	// create disk file
+	ddArgs := []string{"if=/dev/zero", fmt.Sprintf("of=%s", f.Name()), "count=1", "bs=50M"}
+	ddCmd := tests.NewCommand("dd", ddArgs...)
+	if _, stderr, exitCode := ddCmd.Run(); exitCode != 0 {
+		return "", "", fmt.Errorf("%s", stderr)
+	}
+
+	// partitioning disk file
+	fdiskArgs := []string{"-c", fmt.Sprintf(`printf "g\nn\n\n\n\nw\n" | fdisk %s`, f.Name())}
+	fdiskCmd := tests.NewCommand("bash", fdiskArgs...)
+	if _, stderr, exitCode := fdiskCmd.Run(); exitCode != 0 {
+		return "", "", fmt.Errorf("%s", stderr)
+	}
+
+	// create loop device
+	losetupCmd := tests.NewCommand("losetup", "-fP", f.Name())
+	if _, stderr, exitCode := losetupCmd.Run(); exitCode != 0 {
+		return "", "", fmt.Errorf("%s", stderr)
+	}
+
+	// get loop device path
+	getLoopPath := tests.NewCommand("losetup", "-j", f.Name())
+	stdout, stderr, exitCode := getLoopPath.Run()
+	if exitCode != 0 {
+		return "", "", fmt.Errorf("exitCode: %d, stdout: %s, stderr: %s ", exitCode, stdout, stderr)
+	}
+	re := regexp.MustCompile("/dev/loop[0-9]+")
+	loopPath := re.FindStringSubmatch(stdout)
+	if len(loopPath) == 0 {
+		return "", "", fmt.Errorf("Unable to get loop device path, stdout: %s, stderr: %s", stdout, stderr)
+	}
+	return f.Name(), loopPath[0], nil
+}
+
+// deleteLoopDevice removes loopdevices
+func deleteLoopDevice(loopFile string) error {
+	partxCmd := tests.NewCommand("losetup", "-d", loopFile)
+	_, stderr, exitCode := partxCmd.Run()
+	if exitCode != 0 {
+		return fmt.Errorf("%s", stderr)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This will check if a block device passed as a volume is passed to VM using a block driver as well as it adds a tests that checks if a text file under /dev is passed to a container and check that contents are the same.

Fixes #191

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>