### PR TITLE
CI: Make URL checker ignore new Jenkins server

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -308,6 +308,10 @@ check_docs()
 		# This prefix requires the client to be logged in to github, so ignore
 		echo "$url"|grep -q 'https://github.com/pulls' && continue
 
+		# This prefix require the client to be logged into Jenkins, so
+		# ignore
+		echo "$url"|grep -q 'http://199.204.45.34' && continue
+
 		# Sigh.
 		echo "$url"|grep -q 'https://example.com' && continue
 


### PR DESCRIPTION
The new Jenkins server requires the client to authenticate so just
ignore those URLs

Fixes #412.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>