### PR TITLE
CI: do not use latest version of alpine docker image

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -24,7 +24,7 @@ const (
 	Image = "busybox"
 
 	// AlpineImage is the alpine image
-	AlpineImage = "alpine"
+	AlpineImage = "alpine:3.7"
 
 	// PostgresImage is the postgres image
 	PostgresImage = "postgres"

--- a/metrics/density/memory_usage_inside_container.sh
+++ b/metrics/density/memory_usage_inside_container.sh
@@ -15,7 +15,7 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../lib/common.bash"
 
 TEST_NAME="memory footprint inside container"
-IMAGE="alpine"
+IMAGE="alpine:3.7"
 CMD="cat /proc/meminfo"
 TMP_FILE=$(mktemp meminfo.XXXXXXXXXX || true)
 


### PR DESCRIPTION
latest version of alpine image is broken, use 3.7 which
is the last know working version.

Fixes: #481.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>