### PR TITLE
metrics: density: serialise docker rm and stops

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -182,7 +182,7 @@ get_docker_memory_usage(){
 
 	for ((i=1; i<= NUM_CONTAINERS; i++)); do
 		containers+=($(random_name))
-		${DOCKER_EXE} run --runtime "$RUNTIME" --name ${containers[-1]} -tid $IMAGE $CMD
+		${DOCKER_EXE} run --rm --runtime "$RUNTIME" --name ${containers[-1]} -tid $IMAGE $CMD
 	done
 
 	if [ "$AUTO_MODE" == "auto" ]; then
@@ -277,7 +277,14 @@ EOF
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
 
-	docker rm -f ${containers[@]}
+	# FIXME - temporary workaround for https://github.com/kata-containers/runtime/issues/406
+	# When that is fixed, we can go back to a hard 'docker rm -f *' with no sleep.
+	# Or, in fact we can leave the '--rm' on the docker run, and just change this
+	# to a 'docker stop *'.
+	for c in ${containers[@]}; do
+		docker stop $c
+		sleep 3
+	done
 }
 
 save_config(){


### PR DESCRIPTION
The parallel `docker rm -f` in the test often runs into
the hang up detailed at:
https://github.com/kata-containers/runtime/issues/406

Until that is resolved, try to work around the hang with
some timeouts and serialisation of the rm's.

Fixes: #475

Signed-off-by: Graham Whaley <graham.whaley@intel.com>