### PR TITLE
cmd/log-parser: Add containerID and sandboxID to standard log entry

### DIFF
--- a/cmd/log-parser/logentry.go
+++ b/cmd/log-parser/logentry.go
@@ -86,6 +86,14 @@ type LogEntry struct {
 	// - early startup agent log entries.
 	Container string
 
+	// Sandbox ID. This is set for most, but not all log records.
+	//
+	// Excluded log records include:
+	//
+	// - runtime log entries where the specified CLI command does not
+	//   operate on a container (or a single container).
+	Sandbox string
+
 	// Used to store additional (non-standard) fields
 	Data MapSS
 }
@@ -144,8 +152,8 @@ func (le LogEntry) Check() error {
 		return fmt.Errorf("missing component name: %+v", le)
 	}
 
-	// Note: le.Container cannot be checked since it is not present in all
-	// entries.
+	// Note: le.Container and le.Sandbox cannot be checked since they are not
+	// present in all entries.
 
 	m := map[string]string{
 		"Level":  le.Level,

--- a/cmd/log-parser/logentry.go
+++ b/cmd/log-parser/logentry.go
@@ -37,7 +37,7 @@ type MapSS map[string]string
 
 // Version of LogEntry contents (in semver.org format).
 // XXX: Update whenever LogEntry changes!
-const logEntryFormatVersion = "0.0.1"
+const logEntryFormatVersion = "0.0.2"
 
 // LogEntry is the main type used by the tool. It encapsulates a number of
 // fields that all system components are expected to set, but also includes
@@ -72,6 +72,19 @@ type LogEntry struct {
 	// System component type and name that generated the log entry
 	Source string
 	Name   string
+
+	// Container ID. This is set for most, but not all log records.
+	//
+	// Excluded log records include:
+	//
+	// - runtime log entries where the specified CLI command does not
+	//   operate on a container (or a single container).
+	//
+	// - proxy log entries which contain kernel boot output from the
+	//   guest.
+	//
+	// - early startup agent log entries.
+	Container string
 
 	// Used to store additional (non-standard) fields
 	Data MapSS
@@ -130,6 +143,9 @@ func (le LogEntry) Check() error {
 	if le.Name == "" {
 		return fmt.Errorf("missing component name: %+v", le)
 	}
+
+	// Note: le.Container cannot be checked since it is not present in all
+	// entries.
 
 	m := map[string]string{
 		"Level":  le.Level,

--- a/cmd/log-parser/parse.go
+++ b/cmd/log-parser/parse.go
@@ -261,11 +261,11 @@ func createLogEntry(filename string, line uint64, pairs kvPairs) (LogEntry, erro
 	}
 
 	if line == 0 {
-		return LogEntry{}, fmt.Errorf("need line number")
+		return LogEntry{}, fmt.Errorf("need line number for file %v", filename)
 	}
 
 	if pairs == nil || len(pairs) == 0 {
-		return LogEntry{}, fmt.Errorf("need key/value pairs")
+		return LogEntry{}, fmt.Errorf("need key/value pairs for line %v:%d", filename, line)
 	}
 
 	l := LogEntry{}
@@ -290,7 +290,7 @@ func createLogEntry(filename string, line uint64, pairs kvPairs) (LogEntry, erro
 				return LogEntry{}, err
 			}
 
-			logger.Warnf("failed to unpack agent log entry: %v", l)
+			logger.Warnf("failed to unpack agent log entry %v: %v", l, err)
 		} else {
 			// the agent log entry totally replaces the proxy log entry
 			// that encapsulated it.

--- a/cmd/log-parser/parse.go
+++ b/cmd/log-parser/parse.go
@@ -264,6 +264,9 @@ func handleLogEntry(l *LogEntry, key, value string) (err error) {
 
 		l.Pid = pid
 
+	case "sandbox":
+		l.Sandbox = value
+
 	case "source":
 		l.Source = value
 


### PR DESCRIPTION
Extract the container ID from the structured logs and add it to the
standard `LogEntry` type. This will allow (most of) the log entries to
be associated with individual containers, which will make debugging and
analysis easier.

Also, enhance some of the errors that are returned to make locating the issue
in the log file easier.

Fixes #453.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>