### PR TITLE
CI: specify runc version that we use for crio

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -74,6 +74,7 @@ sudo install -m0444 test/policy.json "$containers_config_path"
 popd
 
 echo "Install runc for CRI-O"
+runc_version=$(get_version "externals.runc.version")
 go get -d github.com/opencontainers/runc
 pushd "${GOPATH}/src/github.com/opencontainers/runc"
 git checkout "$runc_version"


### PR DESCRIPTION
We use a `runc_version` variable for building an specific
runc version, but there is no value assigned to that variable.
This fixes it by getting the value from versions.yaml in the
runtime repository.

Fixes #354.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>