### PR TITLE
kata-manager: Fix config setting

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -128,6 +128,16 @@ disable_initrd()
 	sudo sed -i 's/^\(initrd *=.*\)/# \1/g' "$config_file"
 }
 
+add_hypervisor_config()
+{
+	local name="$1"
+	local value="$2"
+
+	local -r hypervisor="qemu"
+
+	sudo sed -i "/\[hypervisor\.${hypervisor}\]/a ${name} = $value" "$config_file"
+}
+
 enable_image()
 {
 	local file="$1"
@@ -135,6 +145,11 @@ enable_image()
 	config_checks
 
 	sudo sed -i "s!^#*.*image *=.*\$!image = \"$file\"!g" "$config_file"
+
+	egrep -q "\<image\> *=" "$config_file" && return
+
+	# Add missing entry
+	add_hypervisor_config "image" "\"$file\""
 }
 
 enable_initrd()
@@ -144,6 +159,11 @@ enable_initrd()
 	config_checks
 
 	sudo sed -i "s!^#*.*initrd *=.*\$!initrd = \"$file\"!g" "$config_file"
+
+	egrep -q "\<initrd\> *=" "$config_file" && return
+
+	# Add missing entry
+	add_hypervisor_config "initrd" "\"$file\""
 }
 
 cmd_enable_full_debug()

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -287,7 +287,7 @@ parse_args()
 	do
 		case "$opt" in
 			c)
-				config_file="$1"
+				config_file="$OPTARG"
 				;;
 			h)
 				usage

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -143,7 +143,7 @@ enable_initrd()
 
 	config_checks
 
-	sudo sed -i "s!^#*.*initrd *=.*\$!initrd =\"$file\"!g" "$config_file"
+	sudo sed -i "s!^#*.*initrd *=.*\$!initrd = \"$file\"!g" "$config_file"
 }
 
 cmd_enable_full_debug()


### PR DESCRIPTION
Fix assumption that the runtime config file will always contain both
`initrd=` and `image=` options (with one disabled).

Now, if the specified config command doesn't find the field in the
config file, it will add it.

Also, fixed bug stopping `kata-manager.sh -c $file` from using the specified `$file`.

Fixes #368.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>