### PR TITLE
tests: Use block device for cri-o tests

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -15,6 +15,16 @@ source /etc/os-release
 crio_repository="github.com/kubernetes-incubator/cri-o"
 crio_repository_path="$GOPATH/src/${crio_repository}"
 
+# devicemapper device and options
+export LVM_DEVICE=${LVM_DEVICE:-/dev/vdb}
+DM_STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.directlvm_device=${LVM_DEVICE}
+	--storage-opt dm.directlvm_device_force=true --storage-opt dm.thinp_percent=95
+	--storage-opt dm.thinp_metapercent=1 --storage-opt dm.thinp_autoextend_threshold=80
+	--storage-opt dm.thinp_autoextend_percent=20"
+
+# overlay storage options
+OVERLAY_STORAGE_OPTIONS="--storage-driver overlay"
+
 # Clone CRI-O repo if it is not already present.
 if [ ! -d "${crio_repository_path}" ]; then
 	go get -d "${crio_repository}" || true
@@ -39,45 +49,35 @@ IFS=''
 
 # Skip CRI-O tests that currently are not working
 pushd "${crio_repository_path}/test/"
-for i in ${skipCRIOTests[@]}
+for i in "${skipCRIOTests[@]}"
 do
 	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/agent/issues/138)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
 done
 
 IFS=$OLD_IFS
 
-# By default run CRI-O tests using devicemapper
+# run CRI-O tests using devicemapper on ubuntu 16.04
 MAJOR=$(echo "$VERSION_ID"|cut -d\. -f1)
-if [ "$ID" == "ubuntu" ]; then
-	export STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.use_deferred_removal=false"
+if [ "$ID" == "ubuntu" ] && [ "$MAJOR" -eq 16 ]; then
+	# Block device attached to the VM where we run the CI
+	# If the block device has a partition, cri-o will not be able to use it.
+	if sudo fdisk -l "$LVM_DEVICE" | grep "${LVM_DEVICE}[1-9]"; then
+		die "detected partitions on block device: ${LVM_DEVICE}. Will not continue"
+	fi
+	export STORAGE_OPTIONS="$DM_STORAGE_OPTIONS"
 fi
 
 # But if on ubuntu 17.10 or newer, test using overlay
 # This will allow us to run tests with at least 2 different
 # storage drivers.
 if [ "$ID" == "ubuntu" ] && [ "$MAJOR" -ge 17 ]; then
-	export STORAGE_OPTIONS="--storage-driver overlay"
+	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
 fi
 
-
-# If we are testing a CRI-O PR in a CI environment,
-# use devicemapper driver using a block device.
-# This is needed since support for loopback devices
-# is being deprecated.
-# More info: https://github.com/kubernetes-incubator/cri-o/pull/1574
-#            https://github.com/containers/storage/pull/80/commits/da1e7e5d28da7d0a1e6ac0d4a9e647bee72282e2
-if [ "$ghprbGhRepository" == "${crio_repository/github.com\/}" ] && [ "$CI" == true ] && [ -z "${KATA_DEV_MODE}" ] ;then
-	# block device attached to the Azure VM where we run the CI
-	# if the block device has a partition, cri-o will not be able to use it.
-	export LVM_DEVICE=${LVM_DEVICE:-/dev/vdb}
-	if sudo fdisk -l "$LVM_DEVICE" | grep "${LVM_DEVICE}[1-9]"; then
-		die "detected partitions on block device: ${LVM_DEVICE}. Will not continue"
-	fi
-	export STORAGE_OPTIONS="--storage-driver devicemapper --storage-opt dm.directlvm_device=${LVM_DEVICE}
-				--storage-opt dm.directlvm_device_force=true --storage-opt dm.thinp_percent=95
-				--storage-opt dm.thinp_metapercent=1 --storage-opt dm.thinp_autoextend_threshold=80
-				--storage-opt dm.thinp_autoextend_percent=20"
+if [ "$ID" == "fedora" ] || [ "$ID" == "centos" ]; then
+	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
 fi
+
 
 ./test_runner.sh ctr.bats
 


### PR DESCRIPTION
Use a block device attached to the VMs for testing
CRI-O with devicemapper, instead of rely on loopback
devices.

Fixes #442.

Depends-on: github.com/kata-containers/runtime#454

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>