### PR TITLE
 CI: Install kernel from packages if up-to-date 

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -37,32 +37,35 @@ else
 	die "Unsupported architecture: $arch"
 fi
 
-echo "Install Qemu"
-bash -f ${cidir}/install_qemu.sh
-
-echo "Install shim"
-bash -f ${cidir}/install_shim.sh
-
-echo "Install proxy"
-bash -f ${cidir}/install_proxy.sh
-
-echo "Install runtime"
-bash -f ${cidir}/install_runtime.sh
-
-echo "Install CNI plugins"
-bash -f ${cidir}/install_cni_plugins.sh
-
-echo "Install CRI-O"
-bash -f ${cidir}/install_crio.sh
-
-echo "Install Kubernetes"
-bash -f ${cidir}/install_kubernetes.sh
-
-echo "Install Openshift"
-bash -f ${cidir}/install_openshift.sh
+echo "Install Kata Containers image"
+bash -f "${cidir}/install_kata_image.sh"
 
 echo "Install Kata Containers Kernel"
-${cidir}/install_kata_kernel.sh
+"${cidir}/install_kata_kernel.sh"
+
+echo "Install Qemu"
+bash -f "${cidir}/install_qemu.sh"
+
+echo "Install Kata Containers shim"
+bash -f "${cidir}/install_shim.sh"
+
+echo "Install Kata Containers proxy"
+bash -f "${cidir}/install_proxy.sh"
+
+echo "Install Kata Containers runtime"
+bash -f "${cidir}/install_runtime.sh"
+
+echo "Install CNI plugins"
+bash -f "${cidir}/install_cni_plugins.sh"
+
+echo "Install CRI-O"
+bash -f "${cidir}/install_crio.sh"
+
+echo "Install Kubernetes"
+bash -f "${cidir}/install_kubernetes.sh"
+
+echo "Install Openshift"
+bash -f "${cidir}/install_openshift.sh"
 
 echo "Drop caches"
 sync

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -43,9 +43,6 @@ chronic sudo -E yum install -y libcap-devel libcap-ng-devel libattr-devel libcap
 echo "Install kernel dependencies"
 chronic sudo -E yum -y install elfutils-libelf-devel
 
-echo "Install kata-containers image"
-"${cidir}/install_kata_image.sh"
-
 echo "Install CRI-O dependencies for CentOS"
 chronic sudo -E yum install -y glibc-static libglib2.0-devel libseccomp-devel libassuan-devel libgpg-error-devel go-md2man device-mapper-libs \
 	 btrfs-progs-devel util-linux gpgme-devel

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -57,12 +57,18 @@ echo "Install libgudev1-devel"
 chronic sudo -E yum install -y libgudev1-devel
 
 echo "Install Build Tools"
-sudo -E yum install -y python pkgconfig zlib-devel
+chronic sudo -E yum install -y python pkgconfig zlib-devel
 
-sudo -E yum install -y ostree-devel
+chronic sudo -E yum install -y ostree-devel
 
 echo "Install YAML validator"
-sudo -E yum install -y yamllint
+chronic sudo -E yum install -y yamllint
 
 echo "Install tools for metrics tests"
-sudo -E yum install -y smem jq
+chronic sudo -E yum install -y smem jq
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
+	sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
+fi

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -35,9 +35,6 @@ chronic sudo -E dnf -y install libcap-devel libattr-devel \
 echo "Install kernel dependencies"
 chronic sudo -E dnf -y install elfutils-libelf-devel
 
-echo "Install kata containers image"
-"${cidir}/install_kata_image.sh"
-
 echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel      \
 	glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel  \

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -52,3 +52,9 @@ sudo -E dnf -y install yamllint
 
 echo "Install tools for metrics tests"
 sudo -E dnf -y install smem jq
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="http://download.opensuse.org/repositories/home:/katacontainers:/release/Fedora_$VERSION_ID/home:katacontainers:release.repo"
+	sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo "$obs_url"
+fi

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -27,9 +27,6 @@ fi
 echo "Install qemu dependencies"
 chronic sudo -E apt install -y libcap-dev libattr1-dev libcap-ng-dev librbd-dev
 
-echo "Install kata-containers image"
-"${cidir}/install_kata_image.sh"
-
 echo "Install kernel dependencies"
 chronic sudo -E apt install -y libelf-dev
 

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -61,3 +61,11 @@ sudo -E apt install -y yamllint
 
 echo "Install tools for metrics tests"
 sudo -E apt install -y smem jq
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/"
+	sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
+	curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
+	sudo -E apt-get update
+fi


### PR DESCRIPTION
Instead of building the kernel from sources, we can
use the packaged version if there hasn't been any
changes. This will allow us to save time in the CI
jobs.

In addition, this PR contains two other changes:
- Install OBS repositories (needed to install kata packages).
- Move the kata image installation to the main setup script instead 
   calling it on every distro setup.