### PR TITLE
ci: Install kernel with new script.

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -24,8 +24,14 @@ kernel_repo="github.com/${kernel_repo_owner}/${kernel_repo_name}"
 export GOPATH=${GOPATH:-${HOME}/go}
 kernel_repo_dir="${GOPATH}/src/${kernel_repo}"
 kernel_arch="$(arch)"
-tmp_dir="$(mktemp -d)"
+tmp_dir="$(mktemp -d -t install-kata-XXXXXXXXXXX)"
 packaged_kernel="kata-linux-container"
+
+exit_handler () {
+	rm -rf "$tmp_dir"
+}
+
+trap exit_handler EXIT
 
 download_repo() {
 	pushd ${tmp_dir}

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -8,24 +8,28 @@
 # Currently we will use this repository until this issue is solved
 # See https://github.com/kata-containers/packaging/issues/1
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[ -z "${DEBUG:-}" ] || set -x
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source "/etc/os-release"
 
-repo_name="packaging"
-repo_owner="kata-containers"
-kata_kernel_dir="/usr/share/kata-containers"
+kernel_repo_name="packaging"
+kernel_repo_owner="kata-containers"
+kernel_repo="github.com/${kernel_repo_owner}/${kernel_repo_name}"
+export GOPATH=${GOPATH:-${HOME}/go}
+kernel_repo_dir="${GOPATH}/src/${kernel_repo}"
 kernel_arch="$(arch)"
-get_kernel_url="https://cdn.kernel.org/pub/linux/kernel"
 tmp_dir="$(mktemp -d)"
-hypervisor="kvm"
 packaged_kernel="kata-linux-container"
 
 download_repo() {
 	pushd ${tmp_dir}
-	git clone --depth 1 https://github.com/${repo_owner}/${repo_name}
+	go get -d -u "${kernel_repo}" || true
 	popd
 }
 
@@ -35,9 +39,7 @@ get_current_kernel_version() {
 }
 
 get_kata_config_version() {
-	pushd "${tmp_dir}/${repo_name}" >> /dev/null
-	kata_config_version=$(cat kernel/kata_config_version)
-	popd >> /dev/null
+	kata_config_version=$(cat "${kernel_repo_dir}/kernel/kata_config_version")
 	echo "${kata_config_version}"
 }
 
@@ -45,7 +47,10 @@ get_packaged_kernel_version() {
 	if [ "$ID" == "ubuntu" ]; then
 		kernel_version=$(sudo apt-cache madison $packaged_kernel | awk '{print $3}' | cut -d'-' -f1)
 	elif [ "$ID" == "fedora" ]; then
-		kernel_version=$(sudo dnf --showduplicate list ${packaged_kernel}.${kernel_arch} | awk '/'$packaged_kernel'/ {print $2}' | cut -d'-' -f1)
+		kernel_version=$(sudo dnf --showduplicate list ${packaged_kernel}.${kernel_arch} |
+			awk '/'$packaged_kernel'/ {print $2}' |
+			tail -1 |
+			cut -d'-' -f1)
 	elif [ "$ID" == "centos" ]; then
 		kernel_version=$(sudo yum --showduplicate list $packaged_kernel | awk '/'$packaged_kernel'/ {print $2}' | cut -d'-' -f1)
 	fi
@@ -53,44 +58,17 @@ get_packaged_kernel_version() {
 	echo "${kernel_version}"
 }
 
-# download the linux kernel, first argument is the kernel version
-download_kernel() {
-	kernel_version=$1
-	pushd $tmp_dir
-	kernel_tar_file="linux-${kernel_version}.tar.xz"
-	kernel_url="${get_kernel_url}/v$(echo $kernel_version | cut -f1 -d.).x/${kernel_tar_file}"
-	curl -LOk ${kernel_url}
-	tar -xf ${kernel_tar_file}
-	popd
-}
-
-# build the linux kernel, first argument is the kernel version
 build_and_install_kernel() {
-	kernel_version=$1
-	download_kernel ${kernel_version}
-	pushd ${tmp_dir}
-	kernel_config_file=$(realpath ${repo_name}/kernel/configs/[${kernel_arch}]*_kata_${hypervisor}_* | tail -1)
-	kernel_patches=$(realpath ${repo_name}/kernel/patches/*)
-	kernel_src_dir="linux-${kernel_version}"
-	pushd ${kernel_src_dir}
-	cp ${kernel_config_file} .config
-	for p in ${kernel_patches}; do patch -p1 < $p; done
-	make -s ARCH=${kernel_arch} oldconfig > /dev/null
-	if [ $CI == "true" ]; then
-		make ARCH=${kernel_arch} -j$(nproc)
-	else
-		make ARCH=${kernel_arch}
-	fi
-	sudo mkdir -p ${kata_kernel_dir}
-	sudo cp -a "$(realpath arch/${kernel_arch}/boot/bzImage)" "${kata_kernel_dir}/vmlinuz.container"
-	sudo cp -a "$(realpath vmlinux)" "${kata_kernel_dir}/vmlinux.container"
-	popd
-	popd
-
-	cleanup
+	info "Install kernel from sources"
+	pushd "${tmp_dir}" >> /dev/null
+	"${kernel_repo_dir}/kernel/build-kernel.sh" "setup"
+	"${kernel_repo_dir}/kernel/build-kernel.sh" "build"
+	sudo -E PATH="$PATH" "${kernel_repo_dir}/kernel/build-kernel.sh" "install"
+	popd >> /dev/null
 }
 
 install_packaged_kernel(){
+	info "Install packaged kernel version"
 	rc=0
 	if [ "$ID"  == "ubuntu" ]; then
 		chronic sudo apt install -y "$packaged_kernel" || rc=1
@@ -114,15 +92,20 @@ main() {
 	kernel_version="$(get_current_kernel_version)"
 	kata_config_version="$(get_kata_config_version)"
 	current_kernel_version="${kernel_version}.${kata_config_version}"
+	info "Current Kernel version ${current_kernel_version}"
+	info "Get packaged kernel version"
 	packaged_kernel_version=$(get_packaged_kernel_version)
+	info "Packaged Kernel version ${packaged_kernel_version}"
 	if [ "$packaged_kernel_version" == "$current_kernel_version" ] && [ "$kernel_arch" == "x86_64" ]; then
 		# If installing packaged kernel from OBS fails,
 		# then build and install it from sources.
-		install_packaged_kernel || \
-			build_and_install_kernel ${kernel_version}
+		if ! install_packaged_kernel;then
+			info "failed to install packaged kernel, trying to build from source"
+			build_and_install_kernel
+		fi
 
 	else
-		build_and_install_kernel ${kernel_version}
+		build_and_install_kernel
 	fi
 }
 


### PR DESCRIPTION
The Kata packaging now provides an script to build a kernel.

Fixes: #531 

/cc Pennyzct.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>