### PR TITLE
 ci: add filter scheme for architecture-independent

### DIFF
--- a/.ci/filter_docker_aarch64.sh
+++ b/.ci/filter_docker_aarch64.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+GOPATH_LOCAL="${GOPATH%%:*}"
+kata_dir="${GOPATH_LOCAL}/src/github.com/kata-containers"
+test_dir="${kata_dir}/tests"
+ci_dir="${test_dir}/.ci"
+test_config_file="${ci_dir}/configuration_aarch64.yaml"
+
+describe_skip_flag="docker.Describe"
+context_skip_flag="docker.Context"
+it_skip_flag="docker.It"
+
+# value for '-skip' in ginkgo
+_skip_options=()
+
+filter_and_build()
+{
+	local dependency="$1"
+	local array_docker=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${dependency}")
+	[ "${array_docker}" = "null" ] && return
+	mapfile -t _array_docker <<< "${array_docker}"
+	for entry in "${_array_docker[@]}"
+	do
+		_skip_options+=("${entry#- }|")
+	done
+}
+
+main()
+{
+	# build skip option based on Describe block
+	filter_and_build "${describe_skip_flag}"
+
+	# build skip option based on context block
+	filter_and_build "${context_skip_flag}"
+
+	# build skip option based on it block
+	filter_and_build "${it_skip_flag}"
+
+	skip_options=$(IFS= ; echo "${_skip_options[*]}")
+
+	echo "${skip_options%|}"
+}
+
+main

--- a/.ci/filter_test_aarch64.sh
+++ b/.ci/filter_test_aarch64.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+GOPATH_LOCAL="${GOPATH%%:*}"
+kata_dir="${GOPATH_LOCAL}/src/github.com/kata-containers"
+test_dir="${kata_dir}/tests"
+ci_dir="${test_dir}/.ci"
+test_config_file="${ci_dir}/configuration_aarch64.yaml"
+
+test_filter_flag="test"
+
+_test_union=()
+
+main()
+{
+	local array_test=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${test_filter_flag}")
+	[ "${array_test}" = "null" ] && return
+	mapfile -t _array_test <<< "${array_test}"
+	for entry in "${_array_test[@]}"
+	do
+		_test_union+=("${entry#- }")
+	done
+	test_union=$(IFS=" "; echo "${_test_union[*]}")
+	echo "${test_union}"
+}
+
+main

--- a/.ci/lib_setup_aarch64.sh
+++ b/.ci/lib_setup_aarch64.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+filter_test_script="${cidir}/filter_test_aarch64.sh"
+
+check_test_union()
+{
+	local test_union=$(bash -f ${filter_test_script})
+	flag="$1"
+	# regex match
+	[[ ${test_union} =~ ${flag} ]] && echo "true"
+
+	echo "false"
+}
+
+CRIO=$(check_test_union crio)
+KUBERNETES=$(check_test_union kubernetes)
+OPENSHIFT=$(check_test_union openshift)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ TIMEOUT := 60
 # union for 'make test'
 UNION := functional docker crio docker-compose openshift kubernetes swarm cri-containerd
 
+# skipped test suites for docker integration tests
+SKIP :=
+
 # get arch
 ARCH := $(shell bash -c '.ci/kata-arch.sh -d')
 
@@ -43,7 +46,7 @@ docker: ginkgo
 ifeq ($(RUNTIME),)
 	$(error RUNTIME is not set)
 else
-	./ginkgo -v -focus "${FOCUS}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 endif
 
 crio:
@@ -87,7 +90,7 @@ check: checkcommits log-parser
 	docker-compose \
 	functional \
 	ginkgo \
-	integration \
+	docker \
 	kubernetes \
 	log-parser \
 	openshift \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,22 @@
 #
 
 # The time limit in seconds for each test
-TIMEOUT ?= 60
+TIMEOUT := 60
+
+# union for 'make test'
+UNION := functional docker crio docker-compose openshift kubernetes swarm cri-containerd
+
+# get arch
+ARCH := $(shell bash -c '.ci/kata-arch.sh -d')
+
+ARCH_DIR = arch
+ARCH_FILE_SUFFIX = -options.mk
+ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
+
+# Load architecture-dependent settings
+ifneq ($(wildcard $(ARCH_FILE)),)
+include $(ARCH_FILE)
+endif
 
 default: checkcommits
 
@@ -24,7 +39,7 @@ else
 	./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 endif
 
-integration: ginkgo
+docker: ginkgo
 ifeq ($(RUNTIME),)
 	$(error RUNTIME is not set)
 else
@@ -61,7 +76,7 @@ openshift:
 	bash -f .ci/install_bats.sh
 	bash -f integration/openshift/run_openshift_tests.sh
 
-test: functional integration crio docker-compose openshift kubernetes swarm cri-containerd
+test: ${UNION}
 
 check: checkcommits log-parser
 

--- a/arch/aarch64-options.mk
+++ b/arch/aarch64-options.mk
@@ -6,3 +6,5 @@
 # union for 'make test'
 UNION := $(shell bash -f .ci/filter_test_aarch64.sh)
 
+# skiped test suites for docker integration tests
+SKIP := $(shell bash -f .ci/filter_docker_aarch64.sh)

--- a/arch/aarch64-options.mk
+++ b/arch/aarch64-options.mk
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# union for 'make test'
+UNION := $(shell bash -f .ci/filter_test_aarch64.sh)
+


### PR DESCRIPTION
1. Not all test components are supported in all archs, so adding filter scheme to select specific ones for different archs is necessary.
a few test components wouldn't be supported in aarch64 for quite a time(such like: swarm, etc.)
2. For supporting filter scheme in arm64, configuration_aarch64.yaml file should be added to elaborate specific test components in arm64 ci.
for now, this configuration file is just for elaborating whole filter frame.

@jodh-intel @weichen81