### PR TITLE
test: Add functional test for global options.

### DIFF
--- a/functional/main_test.go
+++ b/functional/main_test.go
@@ -11,7 +11,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const shouldFail = true
+const (
+	shouldFail    = true
+	shouldNotFail = false
+)
 
 func TestFunctional(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/functional/options_test.go
+++ b/functional/options_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package functional
+
+import (
+	"fmt"
+
+	. "github.com/kata-containers/tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func withOption(option string, fail bool) TableEntry {
+	command := NewCommand(Runtime, option)
+	return Entry(fmt.Sprintf("with option '%s'", option), command, fail)
+}
+
+var _ = Describe("global options", func() {
+	DescribeTable("option",
+		func(command *Command, fail bool) {
+			stdout, stderr, exitCode := command.Run()
+
+			if fail {
+				Expect(exitCode).NotTo(Equal(0))
+				Expect(stderr).NotTo(BeEmpty())
+				Expect(stdout).NotTo(BeEmpty())
+			} else {
+				Expect(exitCode).To(Equal(0))
+				Expect(stderr).To(BeEmpty())
+				Expect(stdout).NotTo(BeEmpty())
+			}
+		},
+		withOption("--version", shouldNotFail),
+		withOption("--v", shouldNotFail),
+		withOption("--help", shouldNotFail),
+		withOption("--h", shouldNotFail),
+		withOption("--this-option-does-not-exist", shouldFail),
+	)
+})


### PR DESCRIPTION
This is a standalone test for global options like help and version.

Fixes #274

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>