### PR TITLE
CI: Add license header to generated script

### DIFF
--- a/.ci/kata-doc-to-script.sh
+++ b/.ci/kata-doc-to-script.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+license="
 #
 # Copyright (c) 2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+"
 
 set -e
 
@@ -72,6 +74,7 @@ script_header()
 {
 	cat <<-EOT
 	#!/bin/bash
+	${license}
 	#----------------------------------------------
 	# WARNING: Script auto-generated from '$file'.
 	#


### PR DESCRIPTION
Add the standard SPDX license header to the script generated by the
doc-to-script script.

Fixes #325.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>