### PR TITLE
CI: Only check URL changed by PRs

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -99,7 +99,9 @@ ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p
 # Run the static analysis tools
 if [ -z "${METRICS_CI}" ]
 then
-	.ci/static-checks.sh
+	master_branch=""
+	[ -z "$pr_number" ] && master_branch="true"
+	.ci/static-checks.sh "$kata_repo" "$master_branch"
 fi
 
 if [ -n "$pr_number" ]

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -17,7 +17,7 @@ die(){
 }
 
 info() {
-	echo "INFO: $*"
+	echo -e "INFO: $*"
 }
 
 function clone_and_build() {

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -284,6 +284,8 @@ check_docs()
 	local invalid_urls=$(mktemp)
 	local doc
 
+	info "Checking document code blocks"
+
 	for doc in $docs
 	do
 		bash "${cidir}/kata-doc-to-script.sh" -csv "$doc"
@@ -291,6 +293,7 @@ check_docs()
 		# Look for URLs in the document
 		urls=$($cmd "$doc")
 
+		# Gather URLs
 		for url in $urls
 		do
 			printf "%s\t%s\n" "${url}" "${doc}" >> "$url_map"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -88,7 +88,7 @@ check_go()
 	# Run golang checks
 	if [ ! "$(command -v $linter)" ]
 	then
-		echo "INFO: Installing ${linter}"
+		info "Installing ${linter}"
 
 		local linter_url="github.com/alecthomas/gometalinter"
 		go get -d "$linter_url"
@@ -100,7 +100,7 @@ check_go()
 		#
 		local linter_version=$(get_version "externals.gometalinter.version")
 
-		echo "INFO: Forcing ${linter} version ${linter_version}"
+		info "Forcing ${linter} version ${linter_version}"
 
 		(cd "$GOPATH/src/$linter_url" && git checkout "$linter_version" && go install)
 		eval "$linter" --install --vendor
@@ -147,7 +147,7 @@ check_go()
 	linter_args+=" --enable=varcheck"
 	linter_args+=" --enable=unconvert"
 
-	echo -e "INFO: $linter args: '$linter_args'"
+	info "$linter args: '$linter_args'"
 
 	# Non-option arguments other than "./..." are
 	# considered to be directories by $linter, not package names.
@@ -169,10 +169,10 @@ check_go()
 		dirs+=" $path"
 	done
 
-	echo -e "INFO: Running $linter checks on the following packages:\n"
+	info "Running $linter checks on the following packages:\n"
 	echo "$go_packages"
 	echo
-	echo -e "INFO: Package paths:\n"
+	info "Package paths:\n"
 	echo "$dirs" | sed 's/^ *//g' | tr ' ' '\n'
 
 	eval "$linter" "${linter_args}" "$dirs"
@@ -202,7 +202,7 @@ check_license_headers()
 	local -r spdx_license="Apache-2.0"
 	local -r pattern="${spdx_tag}: ${spdx_license}"
 
-	echo "INFO: Checking for SPDX license headers"
+	info "Checking for SPDX license headers"
 
 	# List of filters used to restrict the types of file changes.
 	# See git-diff-tree(1) for further info.
@@ -233,7 +233,7 @@ check_license_headers()
 		origin/master HEAD || true)
 
 	# no files were changed
-	[ -z "$files" ] && echo "INFO: No files found" && return
+	[ -z "$files" ] && info "No files found" && return
 
 	local missing=$(egrep \
 		--exclude=".git/*" \
@@ -270,11 +270,11 @@ check_docs()
 
 	if [ ! "$(command -v $cmd)" ]
 	then
-		echo "Install $cmd utility"
+		info "Installing $cmd utility"
 		go get -u "mvdan.cc/xurls/cmd/$cmd"
 	fi
 
-	echo "INFO: Checking documentation"
+	info "Checking documentation"
 
 	local docs=$(find . -name "*.md" |grep -v "vendor/" || true)
 
@@ -300,7 +300,7 @@ check_docs()
 	# Get unique list of URLs
 	urls=$(awk '{print $1}' "$url_map"|sort -u)
 
-	echo "INFO: Checking all document URLs"
+	info "Checking all document URLs"
 
 	for url in $urls
 	do

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -313,10 +313,6 @@ check_docs()
 		# This prefix requires the client to be logged in to github, so ignore
 		echo "$url"|grep -q 'https://github.com/pulls' && continue
 
-		# This prefix require the client to be logged into Jenkins, so
-		# ignore
-		echo "$url"|grep -q 'http://199.204.45.34' && continue
-
 		# Sigh.
 		echo "$url"|grep -q 'https://example.com' && continue
 		

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -10,6 +10,8 @@
 
 set -e
 
+[ -n "$DEBUG" ] && set -x
+
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -15,6 +15,14 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+# Convert a golang package to a full path
+pkg_to_path()
+{
+	local pkg="$1"
+
+	go list -f '{{.Dir}}' "$pkg"
+}
+
 check_commits()
 {
 	# Since this script is called from another repositories directory,
@@ -43,14 +51,6 @@ check_commits()
 EOT
 		exit 1
 	fi
-}
-
-# Convert a golang package to a full path
-pkg_to_path()
-{
-	local pkg="$1"
-
-	go list -f '{{.Dir}}' "$pkg"
 }
 
 check_go()

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ go:
   - stable
 
 before_script:
-  - ".ci/static-checks.sh"
+  - ".ci/static-checks.sh github.com/kata-containers/tests"


### PR DESCRIPTION
Change the URL checker to only check the URLs inside document files modified
by a PR. This is relatively difficult since if a PR adds a new document and
modifies an existing document that references that new document, the URL for
the new document will not be valid. The checker handles this by constructing
the correct URL for this new document which will be valid once the PR lands.
As long as the new-but-not-yet-valid URL referenced by the modified document
matches what the checker things the URL will be, the URL is accepted.

For the master branch, all doc URLs are checked.

This change necessitated modifying how the static check script is called by
the CI.

Includes refactoring commits.

Fixes #409.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>