### PR TITLE
CI: Move more tests to teardown

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -9,86 +9,6 @@
 
 set -e
 
-check_log_files()
-{
-	make log-parser
-
-	# XXX: Only the CC runtime uses structured logging,
-	# XXX: hence specify by name (rather than using $RUNTIME).
-	for component in \
-		kata-proxy \
-		kata-runtime \
-		kata-shim
-	do
-		file="${component}.log"
-		args="--no-pager -q -o cat -a -t \"${component}\""
-
-		cmd="sudo journalctl ${args} > ${file}"
-		eval "$cmd"
-	done
-
-	logs=$(ls "$(pwd)"/*.log)
-	{ kata-log-parser --debug --check-only --error-if-no-records $logs; ret=$?; } || true
-
-	errors=0
-
-	for log in $logs
-	do
-		# Display *all* errors caused by runtime exceptions and fatal
-		# signals.
-		for pattern in "fatal error" "fatal signal"
-		do
-			# Search for pattern and print all subsequent lines with specified log
-			# level.
-			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true | grep "level=\"*error\"*")
-			if [ -n "$results" ]
-			then
-				errors=1
-				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}" || true
-			fi
-		done
-
-		for pattern in "segfault at [0-9]"
-		do
-			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true)
-
-			if [ -n "$results" ]
-			then
-				errors=1
-				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}" || true
-			fi
-		done
-	done
-
-	[ "$errors" -ne 0 ] && exit 1
-
-	# Always remove logs since:
-	#
-	# - We don't want to waste disk-space.
-	# - The teardown script will save the full logs anyway.
-	# - the log parser tool shows full details of what went wrong.
-	rm -f $logs
-
-	[ $ret -eq 0 ] && true || false
-}
-
-check_collect_script()
-{
-	local cmd="kata-collect-data.sh"
-	local cmdpath=$(command -v "$cmd" || true)
-
-	local msg="Kata data collection script"
-
-	if [ -z "$cmdpath" ]
-	then
-		echo "INFO: $msg not found"
-		return
-	fi
-
-	echo "INFO: Checking $msg"
-	sudo -E PATH="$PATH" chronic $cmd
-}
-
 export RUNTIME="kata-runtime"
 
 echo "INFO: Running checks"
@@ -96,8 +16,3 @@ sudo -E PATH="$PATH" bash -c "make check"
 
 echo "INFO: Running functional and integration tests ($PWD)"
 sudo -E PATH="$PATH" bash -c "make test"
-
-echo "INFO: Checking log files"
-check_log_files
-
-check_collect_script

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -5,103 +5,117 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-log_copy_dest="$1"
+collect_logs()
+{
+	local -r log_copy_dest="$1"
 
-kata_runtime_log_filename="kata-runtime.log"
-kata_runtime_log_path="${log_copy_dest}/${kata_runtime_log_filename}"
-kata_runtime_log_prefix="kata-runtime_"
+	local -r kata_runtime_log_filename="kata-runtime.log"
+	local -r kata_runtime_log_path="${log_copy_dest}/${kata_runtime_log_filename}"
+	local -r kata_runtime_log_prefix="kata-runtime_"
 
-proxy_log_filename="kata-proxy.log"
-proxy_log_path="${log_copy_dest}/${proxy_log_filename}"
-proxy_log_prefix="kata-proxy_"
+	local -r proxy_log_filename="kata-proxy.log"
+	local -r proxy_log_path="${log_copy_dest}/${proxy_log_filename}"
+	local -r proxy_log_prefix="kata-proxy_"
 
-shim_log_filename="kata-shim.log"
-shim_log_path="${log_copy_dest}/${shim_log_filename}"
-shim_log_prefix="kata-shim_"
+	local -r shim_log_filename="kata-shim.log"
+	local -r shim_log_path="${log_copy_dest}/${shim_log_filename}"
+	local -r shim_log_prefix="kata-shim_"
 
-crio_log_filename="crio.log"
-crio_log_path="${log_copy_dest}/${crio_log_filename}"
-crio_log_prefix="crio_"
+	local -r crio_log_filename="crio.log"
+	local -r crio_log_path="${log_copy_dest}/${crio_log_filename}"
+	local -r crio_log_prefix="crio_"
 
-docker_log_filename="docker.log"
-docker_log_path="${log_copy_dest}/${docker_log_filename}"
-docker_log_prefix="docker_"
+	local -r docker_log_filename="docker.log"
+	local -r docker_log_path="${log_copy_dest}/${docker_log_filename}"
+	local -r docker_log_prefix="docker_"
 
-collect_data_filename="kata-collect-data.log"
-collect_data_log_path="${log_copy_dest}/${collect_data_filename}"
-collect_data_log_prefix="kata-collect-data_"
+	local -r collect_data_filename="kata-collect-data.log"
+	local -r collect_data_log_path="${log_copy_dest}/${collect_data_filename}"
+	local -r collect_data_log_prefix="kata-collect-data_"
 
-kubelet_log_filename="kubelet.log"
-kubelet_log_path="${log_copy_dest}/${kubelet_log_filename}"
-kubelet_log_prefix="kubelet_"
+	local -r kubelet_log_filename="kubelet.log"
+	local -r kubelet_log_path="${log_copy_dest}/${kubelet_log_filename}"
+	local -r kubelet_log_prefix="kubelet_"
 
-collect_script="kata-collect-data.sh"
-have_collect_script="no"
-[ -n "$(command -v $collect_script)" ] && have_collect_script="yes"
+	local -r collect_script="kata-collect-data.sh"
 
-# Copy log files if a destination path is provided, otherwise simply
-# display them.
-if [ "${log_copy_dest}" ]; then
-	# Create the log files
-	sudo journalctl --no-pager -t kata-runtime > "${kata_runtime_log_path}"
-	sudo journalctl --no-pager -t kata-proxy > "${proxy_log_path}"
-	sudo journalctl --no-pager -t kata-shim > "${shim_log_path}"
-	sudo journalctl --no-pager -u crio > "${crio_log_path}"
-	sudo journalctl --no-pager -u docker > "${docker_log_path}"
-	sudo journalctl --no-pager -u kubelet > "${kubelet_log_path}"
+	have_collect_script="no"
+	[ -n "$(command -v $collect_script)" ] && have_collect_script="yes"
 
-	[ "${have_collect_script}" = "yes" ] && sudo -E PATH="$PATH" $collect_script > "${collect_data_log_path}"
+	# Copy log files if a destination path is provided, otherwise simply
+	# display them.
+	if [ "${log_copy_dest}" ]; then
+		# Create the log files
+		sudo journalctl --no-pager -t kata-runtime > "${kata_runtime_log_path}"
+		sudo journalctl --no-pager -t kata-proxy > "${proxy_log_path}"
+		sudo journalctl --no-pager -t kata-shim > "${shim_log_path}"
+		sudo journalctl --no-pager -u crio > "${crio_log_path}"
+		sudo journalctl --no-pager -u docker > "${docker_log_path}"
+		sudo journalctl --no-pager -u kubelet > "${kubelet_log_path}"
 
-	# Split them in 5 MiB subfiles to avoid too large files.
-	subfile_size=5242880
-	pushd "${log_copy_dest}"
-	split -b "${subfile_size}" -d "${kata_runtime_log_path}" "${kata_runtime_log_prefix}"
-	split -b "${subfile_size}" -d "${proxy_log_path}" "${proxy_log_prefix}"
-	split -b "${subfile_size}" -d "${shim_log_path}" "${shim_log_prefix}"
-	split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
-	split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
-	split -b "${subfile_size}" -d "${kubelet_log_path}" "${kubelet_log_prefix}"
+		[ "${have_collect_script}" = "yes" ] && sudo -E PATH="$PATH" $collect_script > "${collect_data_log_path}"
 
-	[ "${have_collect_script}" = "yes" ] &&  split -b "${subfile_size}" -d "${collect_data_log_path}" "${collect_data_log_prefix}"
+		# Split them in 5 MiB subfiles to avoid too large files.
+		local -r subfile_size=5242880
 
-	prefixes=""
-	prefixes+=" ${kata_runtime_log_prefix}"
-	prefixes+=" ${proxy_log_prefix}"
-	prefixes+=" ${shim_log_prefix}"
-	prefixes+=" ${crio_log_prefix}"
-	prefixes+=" ${docker_log_prefix}"
-	prefixes+=" ${kubelet_log_prefix}"
+		pushd "${log_copy_dest}"
+		split -b "${subfile_size}" -d "${kata_runtime_log_path}" "${kata_runtime_log_prefix}"
+		split -b "${subfile_size}" -d "${proxy_log_path}" "${proxy_log_prefix}"
+		split -b "${subfile_size}" -d "${shim_log_path}" "${shim_log_prefix}"
+		split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
+		split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
+		split -b "${subfile_size}" -d "${kubelet_log_path}" "${kubelet_log_prefix}"
 
-	 [ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
+		[ "${have_collect_script}" = "yes" ] &&  split -b "${subfile_size}" -d "${collect_data_log_path}" "${collect_data_log_prefix}"
 
-	for prefix in $prefixes
-	do
-		gzip -9 "$prefix"*
-	done
+		local prefixes=""
+		prefixes+=" ${kata_runtime_log_prefix}"
+		prefixes+=" ${proxy_log_prefix}"
+		prefixes+=" ${shim_log_prefix}"
+		prefixes+=" ${crio_log_prefix}"
+		prefixes+=" ${docker_log_prefix}"
+		prefixes+=" ${kubelet_log_prefix}"
 
-	popd
-else
-	echo "Kata Containers Runtime Log:"
-	sudo journalctl --no-pager -t kata-runtime
+		[ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
 
-	echo "Kata Containers Proxy Log:"
-	sudo journalctl --no-pager -t kata-proxy
+		local prefix
 
-	echo "Kata Containers Shim Log:"
-	sudo journalctl --no-pager -t kata-shim
+		for prefix in $prefixes
+		do
+			gzip -9 "$prefix"*
+		done
 
-	echo "CRI-O Log:"
-	sudo journalctl --no-pager -u crio
+		popd
+	else
+		echo "Kata Containers Runtime Log:"
+		sudo journalctl --no-pager -t kata-runtime
 
-	echo "Docker Log:"
-	sudo journalctl --no-pager -u docker
+		echo "Kata Containers Proxy Log:"
+		sudo journalctl --no-pager -t kata-proxy
 
-	echo "Kubelet Log:"
-	sudo journalctl --no-pager -u kubelet
+		echo "Kata Containers Shim Log:"
+		sudo journalctl --no-pager -t kata-shim
 
-	if [ "${have_collect_script}" = "yes" ]
-	then
-		echo "Kata Collect Data script output"
-		sudo -E PATH="$PATH" $collect_script
+		echo "CRI-O Log:"
+		sudo journalctl --no-pager -u crio
+
+		echo "Docker Log:"
+		sudo journalctl --no-pager -u docker
+
+		echo "Kubelet Log:"
+		sudo journalctl --no-pager -u kubelet
+
+		if [ "${have_collect_script}" = "yes" ]
+		then
+			echo "Kata Collect Data script output"
+			sudo -E PATH="$PATH" $collect_script
+		fi
 	fi
-fi
+}
+
+main()
+{
+	collect_logs "$1"
+}
+
+main "@$"


### PR DESCRIPTION
The CI run script contained a couple of tests that need to be in the
teardown script since they:

- are not part of the test run itself.
- need to be run for all repos, not just `tests`.

Also required the teardown script to be reworked to put the existing code into its own function.

Fixes #449.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
