### PR TITLE
CI: add support for adding virtio-blk job

### DIFF
--- a/.ci/install_qemu_lite.sh
+++ b/.ci/install_qemu_lite.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+arch=$(arch)
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <CLEAR_RELEASE> <QEMU_LITE_VERSION> <DISTRO>"
+    echo "       Install the QEMU_LITE_VERSION from clear CLEAR_RELEASE."
+    exit 1
+fi
+
+clear_release="$1"
+qemu_lite_version="$2"
+distro="$3"
+qemu_lite_bin="qemu-lite-bin-${qemu_lite_version}.${arch}.rpm"
+qemu_lite_data="qemu-lite-data-${qemu_lite_version}.${arch}.rpm"
+
+echo -e "Install qemu-lite ${qemu_lite_version}"
+
+# download packages
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/${arch}/os/Packages/${qemu_lite_bin}"
+curl -LO "https://download.clearlinux.org/releases/${clear_release}/clear/${arch}/os/Packages/${qemu_lite_data}"
+
+# install packages
+if [ "$distro" == "ubuntu" ];  then
+	sudo alien -i "./${qemu_lite_bin}"
+	sudo alien -i "./${qemu_lite_data}"
+elif [ "$distro" == "fedora" ]; then
+	sudo rpm -ihv "./${qemu_lite_bin}" --nodeps
+	sudo rpm -ihv "./${qemu_lite_data}" --nodeps
+fi
+
+# cleanup
+rm -f "./${qemu_lite_bin}"
+rm -f "./${qemu_lite_data}"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -61,3 +61,9 @@ docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
 
 echo "Add kata-runtime as a new/default Docker runtime."
 "${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
+
+if [ "$USE_VIRTIO_BLK" == true ]; then
+	echo "Set virtio-blk as the block device driver"
+	sudo sed -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
+	sudo sed -i 's/qemu-system/qemu-lite-system/' "${runtime_config_path}"
+fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -37,8 +37,15 @@ else
 	die "Unsupported architecture: $arch"
 fi
 
+
+# Use qemu-lite 2.7 for virtio-blk as there is
+# a bug using qemu>=2.9
 echo "Install Qemu"
-bash -f ${cidir}/install_qemu.sh
+if [ "$USE_VIRTIO_BLK" == true ]; then
+	bash -f ${cidir}/install_qemu_lite.sh "22280" "741f430a960b5b67745670e8270db91aeb083c5f-31" "$ID"
+else
+	bash -f ${cidir}/install_qemu.sh
+fi
 
 echo "Install shim"
 bash -f ${cidir}/install_shim.sh


### PR DESCRIPTION
In addition to the current CI jobs, which currently test
using virtio-scsi driver, we need to also test virtio-blk
as we also support this driver but using qemu-lite 2.7

Fixes: #271.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>