### PR TITLE
Re-enable cri-containerd and k8s tests

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -32,6 +32,14 @@ if ! command -v docker > /dev/null; then
         "${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
 fi
 
+# If on CI, check that docker version is the one defined
+# in versions.yaml. If there is a different version installed,
+# install the correct version..
+docker_version=$(get_version "externals.docker.version")
+if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
+	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
+fi
+
 if [ "$arch" = x86_64 ]; then
 	if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
 		echo "enable Nested Virtualization"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ openshift:
 	bash -f .ci/install_bats.sh
 	bash -f integration/openshift/run_openshift_tests.sh
 
-test: functional integration crio docker-compose openshift kubernetes swarm
+test: functional integration crio docker-compose openshift kubernetes swarm cri-containerd
 
 check: checkcommits log-parser
 

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -20,7 +20,6 @@ setup() {
 }
 
 @test "Check CPU constraints" {
-	skip "Issue: https://github.com/kata-containers/tests/issues/520"
 	wait_time=30
 	sleep_time=5
 


### PR DESCRIPTION
This PR contains 3 commits:

1. Fixes the container-manger.sh to install the correct docker version on centos. 
2. Adds a check to the setup.sh to install correct docker version if the installed one is different.
3. Re-enable cri-containerd and k8s tests