### PR TITLE
metrics: Add bidirectional iperf network bandwidth

### DIFF
--- a/metrics/network/README.md
+++ b/metrics/network/README.md
@@ -12,7 +12,7 @@ packet per second throughput, and latency.
 
 ## Networking tests
 
-- `network-metrics-iperf3.sh` measures bandwidth, jitter, bidirectional bandwidth,
+- `network-metrics-iperf3.sh` measures bandwidth, jitter,
 and packet-per-second throughput using iperf3 on single threaded connections. The
 bandwidth test shows the speed of the data transfer. The jitter test measures the
 variation in the delay of received packets. The packet-per-second tests show the
@@ -20,6 +20,9 @@ maximum number of (smallest sized) packets allowed through the transports.
 
 - `network-metrics-nuttcp.sh` measures the UDP bandwidth using nuttcp. This tool
 shows the speed of the data transfer for the UDP protocol.
+
+- `network-metrics-iperf.sh` measures bidirectional bandwidth. Bidirectional tests
+are used to test both servers for the maximum amount of throughput.
  
 ## Running the tests
 

--- a/metrics/network/network-metrics-iperf.sh
+++ b/metrics/network/network-metrics-iperf.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This test measures bidirectional bandwidth. This
+# is used when we want to test both directions for the
+# maximum amount of throughput.
+# Bidirectional bandwidth is only supported by iperf,
+# this feature was dropped for iperf3.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/lib/network-common.bash"
+source "${SCRIPT_PATH}/../lib/common.bash"
+
+# Test name
+TEST_NAME="${TEST_NAME:-network iperf bidirectional bandwidth}"
+# Image name
+image="${image:-local-iperf}"
+# Dockerfile
+dockerfile="${SCRIPT_PATH}/iperf_dockerfile/Dockerfile"
+# Measurement time (seconds)
+transmit_timeout="${transmit_timeout:-30}"
+
+save_config(){
+	metrics_json_start_array
+
+	local json="$(cat << EOF
+	{
+		"image": "$image",
+		"iperf version": "2.0.5",
+		"transmit timeout": $transmit_timeout
+	}
+EOF
+)"
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Config"
+}
+
+
+function main() {
+	cmds=("awk")
+	check_cmds "${cmds[@]}"
+	check_dockerfiles_images "$image" "$dockerfile"
+	init_env
+
+	# Start iperf server configuration
+	# Set the TMPDIR to an existing tmpfs mount to avoid a 9p unlink error
+	local init_cmds="export TMPDIR=/dev/shm"
+	local server_command="$init_cmds && iperf -s"
+	local server_address=$(start_server "$image" "$server_command" "$server_extra_args")
+
+	# Verify server IP address
+	if [ -z "$server_address" ];then
+		clean_env
+		die "server: ip address no found"
+	fi
+
+	# Start iperf client
+	local client_command="$init_cmds && iperf -c $server_address -d -T $transmit_timeout"
+
+	metrics_json_init
+	save_config
+
+	result=$(start_client "$image" "$client_command" "$client_extra_args")
+
+	metrics_json_start_array
+
+	local total_bidirectional_client_bandwidth=$(echo $result | tail -1 | awk '{print $(NF-9)}')
+	local total_bidirectional_client_bandwidth_units=$(echo $result | tail -1 | awk '{print $(NF-8)}')
+	local total_bidirectional_server_bandwidth=$(echo $result | tail -1 |  awk '{print $(NF-1)}')
+	local total_bidirectional_server_bandwidth_units=$(echo $result | tail -1 |  awk '{print $(NF)}')
+
+	local json="$(cat << EOF
+	{
+		"client to server": {
+			"Result" : $total_bidirectional_client_bandwidth,
+			"Units"  : "$total_bidirectional_client_bandwidth_units"
+	},
+		"server to client": {
+			"Result" : $total_bidirectional_server_bandwidth,
+			"Units"  : "$total_bidirectional_server_bandwidth_units"
+		}
+	}
+EOF
+)"
+
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Results"
+	metrics_json_save
+	clean_env
+}
+main "$@"


### PR DESCRIPTION
This will measures bidirectional bandwidth using iperf.

Fixes #583

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>