### PR TITLE
tests: Skip CPU hot-plug tests

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU period and quota",
 		func(quota, period int, fail bool) {
+			Skip("https://github.com/kata-containers/agent/issues/232")
 			vCPUs = ((quota + period - 1) / period) + defaultVCPUs
 			args = append(args, "--cpu-quota", fmt.Sprintf("%d", quota),
 				"--cpu-period", fmt.Sprintf("%d", period), Image, "sh", "-c",
@@ -105,6 +106,7 @@ var _ = Describe("Hot plug CPUs", func() {
 
 	DescribeTable("container with CPU constraint",
 		func(cpus int, fail bool) {
+			Skip("https://github.com/kata-containers/agent/issues/232")
 			vCPUs = cpus + defaultVCPUs
 			args = append(args, "--cpus", fmt.Sprintf("%d", cpus), Image, "sh", "-c",
 				fmt.Sprintf(checkCpusCmdFmt, vCPUs-1, maxTries, waitTime))


### PR DESCRIPTION
We still have issues with the CPU hot-plug functionality.
Reported on https://github.com/kata-containers/agent/issues/232.

Fixes #294.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>