### PR TITLE
CI: Fix collect script bug in teardown script

### DIFF
--- a/.ci/kata-doc-to-script.sh
+++ b/.ci/kata-doc-to-script.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+[ -n "$DEBUG" ] && set -x
+
+script_name="${0##*/}"
+
+typeset -r warning="WARNING: Do *NOT* run the generated script without reviewing it carefully first!"
+
+# github markdown markers used to surround a code block. All text within the
+# markers is rendered in a fixed font.
+typeset -r block_open="\`\`\`bash"
+typeset -r block_close="\`\`\`"
+
+# convention used in all documentation to represent a non-privileged users
+# shell prompt. All lines starting with this value inside a code block are
+# commands the user should run.
+typeset -r code_prompt="\$ "
+
+# files are expected to match this regular expression
+typeset -r extension_regex="\.md$"
+
+strict="no"
+require_commands="no"
+check_only="no"
+verbose="no"
+
+usage()
+{
+	cat <<EOT
+Usage: ${script_name} [options] <markdown-file> [<script-file>]
+
+This script will convert a github-flavoured markdown document file into a
+bash(1) script to stdout by extracting the bash code blocks.
+
+
+Options:
+
+  -c : check the file but don't create the script (sets exit code).
+  -h : show this usage.
+  -r : require atleast one command block to be found.
+  -s : strict mode - perform extra checks.
+  -v : verbose mode.
+
+${warning}
+
+Example usage:
+
+  $ ${script_name} foo.md foo.md.sh
+
+${warning}
+
+EOT
+
+	exit 0
+}
+
+die()
+{
+	local msg="$*"
+
+	echo "ERROR: $msg" >&2
+	exit 1
+}
+
+script_header()
+{
+	cat <<-EOT
+	#!/bin/bash
+	#----------------------------------------------
+	# WARNING: Script auto-generated from '$file'.
+	#
+	# ${warning}
+	#----------------------------------------------
+
+	# fail the entire script if any simple command fails
+	set -e
+
+EOT
+}
+
+# Convert the specified github-flavoured markdown format file
+# into a bash script by extracting the bash blocks.
+doc_to_script()
+{
+	file="$1"
+	outfile="$2"
+
+	[ -n "$file" ] || die "need file"
+
+	[ "${check_only}" = "no" ] && [ -z "$outfile" ] && die "need output file"
+
+	all=$(mktemp)
+	body=$(mktemp)
+
+	cat "$file" |\
+		sed -n "/^${block_open}/,/^${block_close}/ p" |\
+		sed -e "/^${block_close}/ d" \
+		-e "s/^${code_prompt}//g" > "$body"
+
+	[ "$require_commands" = "yes" ] && [ ! -s "$body" ] && die "no commands found in file '$file'"
+
+	script_header > "$all"
+	cat "$body" >> "$all"
+
+	# sanity check
+	[ "$check_only" = "yes" ] && redirect="1>/dev/null 2>/dev/null"
+
+	eval bash -n "$all" $redirect
+
+	# create output file
+	[ "$check_only" = "no" ] && cp "$all" "$outfile"
+
+	# clean up
+	rm -f "$body" "$all"
+}
+
+main()
+{
+	while getopts "chrsv" opt
+	do
+		case $opt in
+			c)	check_only="yes" ;;
+			h)	usage ;;
+			r)	require_commands="yes" ;;
+			s)	strict="yes" ;;
+			v)	verbose="yes" ;;
+		esac
+	done
+
+	shift $(($OPTIND - 1))
+
+	file="$1"
+	outfile="$2"
+
+	[ -n "$file" ] || die "need file"
+
+	[ "$verbose" = "yes" ] && echo "INFO: processing file '$file'"
+
+	if [ "$strict" = "yes" ]
+	then
+		echo "$file"|grep -q "$extension_regex" ||\
+			die "file '$file' doesn't match pattern '$extension_regex'"
+	fi
+
+	doc_to_script "$file" "$outfile"
+}
+
+main "$@"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -259,7 +259,21 @@ EOT
 	fi
 }
 
+# Perform basic checks on documentation files
+check_docs()
+{
+	echo "INFO: Checking documentation"
+
+	docs=$(find . -name "*.md" |grep -v "vendor/" || true)
+
+	for doc in $docs
+	do
+		bash "${cidir}/kata-doc-to-script.sh" -csv "$doc"
+	done
+}
+
 check_commits
 check_license_headers
 check_go
 check_versions
+check_docs

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -61,7 +61,8 @@ if [ "${log_copy_dest}" ]; then
 	split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
 	split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
 	split -b "${subfile_size}" -d "${kubelet_log_path}" "${kubelet_log_prefix}"
-	split -b "${subfile_size}" -d "${collect_data_log_path}" "${collect_data_log_prefix}"
+
+	[ "${have_collect_script}" = "yes" ] &&  split -b "${subfile_size}" -d "${collect_data_log_path}" "${collect_data_log_prefix}"
 
 	prefixes=""
 	prefixes+=" ${kata_runtime_log_prefix}"

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ system**. See [Developer Mode](#developer-mode).
 The strategy to check if the tests are running under a CI system is to see
 if the `CI` variable is set to the value `true`. For example, in shell syntax:
 
-```bash
+```
 if [ "$CI" = true ]; then
-    # Assumed to be running in a CI environment
+    : # Assumed to be running in a CI environment
 else
-    # Assumed to NOT be running in a CI environment
+    : # Assumed to NOT be running in a CI environment
 fi
 ```
 


### PR DESCRIPTION
The `.ci/teardown.sh` script should not try to split the collect script
log file if the collect script is not available.

Fixes #322.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
