### PR TITLE
CI: Ignore graphic files when checking licenses

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -245,6 +245,8 @@ check_license_headers()
 		--exclude="*.md" \
 		--exclude="*.toml" \
 		--exclude="*.yaml" \
+		--exclude="*.png" \
+		--exclude="*.jpg" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
Don't complain if graphic files don't have a licence header.

Fixes #392.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>