### PR TITLE
tests: k8s: Increase timeouts for integration tests

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -31,7 +31,7 @@ sudo -E kubectl create --namespace kube-system -f "${SCRIPT_PATH}/data/kube-flan
 # The kube-dns pod usually takes around 30 seconds to get ready
 # This instruction will wait until it is up and running, so we can
 # start creating our containers.
-dns_wait_time=180
+dns_wait_time=300
 sleep_time=5
-cmd="sudo -E kubectl get pods --all-namespaces | grep dns | grep Running"
+cmd="sudo -E kubectl get pods --all-namespaces | grep 'dns.*3/3.*Running'"
 waitForProcess "$dns_wait_time" "$sleep_time" "$cmd"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -22,7 +22,7 @@ setup() {
 }
 
 @test "Verify nginx connectivity between pods" {
-	wait_time=30
+	wait_time=120
 	sleep_time=5
 	cmd="sudo -E kubectl get pods | grep $service_name | grep Running"
 	sudo -E kubectl run "$service_name" --image="$nginx_image" --replicas=2


### PR DESCRIPTION
We need to increase timeouts as the CI environment might be slow to
setup all the pods.

Fixes #456

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>