### PR TITLE
CRI-O: Use block device for devicemapper driver

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -34,7 +34,8 @@ echo "Install kernel dependencies"
 chronic sudo -E apt install -y libelf-dev
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
-chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev go-md2man
+chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev \
+	libgpgme11-dev go-md2man thin-provisioning-tools
 
 echo "Install bison binary"
 chronic sudo -E apt install -y bison


### PR DESCRIPTION
Now that cri-o is deprecating the use of loop back
devices when using devicemapper driver, we need to
use a block device on the Azure VMs from our CI.

This fix assumes that the Azure VM will have an
/dev/sdb device and it will only be executed when
CI=true, to prevent from being executed on a
development machine.

Fixes: #341

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>