### PR TITLE
integration/docker: add test to ensure cgroup filesystem is read-only

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -206,3 +206,28 @@ var _ = Describe("run nonexistent command", func() {
 		})
 	})
 })
+
+var _ = Describe("Check read-only cgroup filesystem", func() {
+	var (
+		args     []string
+		id       string
+		exitCode int
+	)
+
+	BeforeEach(func() {
+		id = randomDockerName()
+	})
+
+	AfterEach(func() {
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
+	})
+
+	Context("write anything in the cgroup files", func() {
+		It("should fail because of cgroup filesystem MUST BE read-only", func() {
+			args = []string{"--rm", "--name", id, DebianImage, "bash", "-c",
+				"for f in /sys/fs/cgroup/*/*; do echo 100 > $f && exit 1; done; exit 0"}
+			_, _, exitCode = dockerRun(args...)
+			Expect(exitCode).To(Equal(0))
+		})
+	})
+})


### PR DESCRIPTION
this is a security test, to ensure the container can't update it's constraints
and get access to more resources.

fixes #373

Signed-off-by: Julio Montes <julio.montes@intel.com>