### PR TITLE
ci: Fix how to retrieve kata-agent commit version

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -50,7 +50,7 @@ else
 fi
 
 # Install the image
-agent_commit=$("$GOPATH/src/github.com/kata-containers/agent/kata-agent" --version | awk '{print $NF}')
+agent_commit=$(/usr/bin/kata-agent --version |  awk '{print $NF}')
 commit=$(git log --format=%h -1 HEAD)
 date=$(date +%Y-%m-%d-%T.%N%z)
 image="kata-containers-${date}-osbuilder-${commit}-agent-${agent_commit}"


### PR DESCRIPTION
In order to enable initrd Jenkins testing, we need to fix how to
retrieve the kata-agent commit version. The main reason is that with the
options AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine, the
$GOPATH/src/github.com/kata-containers/agent/kata-agent --version does
not exist.

Fixes #330

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>