### PR TITLE
test: Skip yum test in package manager update.

### DIFF
--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -63,6 +63,7 @@ var _ = Describe("package manager update test", func() {
 
 	Context("check yum update", func() {
 		It("should not fail", func() {
+			Skip("Issue: https://github.com/kata-containers/tests/issues/264")
 			args = append(args, "--rm", "--name", id, CentosImage, "yum", "-y", "update")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())


### PR DESCRIPTION
Skip this test until see why randomly is failing in the CI.

Fixes #267

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>