### PR TITLE
tests: Fix mariadb.cnf path for docker hub popular images.

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -207,7 +207,7 @@ setup() {
 }
 
 @test "[display configuration] start an instance of a mariadb container" {
-	docker run --rm --runtime=$RUNTIME -i -e MYSQL_ROOT_PASSWORD=secretword  mariadb bash -c "cat /etc/mysql/conf.d/mariadb.cnf | grep character"
+	docker run --rm --runtime=$RUNTIME -i -e MYSQL_ROOT_PASSWORD=secretword  mariadb bash -c "cat /etc/mysql/mariadb.cnf | grep character"
 }
 
 @test "[java application] check memory maven container" {


### PR DESCRIPTION
Fix the path for the mariadb.cnf file for docker hub popular images.

Fixes #357

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>