### PR TITLE
integration/docker: unskip remove paused container test

### DIFF
--- a/integration/docker/pause_test.go
+++ b/integration/docker/pause_test.go
@@ -92,7 +92,6 @@ var _ = Describe("remove paused container", func() {
 	})
 
 	AfterEach(func() {
-		Expect(RemoveDockerContainer(id)).To(BeTrue())
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
 	})
 

--- a/integration/docker/pause_test.go
+++ b/integration/docker/pause_test.go
@@ -99,7 +99,6 @@ var _ = Describe("remove paused container", func() {
 	Describe("start, pause, remove container", func() {
 		Context("check if a paused container can be removed", func() {
 			It("should be removed", func() {
-				Skip("Issue: https://github.com/kata-containers/runtime/issues/317")
 				_, _, exitCode = dockerRun("-td", "--name", id, Image, "sh")
 				Expect(0).To(Equal(exitCode))
 				_, _, exitCode = dockerPause(id)


### PR DESCRIPTION
remove paused container test is to ensure paused containers
can be removed.

Depends-on: github.com/kata-containers/runtime#328

fixes #345

Signed-off-by: Julio Montes <julio.montes@intel.com>