### PR TITLE
manage_ctr_mgr: Fix get docker version

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -195,7 +195,7 @@ get_docker_default_runtime(){
 }
 
 get_docker_version(){
-	sudo docker version | awk '/Server/{getline; print $2 }'
+	sudo docker version | awk '/Engine/{getline; print $2 }'
 }
 
 get_docker_package_name(){


### PR DESCRIPTION
Fix how get_docker_version is retrieving the
information from `docker version` command

Fixes: #572.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>