### PR TITLE
test: Enable user docker integration test.

### DIFF
--- a/integration/docker/user_test.go
+++ b/integration/docker/user_test.go
@@ -45,7 +45,6 @@ var _ = Describe("users and groups", func() {
 
 	DescribeTable("running container",
 		func(user string, additionalGroups []string, fail bool) {
-			Skip("Issue: https://github.com/kata-containers/shim/issues/46")
 			cmd := []string{"--name", id, "--rm"}
 			for _, ag := range additionalGroups {
 				cmd = append(cmd, "--group-add", ag)


### PR DESCRIPTION
As the following issue kata-containers/shim#46 was solved,
we need to enable the user docker integration test.

Fixes #431

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>