### PR TITLE
CI: check for segfaults in logs

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -47,6 +47,17 @@ check_log_files()
 				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}" || true
 			fi
 		done
+
+		for pattern in "segfault at [0-9]"
+		do
+			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true)
+
+			if [ -n "$results" ]
+			then
+				errors=1
+				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}" || true
+			fi
+		done
 	done
 
 	[ "$errors" -ne 0 ] && exit 1


### PR DESCRIPTION
Check for segfaults in the log files after the tests have run. This is
particularly important when running with the agent as `init` inside
the image.

Fixes #399.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>