### PR TITLE
test: Skip docker integration test for apt-get update

### DIFF
--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -36,6 +36,7 @@ var _ = Describe("package manager update test", func() {
 
 	Context("check apt-get update", func() {
 		It("should not fail", func() {
+			Skip("Issue: https://github.com/kata-containers/tests/issues/420")
 			args = append(args, "--rm", "--name", id, DebianImage, "apt-get", "-y", "update")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())


### PR DESCRIPTION
Currently the CI is showing random failures for this docker integration
test so we need to skip.

Fixes #420

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>