### PR TITLE
CI: metrics: add installation of smem and jq

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -63,3 +63,6 @@ sudo -E yum install -y ostree-devel
 
 echo "Install YAML validator"
 sudo -E yum install -y yamllint
+
+echo "Install tools for metrics tests"
+sudo -E yum install -y smem jq

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -49,3 +49,6 @@ chronic sudo -E dnf -y install bison
 
 echo "Install YAML validator"
 sudo -E dnf -y install yamllint
+
+echo "Install tools for metrics tests"
+sudo -E dnf -y install smem jq

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -58,3 +58,6 @@ sudo -E apt install -y libostree-dev
 
 echo "Install YAML validator"
 sudo -E apt install -y yamllint
+
+echo "Install tools for metrics tests"
+sudo -E apt install -y smem jq


### PR DESCRIPTION
smem is needed for the memory footprint test and
jq to process the output of the metrics tests.
Add these tools in the setup of the CI.

Fixes: #297.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>