### PR TITLE
metrics: Disable auto updates in Ubuntu.

### DIFF
--- a/metrics/storage/blogbench_dockerfile/Dockerfile
+++ b/metrics/storage/blogbench_dockerfile/Dockerfile
@@ -13,6 +13,7 @@ ENV BLOGBENCH_VERSION 1.1
 
 RUN apt-get update && \
 	apt-get install -y build-essential curl && \
+	apt-get remove -y unattended-upgrades && \
 	curl -OkL ${BLOGBENCH_URL}/blogbench-${BLOGBENCH_VERSION}.tar.gz && \
 	tar xzf blogbench-${BLOGBENCH_VERSION}.tar.gz && \
 	cd blogbench-${BLOGBENCH_VERSION} && \


### PR DESCRIPTION
This will disable the auto updates in the ubuntu image.

Fixes #387

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>