### PR TITLE
ci: refine image-type for arm64

### DIFF
--- a/.ci/lib_kata_image_aarch64.sh
+++ b/.ci/lib_kata_image_aarch64.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-IMAGE_TYPE="assets.image.meta.image-type-aarch64"
+IMAGE_TYPE="assets.image.architecture.aarch64.name"
 
 #packaged kata agent haven't been supported in any mainstream distribution
 get_packaged_agent_version() {


### PR DESCRIPTION
patch #462(https://github.com/kata-containers/runtime/pull/462)has been restructured under upstream review, so refining image-type to follow change.

Fixes: #472

Signed-off-by: Penny Zheng <penny.zheng@arm.com>