### PR TITLE
tests: Add more capabilities for --cap-add and --cap-drop.

### DIFF
--- a/integration/docker/cap_test.go
+++ b/integration/docker/cap_test.go
@@ -75,9 +75,12 @@ var _ = Describe("capabilities", func() {
 		selectCaps("sys_chroot"),
 		selectCaps("sys_nice"),
 		selectCaps("sys_pacct"),
+		selectCaps("sys_ptrace"),
 		selectCaps("sys_rawio"),
 		selectCaps("sys_resource"),
+		selectCaps("sys_module"),
 		selectCaps("sys_time"),
+		selectCaps("sys_tty_config"),
 		selectCaps("syslog"),
 	)
 })


### PR DESCRIPTION
Include more capabilities options for docker integration
test for --cap-add and --cap--drop.

Fixes #493

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>