### PR TITLE
CI: Die if we do not have nested virtualisation

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -44,10 +44,13 @@ fi
 
 case "$arch" in
 	x86_64)
-	if grep -q "N" /sys/module/kvm_intel/parameters/nested; then
+	if [ "$CI" == true ] && grep -q "N" /sys/module/kvm_intel/parameters/nested 2> /dev/null; then
 		echo "enable Nested Virtualization"
 		sudo modprobe -r kvm_intel
 		sudo modprobe kvm_intel nested=1
+		if grep -q "N" /sys/module/kvm_intel/parameters/nested 2> /dev/null; then
+			die "Failed to find or enable Nested virtualization"
+		fi
 	fi
 	;;
 	aarch64)


### PR DESCRIPTION
We grep `/sys/module/kvm_intel/parameters/nested` to check
if we need to load the modules, but if that file does not exist
we get:
  `No such file or directory`
in the logs.

The check failing is currently benign, so ditch the error to
/dev/null

Fixes: #526

Signed-off-by: Graham Whaley <graham.whaley@intel.com>