### PR TITLE
CI: compare only MAJOR.MINOR version of docker

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -36,6 +36,8 @@ fi
 # in versions.yaml. If there is a different version installed,
 # install the correct version..
 docker_version=$(get_version "externals.docker.version")
+docker_version=${docker_version/v}
+docker_version=${docker_version/-*}
 if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
 	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
 fi


### PR DESCRIPTION
In our .ci/setup.sh script, we make a comparsion of
the installed docker version. But we only need the major
and minor versions to make the correct comparison. This
change removes unneeded characters from the version
string.

Fixes #574.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>