### PR TITLE
test: Add docker integration memory constraints test.

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -37,6 +37,9 @@ const (
 
 	// CentosImage is the centos image
 	CentosImage = "centos"
+
+	// StressImage is the vish/stress image
+	StressImage = "vish/stress"
 )
 
 func runDockerCommandWithTimeout(timeout time.Duration, command string, args ...string) (string, string, int) {

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -30,6 +30,7 @@ func TestIntegration(t *testing.T) {
 		DebianImage,
 		FedoraImage,
 		CentosImage,
+		StressImage,
 	}
 
 	for _, i := range images {

--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("memory constraints", func() {
+	var (
+		args     []string
+		id       string
+		memSize  string
+		limSize  string
+		stderr   string
+		exitCode int
+	)
+
+	BeforeEach(func() {
+		id = randomDockerName()
+	})
+
+	AfterEach(func() {
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
+	})
+
+	Context("run container exceeding memory constraints", func() {
+		It("should ran out of memory", func() {
+			memSize = "256MB"
+			limSize = "260M"
+			args = []string{"--name", id, "--rm", "-m", memSize, StressImage, "-mem-total", limSize, "-mem-alloc-size", limSize}
+			_, stderr, exitCode = dockerRun(args...)
+			Expect(exitCode).NotTo(Equal(0))
+			Expect(stderr).To(ContainSubstring("fatal error: runtime: out of memory"))
+		})
+	})
+})


### PR DESCRIPTION
This will test the memory constraint of a container.

Fixes #496

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>