### PR TITLE
CI: Add URL check for documents

### DIFF
--- a/cmd/log-parser/README.md
+++ b/cmd/log-parser/README.md
@@ -52,7 +52,7 @@ The primary logfiles the tool reads are:
 - The [proxy](https://github.com/kata-containers/proxy) log.
 
   This log also includes embedded log entries from the
-  [agent](https://github.com/katacontainers/agent). `kata-log-parser`
+  [agent](https://github.com/kata-containers/agent). `kata-log-parser`
   automatically unpacks and displays the entries. During this process, the
   encapsulating proxy log messages are discarded.
 


### PR DESCRIPTION
Added a new CI test that checks for invalid URLs in our documents.

Fixes #397.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>