### PR TITLE
CI: Add options to static-checks script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -523,7 +523,7 @@ main()
 
 			info "Auto-detected repo as $repo"
 		else
-			usage && exit 1
+			echo >&2 "ERROR: need repo" && usage && exit 1
 		fi
 	fi
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -323,10 +323,12 @@ check_docs()
 
 	if [ "$master_branch" = "true" ]
 	then
-		# Check all documents
+		info "Checking all documents in master branch"
+
 		docs=$(find . -name "*.md" | grep -v "vendor/" || true)
 	else
-		# Check changed documents only
+		info "Checking local branch for changed documents only"
+
 		docs_status=$(get_pr_changed_file_details || true)
 		docs_status=$(echo "$docs_status" | grep "\.md$" || true)
 
@@ -442,8 +444,12 @@ check_files()
 
 	if [ "$master_branch" = "true" ]
 	then
+		info "Checking all files in master branch"
+
 		files=$(find . -type f | egrep -v "(.git|vendor)/" || true)
 	else
+		info "Checking local branch for changed files only"
+
 		files=$(get_pr_changed_file_details || true)
 
 		# Strip off status

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -520,6 +520,8 @@ main()
 			# (backwards compatability).
 			repo=$(git config --get remote.origin.url |\
 				sed 's!https://!!g' || true)
+
+			info "Auto-detected repo as $repo"
 		else
 			usage && exit 1
 		fi

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -457,7 +457,6 @@ check_files()
 	for file in $files
 	do
 		local match
-		#match=$(egrep -l "\<FIXME\>|\<TODO\>" "$file" || true)
 
 		# Look for files containing the specified comment tags but
 		# which do not include a github URL.

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -75,9 +75,20 @@ Parameters:
   true      : Specify as "true" if testing the 'master' branch, else assume a
               PR branch (equivalent to "--master").
 
-Example:
+Examples:
 
-$ $script_name github.com/kata-containers/runtime true
+- Run all tests on master branch of runtime repository:
+
+  $ $script_name github.com/kata-containers/runtime true
+
+- Auto-detect repository and run golang tests for current repository:
+
+  $ KATA_DEV_MODE=true $script_name --golang
+
+- Run all tests on the agent repository, forcing the tests to consider all
+  files, not just those changed by a PR branch:
+
+  $ $script_name github.com/kata-containers/agent --master
 
 
 EOT

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -77,6 +77,10 @@ Parameters:
   true      : Specify as "true" if testing the 'master' branch, else assume a
               PR branch (equivalent to "--master").
 
+Notes:
+
+- If no options are specified, all non-skipped tests will be run.
+
 Examples:
 
 - Run all tests on master branch of runtime repository:

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -440,6 +440,9 @@ check_files()
 	local file
 	local files
 
+	info "Skipping check_files: see https://github.com/kata-containers/tests/issues/469"
+	return
+
 	info "Checking files"
 
 	if [ "$master_branch" = "true" ]
@@ -524,11 +527,13 @@ main()
 
 	master_branch="$2"
 
+	# Run all checks
 	check_commits
 	check_license_headers
 	check_go
 	check_versions
 	check_docs
+	check_files
 }
 
 main "$@"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -19,6 +19,7 @@ script_name=${0##*/}
 
 repo=""
 master_branch="false"
+force="false"
 
 typeset -A long_options
 
@@ -26,6 +27,7 @@ long_options=(
 	[commits]="Check commits"
 	[docs]="Check document files"
 	[files]="Check files"
+	[force]="Force a skipped test to run"
 	[golang]="Check '.go' files"
 	[help]="Display usage statement"
 	[licenses]="Check licenses"
@@ -492,8 +494,13 @@ check_files()
 	local file
 	local files
 
-	info "Skipping check_files: see https://github.com/kata-containers/tests/issues/469"
-	return
+	if [ "$force" = "false" ]
+	then
+		info "Skipping check_files: see https://github.com/kata-containers/tests/issues/469"
+		return
+	else
+		info "Force override of check_files skip"
+	fi
 
 	info "Checking files"
 
@@ -580,6 +587,7 @@ main()
 			--commits) func=check_commits ;;
 			--docs) func=check_docs ;;
 			--files) func=check_files ;;
+			--force) force="true" ;;
 			--golang) func=check_go ;;
 			-h|--help) usage; exit 0 ;;
 			--licenses) func=check_license_headers ;;


### PR DESCRIPTION
Add command-line options to all individual test functions in the `static-checks.sh` script to be run, rather than all of the tests.

Also includes commits for improved messages, and an explicit "skip" for the `TODO`/`FIXME` checker that was disabled on #464.

Fixes #470.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>