### PR TITLE
integration/docker: don't use comounted cgroups to check CPU constraints

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	sharesSysPath     = "/sys/fs/cgroup/cpu,cpuacct/cpu.shares"
-	quotaSysPath      = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
-	periodSysPath     = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
+	sharesSysPath     = "/sys/fs/cgroup/cpu/cpu.shares"
+	quotaSysPath      = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	periodSysPath     = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 	cpusetCpusSysPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
 	cpusetMemsSysPath = "/sys/fs/cgroup/cpuset/cpuset.mems"
 )


### PR DESCRIPTION
Use /sys/fs/cgroup/cpu to check CPU constraints inside the container.
Systemd comounts cpu and cpuacct at /sys/fs/cgroup/cpu,cpuacct, but when
agent runs as init process those cgroups are not comounted, tests shouldn't
use comounted cgroups to check constraints.

fixes #425

Signed-off-by: Julio Montes <julio.montes@intel.com>