### PR TITLE
Ci improve url checker

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -329,7 +329,7 @@ check_docs()
 
 		cat "$invalid_urls" | while read url
 		do
-			files=$(grep "^${url}" "$url_map"|awk '{print $2}')
+			files=$(grep "^${url}" "$url_map"|awk '{print $2}'|sort -u)
 			echo >&2 -e "ERROR: Invalid URL '$url' found in the following files:\n"
 
 			for file in $files

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -330,7 +330,7 @@ check_docs()
 		cat "$invalid_urls" | while read url
 		do
 			files=$(grep "^${url}" "$url_map"|awk '{print $2}')
-			echo >&2 -e "ERROR: URL '$url' in the following files is invalid:\n"
+			echo >&2 -e "ERROR: Invalid URL '$url' found in the following files:\n"
 
 			for file in $files
 			do


### PR DESCRIPTION
When invalid URLs are found, ensure the list of files that contain such URLs are sorted uniquely to avoid duplication.

Also, improve the error message.

Fixes #407.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
