### PR TITLE
test: docker-compose, skip test from setup

### DIFF
--- a/integration/docker-compose/docker-compose.bats
+++ b/integration/docker-compose/docker-compose.bats
@@ -16,6 +16,7 @@ IMAGE_NAME="dockercompose_web"
 INSTALLATION_PATH="/usr/local/bin/docker-compose"
 
 setup () {
+	skip "This is not working (https://github.com/clearcontainers/runtime/issues/1042)"
 	run command -v docker-compose
 	# Check that Docker compose is installed in the system
 	if [ "$status" -ne 0 ]; then
@@ -44,6 +45,7 @@ setup () {
 }
 
 teardown() {
+	skip "This is not working (https://github.com/clearcontainers/runtime/issues/1042)"
 	#Stop containers
 	docker-compose stop
 


### PR DESCRIPTION
docker-compose test is currently being skipped, but the setup
of the test is being executed and it sometimes timeout.
This will skip the setup of the test also, there is no reason
to run the setup if the test is actually not executed.

Fixes #285.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>