### PR TITLE
k8s: Update cri-o endpoint

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -20,7 +20,7 @@ sudo iptables -P FORWARD ACCEPT
 echo "Start crio service"
 sudo systemctl start crio
 
-sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket=/var/run/crio/crio.sock
+sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket=unix:///var/run/crio/crio.sock
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 sudo -E kubectl get nodes


### PR DESCRIPTION
We now need to use full url format:
"unix:///var/run/crio/crio.sock".

Fixes: #456.

Depends-on: github.com/kata-containers/runtime#454

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>