### PR TITLE
ci: add configuration file for filter scheme

### DIFF
--- a/.ci/configuration_aarch64.yaml
+++ b/.ci/configuration_aarch64.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# for now, not all integration test suites are fully passed in aarch64.
+# some need to be tested, and some need to be refined.
+# sequence of 'test' holds supported integration tests components.
+test:
+  - functional
+  - docker
+
+# for now, not all test suites under docker integration are fully passed in aarch64.
+# some need to be tested, and some need to be refined.
+# ginkgo offers '-skip=REGEXP' flag to skip specific ones.
+# you can use infos from docker.Describe, docker.Context or docker.It to point to
+# specific test specs or whole container of specs.
+docker:
+  Describe:
+    - CPUs and CPU set
+    - Update number of CPUs
+    - Hot plug CPUs
+    - Update CPU constraints
+  Context:
+    - remove bind-mount source before container exits
+    - run container exceeding memory constraints
+  It:


### PR DESCRIPTION
For supporting filter scheme in arm64, configuration_aarch64.yaml file should be added to elaborate supported integration test components and which test suites under docker integrtion need to be skipped for now.

Fixes: #472

Signed-off-by: Penny Zheng <penny.zheng@arm.com>