### PR TITLE
ci: build and install kernel from source code

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -61,6 +61,9 @@ bash -f ${cidir}/install_kubernetes.sh
 echo "Install Openshift"
 bash -f ${cidir}/install_openshift.sh
 
+echo "Install Kata Containers Kernel"
+${cidir}/install_kata_kernel.sh
+
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -40,6 +40,9 @@ fi
 echo "Install qemu dependencies"
 chronic sudo -E yum install -y libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex
 
+echo "Install kernel dependencies"
+chronic sudo -E yum -y install elfutils-libelf-devel
+
 echo "Install kata-containers image"
 "${cidir}/install_kata_image.sh"
 
@@ -55,9 +58,6 @@ chronic sudo -E yum install -y libgudev1-devel
 
 echo "Install Build Tools"
 sudo -E yum install -y python pkgconfig zlib-devel
-
-echo "Install Kata Containers Kernel"
-"${cidir}/install_kata_kernel.sh" "latest"
 
 sudo -E yum install -y ostree-devel
 

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -32,11 +32,11 @@ echo "Install qemu dependencies"
 chronic sudo -E dnf -y install libcap-devel libattr-devel \
 	libcap-ng-devel zlib-devel pixman-devel librbd-devel
 
+echo "Install kernel dependencies"
+chronic sudo -E dnf -y install elfutils-libelf-devel
+
 echo "Install kata containers image"
 "${cidir}/install_kata_image.sh"
-
-echo "Install Kata Containers Kernel"
-"${cidir}/install_kata_kernel.sh" "latest"
 
 echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel      \

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -30,6 +30,9 @@ chronic sudo -E apt install -y libcap-dev libattr1-dev libcap-ng-dev librbd-dev
 echo "Install kata-containers image"
 "${cidir}/install_kata_image.sh"
 
+echo "Install kernel dependencies"
+chronic sudo -E apt install -y libelf-dev
+
 echo "Install CRI-O dependencies for all Ubuntu versions"
 chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev go-md2man
 
@@ -41,9 +44,6 @@ chronic sudo -E apt-get install -y libudev-dev
 
 echo "Install Build Tools"
 sudo -E apt install -y build-essential python pkg-config zlib1g-dev
-
-echo "Install Kata Containers Kernel"
-"${cidir}/install_kata_kernel.sh" "latest"
 
 echo -e "Install CRI-O dependencies available for Ubuntu $VERSION_ID"
 sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux


### PR DESCRIPTION
Build and install kernel from source code by using kata patches and config.
Kata patches and config are located in the packaging repository.

fixes #262

Signed-off-by: Julio Montes <julio.montes@intel.com>