### PR TITLE
metrics: fix proxy version and add kata-env to JSON results

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -29,7 +29,7 @@ extract_kata_env(){
 	SHIM_VERSION=$(awk '/^\[Shim\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 
 	PROXY_PATH=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	PROXY_VERSION=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+	PROXY_VERSION=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {print $5; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 
 	HYPERVISOR_PATH=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 	HYPERVISOR_VERSION=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -78,6 +78,15 @@ EOF
 EOF
 )"
 	metrics_json_add_fragment "$json"
+
+	if [ "$RUNTIME" == "kata-runtime" ] ; then
+		local json="$(cat << EOF
+		"kata-env" :
+		$(kata-runtime kata-env --json)
+EOF
+)"
+		metrics_json_add_fragment "$json"
+	fi
 }
 
 # Save out the final JSON file


### PR DESCRIPTION
Fix the proxy version extraction for the JSON metrics results data.
Add storage of the complete `kata-env` json output to the JSON metrics results data.