### PR TITLE
CI: change ports that crio and cri-containerd use

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -95,6 +95,9 @@ crio_config_file="/etc/crio/crio.conf"
 echo "Set runc as default runtime in CRI-O for trusted workloads"
 sudo sed -i 's/^runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
 
+echo "Change stream_port where cri-o will listen"
+sudo sed -i 's/^stream_port.*/stream_port = "10020"/' "$crio_config_file"
+
 echo "Add docker.io registry to pull images"
 # Matches cri-o 1.9 file format
 sudo sed -i 's/^registries = \[/registries = \[ "docker.io"/' "$crio_config_file"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -64,11 +64,13 @@ ci_cleanup() {
 
 create_continerd_config() {
 	local runtime_config=$1
+	local stream_server_port="10030"
 	[ -n "${runtime_config}" ] || die "need runtime to create config"
 
 	cat > "${CONTAINERD_CONFIG_FILE}" << EOT
 [plugins]
   [plugins.cri]
+    stream_server_port = "${stream_server_port}"
     [plugins.cri.containerd]
       [plugins.cri.containerd.default_runtime]
 	runtime_engine = "${runtime_config}"


### PR DESCRIPTION
Now that docker-ce 18.06 was released, docker-containerd listens
by default on the port 10010, same that cri-o and cri-containerd
use. To avoid issues for using the same port, change the ports
of crio and cri-containerd.

Fixes: #520, #521.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>