### PR TITLE
CI: Run k8s tests on ubuntu and Openshift tests on Fedora

### DIFF
--- a/.ci/install_openshift.sh
+++ b/.ci/install_openshift.sh
@@ -10,6 +10,13 @@ set -e
 cidir=$(dirname "$0")
 source /etc/os-release
 source "${cidir}/lib.sh"
+
+if [ "$ID" != "fedora" ] && [ "$CI" == true ]; then
+	echo "Skip Openshift Installation on $ID"
+	echo "CI only runs openshift tests on fedora"
+	exit
+fi
+
 openshift_origin_version=$(get_version "externals.openshift.version")
 openshift_origin_commit=$(get_version "externals.openshift.commit")
 

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -24,7 +24,11 @@ fi
 # then checkout to the version from versions.yaml in the runtime repository.
 if [ "$ghprbGhRepository" != "${crio_repository/github.com\/}" ];then
 	pushd "${crio_repository_path}"
-	crio_version=$(get_version "externals.crio.version")
+	if [ "$ID" == "fedora" ]; then
+		crio_version=$(get_version "externals.crio.meta.openshift")
+	else
+		crio_version=$(get_version "externals.crio.version")
+	fi
 	git fetch
 	git checkout "${crio_version}"
 	popd

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -8,6 +8,18 @@
 export KUBECONFIG=/etc/kubernetes/admin.conf
 sudo -E kubeadm reset --cri-socket=/var/run/crio/crio.sock
 
+# Workaround to delete pods using crictl
+# Needed until https://github.com/kubernetes/kubeadm/issues/748
+# gets fixed
+for ctr in $(sudo crictl ps --quiet); do
+	sudo crictl stop "$ctr"
+	sudo crictl rm "$ctr"
+done
+for pod in $(sudo crictl pods --quiet); do
+	sudo crictl stopp "$pod"
+	sudo crictl rmp "$pod"
+done
+
 sudo systemctl stop crio
 
 sudo ip link set dev cni0 down

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -42,4 +42,8 @@ teardown() {
 	sudo -E kubectl delete deployment "$service_name"
 	sudo -E kubectl delete service "$service_name"
 	sudo -E kubectl delete pod "$busybox_pod"
+	# Wait for the pods to be deleted
+	cmd="sudo -E kubectl get pods | grep found."
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	sudo -E kubectl get pods
 }

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -13,8 +13,9 @@ kubernetes_dir=$(dirname $0)
 # Currently, Kubernetes tests only work on Ubuntu.
 # We should delete this condition, when it works for other Distros.
 if [ "$ID" != ubuntu  ]; then
-    echo "Skip - kubernetes tests on $ID aren't supported yet"
-    exit
+	echo "Skip Kubernetes tests on $ID"
+	echo "kubernetes tests on $ID aren't supported yet"
+	exit
 fi
 
 pushd "$kubernetes_dir"

--- a/integration/openshift/init.sh
+++ b/integration/openshift/init.sh
@@ -9,6 +9,7 @@ set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/openshiftrc"
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
 
 echo "Start crio service"
 sudo systemctl start crio
@@ -37,5 +38,14 @@ EOF
 echo "Start Master"
 sudo -E openshift start master --config "$master_config" &> master.log &
 
+# Wait for the master to get ready.
+wait_time=10
+sleep_time=1
+cmd="sudo -E oc status"
+waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
 echo "Start Node"
 sudo -E openshift start node --config "$node_crio_config" &> node.log &
+
+sudo -E oc get all
+echo "Openshift started successfully"

--- a/integration/openshift/run_openshift_tests.sh
+++ b/integration/openshift/run_openshift_tests.sh
@@ -10,11 +10,11 @@ set -e
 source /etc/os-release
 openshift_dir=$(dirname $0)
 
-# Currently, Kubernetes tests only work on Ubuntu.
-# We should delete this condition, when it works for other Distros.
-if [ "$ID" != ubuntu  ]; then
-    echo "Skip - Openshift tests on $ID aren't supported yet"
-    exit
+# Currently, the CI runs Openshift tests on Fedora.
+if [ "$ID" != "fedora" ] && [ "$CI" == true ]; then
+	echo "Skip Openshift tests on $ID"
+	echo "CI only runs openshift tests on fedora"
+	exit
 fi
 
 pushd "$openshift_dir"


### PR DESCRIPTION
As we need CRI-O 1.9 to run tests on openshift v3.9.0 (latest)
and CRI-O 1.10 to run Kubernetes 1.10, we need to make a
division in our CI, so that we can test both scenarios without
adding more execution time to the CI jobs.
Because of this, we will execute CRI-O 1.9 - openshift v3.9.0
tests under Fedora and CRI-O 1.10 - Kubernetes 1.10 tests
under ubuntu.

Fixes: #276.

Depends-on: github.com/kata-containers/runtime#278

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>