### PR TITLE
CI: Install losetup for kata-collect-data.sh

### DIFF
--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -42,7 +42,7 @@ echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel      \
 	glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel  \
 	libgpg-error-devel libseccomp-devel libselinux-devel ostree-devel \
-	pkgconfig go-md2man
+	pkgconfig go-md2man util-linux
 
 echo "Install bison binary"
 chronic sudo -E dnf -y install bison


### PR DESCRIPTION
Ensure the `losetup` command is available by installing the
`util-linux` package.

Fixes #289.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>