### PR TITLE
ci: Fix kata arch script on ppc64le

### DIFF
--- a/.ci/kata-arch.sh
+++ b/.ci/kata-arch.sh
@@ -35,7 +35,7 @@ arch_to_golang()
 	local -r arch="$1"
 
 	case "$arch" in
-		arm64|ppc64el) echo "$arch";;
+		arm64|ppc64le) echo "$arch";;
 		x86_64) echo "amd64";;
 		*) die "unsupported architecture: $arch";;
 	esac
@@ -48,7 +48,7 @@ arch_to_kernel()
 
 	case "$arch" in
 		arm64|x86_64) echo "$arch";;
-		ppc64el) echo "powerpc";;
+		ppc64le) echo "powerpc";;
 		*) die "unsupported architecture: $arch";;
 	esac
 }


### PR DESCRIPTION
Kata arch scripts tests arch string on ppc64le
against ppc64el, resulting in "ERROR: unsupported
architecture: ppc64le" message.

Fixes: #388

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>