### PR TITLE
ci: Get kata runtime env only if installed.

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -116,8 +116,12 @@ fi
 
 # Now we have all the components installed, log that info before we
 # run the tests.
-echo "Logging kata-env information:"
-kata-runtime kata-env
+if command -v kata-runtime; then
+	echo "Logging kata-env information:"
+	kata-runtime kata-env
+else
+	echo "WARN: Kata runtime is not installed"
+fi
 
 if [ -z "${METRICS_CI}" ]
 then


### PR DESCRIPTION
Run kata-env only if the runtime is installed.

Fixes: #485

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>