### PR TITLE
ci: refine install-kata-image for aarch64

### DIFF
--- a/.ci/lib_kata_image_aarch64.sh
+++ b/.ci/lib_kata_image_aarch64.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+IMAGE_TYPE="assets.image.meta.image-type-aarch64"
+
+#packaged kata agent haven't been supported in any mainstream distribution
+get_packaged_agent_version() {
+	version=""
+	echo "$version"
+}
+
+#packaged kata image haven't been supported in any mainstream distribution
+install_packaged_image() {
+	info "installing packaged kata-image not supported in aarch64"
+}
+


### PR DESCRIPTION
Since packaged kata image haven't been supported for aarch64 in any mainstream distribution, we are left to build from scratch.

Fixes: #472

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>