### PR TITLE
metrics: use docker kill rather than docker stop

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -282,7 +282,9 @@ EOF
 	# Or, in fact we can leave the '--rm' on the docker run, and just change this
 	# to a 'docker stop *'.
 	for c in ${containers[@]}; do
-		docker stop $c
+		# Use a kill, as the containers are benign, and most of the time
+		# a stop request ends up being a kill anyway.
+		docker kill $c
 		sleep 3
 	done
 }

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -154,7 +154,9 @@ function cleanup() {
 	# Or, in fact we can leave the '--rm' on the docker run, and just change this
 	# to a 'docker stop *'.
 	for c in $(docker ps -qa); do
-		docker stop $c
+		# Use a kill, as the containers are benign, and most of the time the stop
+		# request ends up doing a kill anyhow
+		docker kill $c
 		sleep 3
 	done
 #	kill_processes_before_start

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -191,7 +191,9 @@ clean_env()
 
 	if [ ! -z "$containers_running" ]; then
 		# First stop all containers that are running
-		sudo $DOCKER_EXE stop $containers_running
+		# Use kill, as the containers are generally benign, and most
+		# of the time our 'stop' request ends up doing a `kill` anyway
+		sudo $DOCKER_EXE kill $containers_running
 
 		# Remove all containers
 		sudo $DOCKER_EXE rm -f $(docker ps -qa)


### PR DESCRIPTION
For many of our 'used' test containers, issuing a `docker stop`
actually results in the stop timing out (as it cannot signal the
container to stop for any one of a number of potential reasons),
and then docker reverts to a kill anyhow. The cost of this is a
10s delay per `stop`, whilst docker times out and then issues the
kill. That costs us heavily when we are doing multi-container tests
using say 20 or 100 containers, as each one takes a 10s overhead
on stop/kill/removing it.

Move all the metrics test `stops` to be `kills`.

Fixes: #561

Signed-off-by: Graham Whaley <graham.whaley@intel.com>