### PR TITLE
CI: jenkins: log kata-env output

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -114,6 +114,11 @@ then
 	git branch -D "$pr_branch"
 fi
 
+# Now we have all the components installed, log that info before we
+# run the tests.
+echo "Logging kata-env information:"
+kata-runtime kata-env
+
 if [ -z "${METRICS_CI}" ]
 then
 	if [ "${kata_repo}" != "${tests_repo}" ]


### PR DESCRIPTION
It can be very helpful to know exactly which components we ran
the tests against. Log the output of `kata-runtime kata-env`,
which gives us all the pertinent information.

Fixes: #477

Signed-off-by: Graham Whaley <graham.whaley@intel.com>