### PR TITLE
metrics: CI: enable percentage reporting

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -110,7 +110,7 @@ check() {
 		sudo make install
 		popd
 
-		checkmetrics --basefile /etc/checkmetrics/checkmetrics-json-$(uname -n).toml --metricsdir ${RESULTS_DIR}
+		checkmetrics --percentage --basefile /etc/checkmetrics/checkmetrics-json-$(uname -n).toml --metricsdir ${RESULTS_DIR}
 		cm_result=$?
 		if [ ${cm_result} != 0 ]; then
 			echo "checkmetrics FAILED (${cm_result})"


### PR DESCRIPTION
Enable checkmetrics percentage reporting mode in the
metrics CI run script.

Fixes: #517

Signed-off-by: Graham Whaley <graham.whaley@intel.com>