### PR TITLE
CI: Build from sources if packages couldnt be installed

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -64,6 +64,9 @@ if [ "$(arch)" == "x86_64" ]; then
 	echo "Install Kata Containers OBS repository"
 	obs_url="http://download.opensuse.org/repositories/home:/katacontainers:/release/CentOS_${VERSION_ID}/home:katacontainers:release.repo"
 	sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
+	repo_file="/etc/yum.repos.d/home\:katacontainers\:release.repo"
+	sudo bash -c "echo timeout=10 >> $repo_file"
+	sudo bash -c "echo retries=2 >> $repo_file"
 fi
 
 echo "Install cri-containerd dependencies"


### PR DESCRIPTION
Sometimes OBS services are down, so we cannot rely on
them all the time. If getting a package from OBS fails,
build and install it from sources instead of failing.

Fixes: #500.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>