### PR TITLE
CI: Disable systemd-journald rate limit

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -67,6 +67,11 @@ bash -f "${cidir}/install_kubernetes.sh"
 echo "Install Openshift"
 bash -f "${cidir}/install_openshift.sh"
 
+echo "Disable systemd-journald rate limit"
+sudo crudini --set /etc/systemd/journald.conf Journal RateLimitInterval 0s
+sudo crudini --set /etc/systemd/journald.conf Journal RateLimitBurst 0
+sudo systemctl restart systemd-journald
+
 echo "Drop caches"
 sync
 sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -72,3 +72,6 @@ fi
 
 echo "Install cri-containerd dependencies"
 chronic sudo -E yum install -y libseccomp-devel btrfs-progs-devel libseccomp-static
+
+echo "Install crudini"
+chronic sudo -E yum install -y crudini

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -58,3 +58,6 @@ fi
 
 echo "Install cri-containerd dependencies"
 chronic sudo -E dnf -y install libseccomp-devel btrfs-progs-devel libseccomp-static
+
+echo "Install crudini"
+chronic sudo -E dnf -y install crudini

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -70,3 +70,6 @@ fi
 
 echo -e "Install cri-containerd dependencies"
 sudo -E apt install -y libseccomp-dev libapparmor-dev btrfs-tools  make gcc pkg-config
+
+echo "Install crudini"
+sudo -E apt install -y crudini


### PR DESCRIPTION
Disable the systemd-journald rate limit in the CI systems
to capture full logs from Kata Containers components.
This will help us ensure we can debug failed CI jobs.

Fixes: #466.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>