### PR TITLE
tests: Skip kubernetes and openshift tests for initrd.

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -18,6 +18,13 @@ if [ "$ID" != ubuntu  ]; then
 	exit
 fi
 
+# Currently, Kubernetes tests are not working with initrd.
+if [ "$TEST_INITRD" = yes ] && [ "$AGENT_INIT" = yes ]; then
+	echo "Skip Kubernetes tests on INITRD"
+	echo "Issue github.com/kata-containers/tests/issues/335"
+	exit
+fi
+
 pushd "$kubernetes_dir"
 ./init.sh
 bats nginx.bats

--- a/integration/openshift/run_openshift_tests.sh
+++ b/integration/openshift/run_openshift_tests.sh
@@ -17,6 +17,13 @@ if [ "$ID" != "fedora" ] && [ "$CI" == true ]; then
 	exit
 fi
 
+# Currently, Openshift tests are not working with initrd.
+if [ "$TEST_INITRD" = yes ] && [ "$AGENT_INIT" = yes ]; then
+	echo "Skip Openshift tests on INITRD"
+	echo "Issue github.com/kata-containers/tests/issues/335"
+	exit
+fi
+
 pushd "$openshift_dir"
 ./init.sh
 bats hello_world.bats


### PR DESCRIPTION
As currently Kubernetes and Openshift tests are not working
with INITRD, we need to skip them in order to enable
a Jenkins job.

Fixes #380

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>