### PR TITLE
ci: Disabling TODO/FIXME checker

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -524,7 +524,6 @@ main()
 	check_go
 	check_versions
 	check_docs
-	check_files
 }
 
 main "$@"


### PR DESCRIPTION
As currently we are having issues in the CI with several PRs,
the tool should not run in order to have a healthy CI.

Fixes #463

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>