### PR TITLE
Kata manager add docker install option

### DIFF
--- a/.ci/kata-doc-to-script.sh
+++ b/.ci/kata-doc-to-script.sh
@@ -35,11 +35,10 @@ verbose="no"
 usage()
 {
 	cat <<EOT
-Usage: ${script_name} [options] <markdown-file> [<script-file>]
+Usage: ${script_name} [options] <markdown-file> [<script-file> [<description>]]
 
 This script will convert a github-flavoured markdown document file into a
 bash(1) script to stdout by extracting the bash code blocks.
-
 
 Options:
 
@@ -54,6 +53,11 @@ ${warning}
 Example usage:
 
   $ ${script_name} foo.md foo.md.sh
+
+Notes:
+
+- If a description is specified, it will be added to the script as a
+  comment.
 
 ${warning}
 
@@ -72,6 +76,8 @@ die()
 
 script_header()
 {
+	local -r description="$1"
+
 	cat <<-EOT
 	#!/bin/bash
 	${license}
@@ -79,6 +85,10 @@ script_header()
 	# WARNING: Script auto-generated from '$file'.
 	#
 	# ${warning}
+	#----------------------------------------------
+
+	#----------------------------------------------
+	# Description: $description
 	#----------------------------------------------
 
 	# fail the entire script if any simple command fails
@@ -93,6 +103,7 @@ doc_to_script()
 {
 	file="$1"
 	outfile="$2"
+	description="$3"
 
 	[ -n "$file" ] || die "need file"
 
@@ -109,7 +120,7 @@ doc_to_script()
 
 	[ "$require_commands" = "yes" ] && [ ! -s "$body" ] && die "no commands found in file '$file'"
 
-	script_header > "$all"
+	script_header "$description" > "$all"
 	cat "$body" >> "$all"
 
 	# sanity check
@@ -141,6 +152,7 @@ main()
 
 	file="$1"
 	outfile="$2"
+	description="$3"
 
 	[ -n "$file" ] || die "need file"
 
@@ -152,7 +164,7 @@ main()
 			die "file '$file' doesn't match pattern '$extension_regex'"
 	fi
 
-	doc_to_script "$file" "$outfile"
+	doc_to_script "$file" "$outfile" "$description"
 }
 
 main "$@"

--- a/cmd/kata-manager/README.md
+++ b/cmd/kata-manager/README.md
@@ -1,0 +1,60 @@
+# kata-manager
+
+* [Overview](#overview)
+    * [For full details](#for-full-details)
+* [Warning](#warning)
+* [How to use it](#how-to-use-it)
+    * [Download](#download)
+    * [Basic use](#basic-use)
+
+## Overview
+
+The [`kata-manager`](kata-manager.sh) is a tool that can be used to perform
+common tasks such as installing the packaged version of [Kata
+Containers](https://github.com/kata-containers), installing a container
+manager and configuring the runtime.
+
+Unlike normal scripts which specify the steps to run, for installation tasks
+`kata-manager` calling the [`kata-doc-to-script`](/.ci/kata-doc-to-script.sh)
+tool which parses well-formed [GitHub Flavored
+Markdown](https://github.github.com/gfm) format documents that contain `bash`
+code blocks and converts them into a script. This allows `kata-manager` for
+example to convert a Kata installation guide into a script and execute it. Not
+only is this useful for users, since the `kata-manager` is run from the CI
+system, the installation guides are assured of being correct.
+
+### For full details
+
+Run:
+
+```
+$ ./kata-manager -h
+```
+
+## Warning
+
+> **Note:** Since in some cases `kata-manager` is consuming documents and
+> converting their contents, there is some risk associated with running the
+> script. We recommend that if you choose to use `kata-manager` that you only
+> do so on non-critical system. Further, you are encouraged to run
+> `kata-manager` using the `-n` option which will generate the scripts, but
+> will not execute them. This allows you to review the scripts before running
+> them.
+
+## How to use it
+
+### Download
+
+```
+$ repo="github.com/kata-containers/tests"
+$ go get -d "$repo"
+$ PATH=$PATH:$GOPATH/src/${repo}/cmd/kata-manager
+```
+
+This will add the `kata-manager.sh` to your `$PATH`.
+
+### Basic use
+
+```
+$ kata-manager.sh install-packages
+```

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -47,13 +47,14 @@ Options:
 
 Commands:
 
-  configure-image  : Configure the runtime to use the specified image.
-  configure-initrd : Configure the runtime to use the specified initial ramdisk.
-  disable-debug    : Turn off all debug options.
-  enable-debug     : Turn on all debug options for all system components.
-  install-packages : Install the packaged version of Kata Containers.
-  remove-packages  : Uninstall the packaged version of Kata Containers.
-  reset-config     : Undo changes to the runtime configuration [1].
+  configure-image       : Configure the runtime to use the specified image.
+  configure-initrd      : Configure the runtime to use the specified initial ramdisk.
+  disable-debug         : Turn off all debug options.
+  enable-debug          : Turn on all debug options for all system components.
+  install-docker-system : Install and configure Docker (implies 'install-packages').
+  install-packages      : Install the packaged version of Kata Containers only.
+  remove-packages       : Uninstall the packaged version of Kata Containers.
+  reset-config          : Undo changes to the runtime configuration [1].
 
 Notes:
 
@@ -273,6 +274,28 @@ cmd_install_packages()
 	exec_document "${doc}"
 }
 
+install_container_manager()
+{
+	local mgr="$1"
+
+	get_docs_repo
+
+	local file="install/${mgr}/${distro}-${mgr}-install.md"
+
+	local doc="${GOPATH}/src/${doc_repo}/${file}"
+	[ ! -e "$doc" ] && die "no ${mgr} install document for distro ${distro}"
+
+	info "installing ${mgr}"
+
+	exec_document "${doc}"
+}
+
+cmd_install_docker_system()
+{
+	cmd_install_packages
+	install_container_manager "docker"
+}
+
 cmd_remove_packages()
 {
 	local packages_regex="^(kata|qemu-lite)-"
@@ -354,6 +377,7 @@ parse_args()
 		configure-initrd) cmd_configure_initrd "$1" ;;
 		disable-debug) cmd_disable_all_debug ;;
 		enable-debug) cmd_enable_full_debug ;;
+		install-docker-system) cmd_install_docker_system ;;
 		install-packages) cmd_install_packages ;;
 		remove-packages) cmd_remove_packages ;;
 		reset-config) cmd_reset_config ;;

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -229,14 +229,14 @@ cmd_install_packages()
 
 	local repo_dir="${GOPATH}/src/${doc_repo}"
 
-	info "installing packages"
-
 	[ ! -d "${repo_dir}" ] && (cd "$(dirname ${repo_dir})" && git clone "$doc_repo_url")
 
 	local file="${distro}-installation-guide.md"
 
 	local doc="${GOPATH}/src/${doc_repo}/install/${file}"
 	[ ! -e "$doc" ] && die "no install document for distro $distro"
+
+	info "installing packages for distro $distro"
 
 	local -r doc_script="kata-doc-to-script.sh"
 

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -216,14 +216,20 @@ cmd_configure_initrd()
 	disable_image
 }
 
+check_golang()
+{
+	command -v go >/dev/null || die "need golang"
+
+	GOPATH=$(go env GOPATH || true)
+
+	[ -z "${GOPATH}" ] && die "need GOPATH" || true
+}
+
 # Install the packaged version of Kata by executing the commands
 # specified in the installation guide document.
 cmd_install_packages()
 {
-	command -v go >/dev/null || die "need golang"
-
-	GOPATH=$(go env GOPATH)
-	[ -z "${GOPATH}" ] && die "need GOPATH"
+	check_golang
 
 	local doc_repo_url="https://${doc_repo}"
 

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -225,8 +225,6 @@ cmd_install_packages()
 	GOPATH=$(go env GOPATH)
 	[ -z "${GOPATH}" ] && die "need GOPATH"
 
-	source /etc/os-release
-
 	local doc_repo_url="https://${doc_repo}"
 
 	local repo_dir="${GOPATH}/src/${doc_repo}"
@@ -235,7 +233,7 @@ cmd_install_packages()
 
 	[ ! -d "${repo_dir}" ] && (cd "$(dirname ${repo_dir})" && git clone "$doc_repo_url")
 
-	local file="${ID}-installation-guide.md"
+	local file="${distro}-installation-guide.md"
 
 	local doc="${GOPATH}/src/${doc_repo}/install/${file}"
 	[ ! -e "$doc" ] && die "no install document for distro $distro"


### PR DESCRIPTION
Added a new `install-docker-system` command to the `kata-manager`
utility now that the container manager installation instructions are
being moved into separate files.

See:

- https://github.com/kata-containers/documentation/pull/145

Also includes some tidyup and refactoring to support this change and a `README` for `kata-manager`.

Fixes #390.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>