### PR TITLE
Add googleapis.com to unchecked URL list.

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -314,6 +314,9 @@ check_docs()
 
 		# Sigh.
 		echo "$url"|grep -q 'https://example.com' && continue
+		
+		# Google APIs typically require an auth token.
+		echo "$url"|grep -q 'https://www.googleapis.com' && continue
 
 		# Check the URL, saving it if invalid
 		( curl -sLf -o /dev/null "$url" ||\


### PR DESCRIPTION
Google Cloud Platform resources are identified by URLs under
https://www.googleapis.com that are only accessible with a valid OAuth2
token. This change suppresses validation of Google APIs URLs to allow GCP
resource references in Kata documentation.

Fixes: #433
Signed-off-by: Jon Olson <jonolson@google.com>