### PR TITLE
metrics: add data gathering and report generation scripts

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -13,52 +13,9 @@ source "${SCRIPT_DIR}/../metrics/lib/common.bash"
 RESULTS_DIR=${SCRIPT_DIR}/../metrics/results
 CHECKMETRICS_DIR=${SCRIPT_DIR}/../cmd/checkmetrics
 
-KSM_BASE="/sys/kernel/mm/ksm"
-KSM_ENABLE_FILE="${KSM_BASE}/run"
-KSM_PAGES_FILE="${KSM_BASE}/pages_to_scan"
-KSM_SLEEP_FILE="${KSM_BASE}/sleep_millisecs"
-
-# The settings we use for an 'aggresive' KSM setup
-# Scan 1000 pages every 50ms - 20,000 pages/s
-KSM_AGGRESIVE_PAGES=1000
-KSM_AGGRESIVE_SLEEP=50
-
-
 # Set up the initial state
 init() {
 	metrics_onetime_init
-}
-
-# Save the current KSM settings so we can restore them later
-save_ksm_settings(){
-	echo "saving KSM settings"
-	ksm_stored_run=$(cat ${KSM_ENABLE_FILE})
-	ksm_stored_pages=$(cat ${KSM_ENABLE_FILE})
-	ksm_stored_sleep=$(cat ${KSM_ENABLE_FILE})
-}
-
-set_ksm_aggressive(){
-	echo "setting KSM to aggressive mode"
-	# Flip the run off/on to ensure a restart/rescan
-	sudo bash -c "echo 0 > ${KSM_ENABLE_FILE}"
-	sudo bash -c "echo ${KSM_AGGRESIVE_PAGES} > ${KSM_PAGES_FILE}"
-	sudo bash -c "echo ${KSM_AGGRESIVE_SLEEP} > ${KSM_SLEEP_FILE}"
-	sudo bash -c "echo 1 > ${KSM_ENABLE_FILE}"
-}
-
-restore_ksm_settings(){
-	echo "restoring KSM settings"
-	# First turn off the run to ensure if we are then re-enabling
-	# that any changes take effect
-	sudo bash -c "echo 0 > ${KSM_ENABLE_FILE}"
-	sudo bash -c "echo ${ksm_stored_pages} > ${KSM_PAGES_FILE}"
-	sudo bash -c "echo ${ksm_stored_sleep} > ${KSM_SLEEP_FILE}"
-	sudo bash -c "echo ${ksm_stored_run} > ${KSM_ENABLE_FILE}"
-}
-
-disable_ksm(){
-	echo "disabling KSM"
-	sudo bash -c "echo 0 > ${KSM_ENABLE_FILE}"
 }
 
 # Execute metrics scripts

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -99,9 +99,10 @@ build_dockerfile_image()
 {
 	local image="$1"
 	local dockerfile_path="$2"
+	local dockerfile_dir=${2%/*}
 
 	echo "docker building $image"
-	if ! docker build --label "$image" --tag "${image}" -< "$dockerfile_path"; then
+	if ! docker build --label "$image" --tag "${image}" -f "$dockerfile_path" "$dockerfile_dir"; then
 		die "Failed to docker build image $image"
 	fi
 }

--- a/metrics/report/README.md
+++ b/metrics/report/README.md
@@ -1,0 +1,48 @@
+* [Kata Containers metrics report generator](#kata-containers-metrics-report-generator)
+   * [Data gathering](#data-gathering)
+   * [Report generation](#report-generation)
+
+# Kata Containers metrics report generator
+
+The files within this directory can be used to generate a 'metrics report'
+for Kata Containers.
+
+The primary workflow consists of two stages:
+
+1) Run the provided report metrics data gathering scripts on the system(s) you wish
+to analyze.
+2) Run the provided report generation script to analyze the data and generate a
+report file.
+
+## Data gathering
+
+Data gathering is provided by the `grabdata.sh` script. When run, this script
+executes a set of tests from the `tests/metrics` directory. The JSON results files
+will be placed into the `tests/metrics/results` directory.
+
+Once the results are generated, create a suitably named subdirectory of
+`tests/metrics/results`, and move the JSON files into it.
+
+Repeat this process if you want to compare multiple sets of results. Note, the
+report generation scripts process all subfolders of `tests/metrics/results` when
+generating the report.
+
+## Report generation
+
+Report generation is provided by the `makereport.sh` script. By default this script 
+processes all subdirectories of the `tests/metrics/results` directory to generate the report.
+To run in the default mode, execute the following:
+
+```sh
+$ ./makereport.sh
+```
+
+The report generation tool uses [Rmarkdown](https://github.com/rstudio/rmarkdown),
+[R](https://www.r-project.org/about.html) and [pandoc](https://pandoc.org/) to produce
+a PDF report. To avoid the need for all users to set up a working environment
+with all the necessary tooling, the `makereport.sh` script utilises a `Dockerfile` with
+the environment pre-defined in order to produce the report. Thus, you need to
+have Docker installed on your system in order to run the report generation.
+
+The resulting `metrics_report.pdf` is generated into the `output` subdir of the `report`
+directory.

--- a/metrics/report/grabdata.sh
+++ b/metrics/report/grabdata.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run a set of the metrics tests to gather data to be used with the report
+# generator. The general ideal is to have the tests configured to generate
+# useful, meaninful and repeatable (stable, with minimised variance) results.
+# If the tests have to be run more or longer to achieve that, then generally
+# that is fine - this test is not intended to be quick, it is intended to
+# be repeatable.
+
+# Note - no 'set -e' in this file - if one of the metrics tests fails
+# then we wish to continue to try the rest.
+# Finally at the end, in some situations, we explicitly exit with a
+# failure code if necessary.
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/../lib/common.bash"
+RESULTS_DIR=${SCRIPT_DIR}/../results
+
+# Set up the initial state
+init() {
+	metrics_onetime_init
+}
+
+# Execute metrics scripts
+run() {
+	pushd "$SCRIPT_DIR/.."
+
+	# If KSM is available on this platform, let's run any tests that are
+	# affected by having KSM on/off first, and then turn it off for the
+	# rest of the tests, as KSM may introduce some extra noise in the
+	# results by stealing CPU time for instance.
+	if [[ -f ${KSM_ENABLE_FILE} ]]; then
+		save_ksm_settings
+		trap restore_ksm_settings EXIT QUIT KILL
+		set_ksm_aggressive
+
+		# Run the memory footprint test - the main test that
+		# KSM affects. Run for 20 containers (that gives us a fair
+		# view of how memory gets shared across containers), and
+		# a default timeout of 300s - if KSM has not settled down
+		# by then, just take the measurement.
+		# 'auto' mode should detect when KSM has settled automatically.
+		bash density/docker_memory_usage.sh 20 300 auto
+
+		# Grab scaling system level footprint data for different sized
+		# container workloads - with KSM enabled.
+
+		# busybox - small container
+		export PAYLOAD_SLEEP="1"
+		export PAYLOAD="busybox"
+		export PAYLOAD_ARGS="tail -f /dev/null"
+		export PAYLOAD_RUNTIME_ARGS=" -m 2G"
+		bash density/footprint_data.sh
+
+		# mysql - medium sized container
+		export PAYLOAD_SLEEP="10"
+		export PAYLOAD="mysql"
+		PAYLOAD_ARGS=" --innodb_use_native_aio=0 --disable-log-bin"
+		PAYLOAD_RUNTIME_ARGS=" -m 4G -e MYSQL_ALLOW_EMPTY_PASSWORD=1"
+		bash density/footprint_data.sh
+
+		# elasticsearch - large container
+		export PAYLOAD_SLEEP="10"
+		export PAYLOAD="elasticsearch"
+		PAYLOAD_ARGS=" "
+		PAYLOAD_RUNTIME_ARGS=" -m 8G"
+		bash density/footprint_data.sh
+
+		# And now ensure KSM is turned off for the rest of the tests
+		disable_ksm
+	fi
+
+	# Run the time tests - take time measures for an ubuntu image, over
+	# 100 'first and only container' launches.
+	# NOTE - whichever container you test here must support a full 'date'
+	# command - busybox based containers (including Alpine) will not work.
+	bash time/launch_times.sh -i ubuntu -n 100
+
+	# Run the density tests - no KSM, so no need to wait for settle
+	# (so set a token 5s wait). Take the measure across 20 containers.
+	bash density/docker_memory_usage.sh 20 5
+
+	popd
+}
+
+finish() {
+	echo "Now please create a suitably descriptively named subdirectory in"
+	echo "$RESULTS_DIR and copy the .json results files into it before running"
+	echo "this script again."
+}
+
+init
+run
+finish
+

--- a/metrics/report/makereport.sh
+++ b/metrics/report/makereport.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Take the data found in subdirectories of the metrics 'results' directory,
+# and turn them into a PDF report. Use a Dockerfile containing all the tooling
+# and scripts we need to do that.
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../lib/common.bash"
+
+IMAGE="${IMAGE:-metrics-report}"
+DOCKERFILE="${SCRIPT_PATH}/report_dockerfile/Dockerfile"
+
+HOSTINPUTDIR="${SCRIPT_PATH}/../results"
+RENVFILE="${HOSTINPUTDIR}/Env.R"
+HOSTOUTPUTDIR="${SCRIPT_PATH}/output"
+
+GUESTINPUTDIR="/inputdir/"
+GUESTOUTPUTDIR="/outputdir/"
+
+setup() {
+	echo "Checking Dockerfile"
+	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
+
+	mkdir -p "$HOSTOUTPUTDIR" && true
+
+	echo "inputdir=\"${GUESTINPUTDIR}\"" > ${RENVFILE}
+	echo "outputdir=\"${GUESTOUTPUTDIR}\"" >> ${RENVFILE}
+
+	# A bit of a hack to get an R syntax'd list of dirs to process
+	# Also, need it as not host-side dir path - so short relative names
+	resultdirs="$(cd ${HOSTINPUTDIR}; ls -dx */)"
+	resultdirslist=$(echo ${resultdirs} | sed 's/ \+/", "/g')
+	echo "resultdirs=c(" >> ${RENVFILE}
+	echo "	\"${resultdirslist}\"" >> ${RENVFILE}
+	echo ")" >> ${RENVFILE}
+}
+
+run() {
+	docker run -ti --rm -v ${HOSTINPUTDIR}:${GUESTINPUTDIR} -v ${HOSTOUTPUTDIR}:${GUESTOUTPUTDIR} ${IMAGE}
+}
+
+setup
+run
+ls -la ${HOSTOUTPUTDIR}/*

--- a/metrics/report/report_dockerfile/Dockerfile
+++ b/metrics/report/report_dockerfile/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Set up an Ubuntu image with the components needed to generate a
+# metrics report. That includes:
+#  - R
+#  - The R 'tidyverse'
+#  - pandoc
+#  - The report generation R files and helper scripts
+
+# I would have liked to have used from base rocker/verse, but that
+# does not have all the tools we need, and it seems that apt install
+# does not simply work - texlive for instance did not install.
+#
+# So, build up our image by hand then...
+FROM ubuntu
+
+# Version of the Dockerfile
+LABEL DOCKERFILE_VERSION="1.0"
+
+# Without this some of the package installs stop to try and ask questions...
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+	apt-get install -y tzdata r-base pandoc texlive
+
+# R packages get built from source, and can take some time, so split them
+# into individual RUNs so we can make some later modifications without maybe taking
+# the full image rebuild hit.
+RUN Rscript -e "install.packages('tidyverse')"
+RUN Rscript -e "install.packages('knitr')"
+RUN Rscript -e "install.packages('gridExtra')"
+RUN Rscript -e "install.packages('ggpubr')"
+
+# Pull in our actual worker scripts
+COPY . /scripts
+
+# By default generate the report
+CMD ["/scripts/genreport.sh"]

--- a/metrics/report/report_dockerfile/dut-details.R
+++ b/metrics/report/report_dockerfile/dut-details.R
@@ -1,0 +1,112 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Display details for the 'Device Under Test', for all data sets being processed.
+
+suppressMessages(suppressWarnings(library(tidyr)))	# for gather().
+library(tibble)
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+resultsfiles=c(
+	"boot-times.json",
+	"footprint-busybox-ksm.json",
+	"footprint-elasticsearch-ksm.json",
+	"footprint-mysql-ksm.json",
+	"memory-footprint.json",
+	"memory-footprint-ksm.json"
+	)
+
+data=c()
+stats=c()
+stats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	count=1
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="/")
+		if ( !file.exists(fname)) {
+			#warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		if (length(fdata$'kata-env') != 0 ) {
+			# We have kata-runtime data
+			dirstats=tibble("Run Ver"=as.character(fdata$'kata-env'$Runtime$Version$Semver))
+			dirstats=cbind(dirstats, "Run SHA"=as.character(fdata$'kata-env'$Runtime$Version$Commit))
+
+			pver=as.character(fdata$'kata-env'$Proxy$Version)
+			pver=sub("^[[:alpha:][:blank:]-]*", "", pver)
+			# uncomment if you want to drop the commit sha as well
+			#pver=sub("([[:digit:].]*).*", "\\1", pver)
+			dirstats=cbind(dirstats, "Proxy Ver"=pver)
+
+			# Trim the shim string
+			sver=as.character(fdata$'kata-env'$Shim$Version)
+			sver=sub("^[[:alpha:][:blank:]-]*", "", sver)
+			# uncomment if you want to drop the commit sha as well
+			#sver=sub("([[:digit:].]*).*", "\\1", sver)
+			dirstats=cbind(dirstats, "Shim Ver"=sver)
+
+			# Default QEMU ver string is far too long and noisy - trim.
+			hver=as.character(fdata$'kata-env'$Hypervisor$Version)
+			hver=sub("^[[:alpha:][:blank:]]*", "", hver)
+			hver=sub("([[:digit:].]*).*", "\\1", hver)
+			dirstats=cbind(dirstats, "Hyper Ver"=hver)
+
+			iver=as.character(fdata$'kata-env'$Image$Path)
+			iver=sub("^[[:alpha:]/-]*", "", iver)
+			dirstats=cbind(dirstats, "Image Ver"=iver)
+
+			kver=as.character(fdata$'kata-env'$Kernel$Path)
+			kver=sub("^[[:alpha:]/-]*", "", kver)
+			dirstats=cbind(dirstats, "Guest Krnl"=kver)
+
+			dirstats=cbind(dirstats, "Host arch"=as.character(fdata$'kata-env'$Host$Architecture))
+			dirstats=cbind(dirstats, "Host Distro"=as.character(fdata$'kata-env'$Host$Distro$Name))
+			dirstats=cbind(dirstats, "Host DistVer"=as.character(fdata$'kata-env'$Host$Distro$Version))
+			dirstats=cbind(dirstats, "Host Model"=as.character(fdata$'kata-env'$Host$CPU$Model))
+			dirstats=cbind(dirstats, "Host Krnl"=as.character(fdata$'kata-env'$Host$Kernel))
+
+			break
+		}
+	}
+
+	if ( length(dirstats) == 0 ) {
+		warning(paste("No valid data found for directory ", currentdir))
+	}
+
+	stats=rbind(stats, dirstats)
+	stats_names=rbind(stats_names, datasetname)
+}
+
+rownames(stats) = stats_names
+
+# Rotate the tibble so we get data dirs as the columns
+spun_stats = as_tibble(cbind(What=names(stats), t(stats)))
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(spun_stats, check.names=FALSE),
+	theme=ttheme(base_size=8),
+	rows=NULL
+	))
+
+# It may seem odd doing a grid of 1x1, but it should ensure we get a uniform format and
+# layout to match the other charts and tables in the report.
+master_plot = grid.arrange(
+	stats_plot,
+	nrow=1,
+	ncol=1 )
+

--- a/metrics/report/report_dockerfile/footprint-density.R
+++ b/metrics/report/report_dockerfile/footprint-density.R
@@ -1,0 +1,99 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Show system memory reduction, and hence container 'density', by analysing the
+# scaling footprint data results and the 'system free' memory.
+
+library(ggplot2)					# ability to plot nicely.
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+resultsfiles=c(
+	paste("footprint-busybox", test_name_extra, ".json", sep=""),
+	paste("footprint-mysql", test_name_extra, ".json", sep=""),
+	paste("footprint-elasticsearch", test_name_extra, ".json", sep="")
+)
+
+data=c()
+stats=c()
+rstats=c()
+rstats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	count=1
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="")
+		if ( !file.exists(fname)) {
+			warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		testname=paste(datasetname, fdata$Config$payload, sep="-")
+
+		cdata=data.frame(avail_mb=as.numeric(fdata$Results$system$avail)/(1024*1024))
+		cdata=cbind(cdata, avail_decr=as.numeric(fdata$Results$system$avail_decr))
+		cdata=cbind(cdata, count=seq_len(length(cdata[, "avail_mb"])))
+		cdata=cbind(cdata, testname=rep(testname, length(cdata[, "avail_mb"]) ))
+
+		# Gather our statistics
+		sdata=data.frame(num_containers=length(cdata[, "avail_mb"]))
+		# Pick out the last avail_decr value - which in theory should be
+		# the most we have consumed...
+		sdata=cbind(sdata, mem_consumed=cdata[, "avail_decr"][length(cdata[, "avail_decr"])])
+		sdata=cbind(sdata, avg_bytes_per_c=sdata$mem_consumed / sdata$num_containers)
+		sdata=cbind(sdata, runtime=testname)
+
+		# Store away as a single set
+		data=rbind(data, cdata)
+		stats=rbind(stats, sdata)
+
+		s = c(
+			"Test"=testname,
+			"n"=sdata$num_containers,
+			"size"=(sdata$mem_consumed) / 1024,
+			"kb/n"=round((sdata$mem_consumed / sdata$num_containers) / 1024, digits=1),
+			"n/Gb"= round((1*1024*1024*1024) / (sdata$mem_consumed / sdata$num_containers), digits=1)
+		)
+
+		rstats=rbind(rstats, s)
+		count = count + 1
+	}
+}
+
+# Set up the text table headers
+colnames(rstats)=c("Test", "n", "Tot_Kb", "avg_Kb", "n_per_Gb")
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+
+# plot how samples varioed over  'time'
+line_plot <- ggplot() +
+	geom_point( data=data, aes(count, avail_mb, color=testname)) +
+	geom_line( data=data, aes(count, avail_mb, color=testname)) +
+	xlab("Containers") +
+	ylab("System Avail (Mb)") +
+	ggtitle("System Memory free") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+master_plot = grid.arrange(
+	line_plot,
+	stats_plot,
+	nrow=2,
+	ncol=1 )
+

--- a/metrics/report/report_dockerfile/genreport.sh
+++ b/metrics/report/report_dockerfile/genreport.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+REPORTNAME="metrics_report.pdf"
+
+cd scripts
+
+Rscript --slave -e "library(knitr);knit('metrics_report.Rmd')"
+Rscript --slave -e "library(knitr);pandoc('metrics_report.md', format='latex')"
+
+cp /scripts/${REPORTNAME} /outputdir
+echo "The report, named ${REPORTNAME}, can be found in the output directory"

--- a/metrics/report/report_dockerfile/lifecycle-time.R
+++ b/metrics/report/report_dockerfile/lifecycle-time.R
@@ -1,0 +1,154 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Display how long the various phases of a container lifecycle (run, execute, die etc.
+# take.
+
+library(ggplot2)					# ability to plot nicely.
+suppressMessages(suppressWarnings(library(tidyr)))	# for gather().
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+resultsfiles=c(
+	"boot-times.json"
+)
+
+data=c()
+stats=c()
+rstats=c()
+rstats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	count=1
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="/")
+		if ( !file.exists(fname)) {
+			warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		cdata=data.frame(workload=as.numeric(fdata$Results$'to-workload'$Result))
+		cdata=cbind(cdata, quit=as.numeric(fdata$Results$'to-quit'$Result))
+
+		cdata=cbind(cdata, tokernel=as.numeric(fdata$Results$'to-kernel'$Result))
+		cdata=cbind(cdata, inkernel=as.numeric(fdata$Results$'in-kernel'$Result))
+		cdata=cbind(cdata, total=as.numeric(fdata$Results$'total'$Result))
+
+		cdata=cbind(cdata, count=seq_len(length(cdata[,"workload"])))
+		cdata=cbind(cdata, runtime=rep(datasetname, length(cdata[, "workload"]) ))
+
+		# Calculate some stats for total time
+		sdata=data.frame(workload_mean=mean(cdata$workload))
+		sdata=cbind(sdata, workload_min=min(cdata$workload))
+		sdata=cbind(sdata, workload_max=max(cdata$workload))
+		sdata=cbind(sdata, workload_sd=sd(cdata$workload))
+		sdata=cbind(sdata, workload_cov=((sdata$workload_sd / sdata$workload_mean) * 100))
+		sdata=cbind(sdata, runtime=datasetname)
+
+		sdata=cbind(sdata, quit_mean = mean(cdata$quit))
+		sdata=cbind(sdata, quit_min = min(cdata$quit))
+		sdata=cbind(sdata, quit_max = max(cdata$quit))
+		sdata=cbind(sdata, quit_sd = sd(cdata$quit))
+		sdata=cbind(sdata, quit_cov = (sdata$quit_sd / sdata$quit_mean) * 100)
+
+		sdata=cbind(sdata, tokernel_mean = mean(cdata$tokernel))
+		sdata=cbind(sdata, inkernel_mean = mean(cdata$inkernel))
+		sdata=cbind(sdata, total_mean = mean(cdata$total))
+
+		# Store away as a single set
+		data=rbind(data, cdata)
+		stats=rbind(stats, sdata)
+
+		# Store away some stats for the text table
+		dirstats[count]=round(sdata$tokernel_mean, digits=2)
+		count = count + 1
+		dirstats[count]=round(sdata$inkernel_mean, digits=2)
+		count = count + 1
+		dirstats[count]=round(sdata$workload_mean, digits=2)
+		count = count + 1
+		dirstats[count]=round(sdata$quit_mean, digits=2)
+		count = count + 1
+		dirstats[count]=round(sdata$total_mean, digits=2)
+		count = count + 1
+	}
+	rstats=rbind(rstats, dirstats)
+	rstats_names=rbind(rstats_names, datasetname)
+}
+
+unts=c("s", "s", "s", "s", "s")
+rstats=rbind(rstats, unts)
+rstats_names=rbind(rstats_names, "Units")
+
+
+# If we have only 2 sets of results, then we can do some more
+# stats math for the text table
+if (length(resultdirs) == 2) {
+	# This is a touch hard wired - but we *know* we only have two
+	# datasets...
+	for( i in 1:5) {
+		val = ((as.double(rstats[1,i]) / as.double(rstats[2,i])) * 100) - 100
+		diff[i] = paste(round(val, digits=2), "%", sep=" ")
+	}
+
+	rstats=rbind(rstats, diff)
+	rstats_names=rbind(rstats_names, "Diff")
+}
+
+rstats=cbind(rstats_names, rstats)
+
+# Set up the text table headers
+colnames(rstats)=c("Results", "2k", "ik", "2w", "2q", "tot")
+
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(rstats, check.names=FALSE),
+	theme=ttheme(base_size=8),
+	rows=NULL
+	))
+
+# plot how samples varioed over  'time'
+line_plot <- ggplot() +
+	geom_line( data=data, aes(count, workload, color=runtime)) +
+	geom_smooth( data=data, aes(count, workload, color=runtime), se=FALSE, method="loess") +
+	xlab("Iteration") +
+	ylab("Time (s)") +
+	ggtitle("Boot to workload", subtitle="First container") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+boot_boxplot <- ggplot() +
+	geom_boxplot( data=data, aes(runtime, workload, color=runtime), show.legend=FALSE) +
+	ylim(0, NA) +
+	ylab("Time (s)")
+
+# convert the stats to a long format so we can more easily do a side-by-side barplot
+longstats <- gather(stats, measure, value, workload_mean, quit_mean, inkernel_mean, tokernel_mean, total_mean)
+
+bar_plot <- ggplot() +
+	geom_bar( data=longstats, aes(measure, value, fill=runtime), stat="identity", position="dodge", show.legend=FALSE) +
+	xlab("Phase") +
+	ylab("Time (s)") +
+	ggtitle("Lifecycle phase times", subtitle="Mean") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+master_plot = grid.arrange(
+	bar_plot,
+	line_plot,
+	stats_plot,
+	boot_boxplot,
+	nrow=2,
+	ncol=2 )
+

--- a/metrics/report/report_dockerfile/memory-footprint.R
+++ b/metrics/report/report_dockerfile/memory-footprint.R
@@ -1,0 +1,119 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Analyse the runtime component memory footprint data.
+
+library(ggplot2)					# ability to plot nicely.
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+resultsfiles=c(
+	"memory-footprint.json",
+	"memory-footprint-ksm.json"
+)
+
+resultsfilesshort=c(
+	"noKSM",
+	"KSM"
+)
+
+data=c()
+rstats=c()
+rstats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	count=1
+	dirstats=c()
+	# For the two different types of memory footprint measures
+	for (resultsfile in resultsfiles) {
+		# R seems not to like double path slashes '//' ?
+		fname=paste(inputdir, currentdir, resultsfile, sep="")
+		if ( !file.exists(fname)) {
+			warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+		datasetvariant=resultsfilesshort[count]
+
+		# Import the data
+		fdata=fromJSON(fname)
+		# Copy the average result into a shorter, more accesible name
+		fdata$Result=fdata$Results$average$Result
+		fdata$variant=rep(datasetvariant, length(fdata$Result) )
+		fdata$Runtime=rep(datasetname, length(fdata$Result) )
+		fdata$Count=seq_len(length(fdata$Result))
+
+		# Calculate some stats
+		fdata.mean = mean(fdata$Result)
+		fdata.min = min(fdata$Result)
+		fdata.max = max(fdata$Result)
+		fdata.sd = sd(fdata$Result)
+		fdata.cov = (fdata.sd / fdata.mean) * 100
+
+		# Store away the bits we need
+		data=rbind(data, data.frame(
+			Result=fdata$Result,
+			Count=fdata$Count,
+			Runtime=fdata$Runtime,
+			variant=fdata$variant ) )
+
+		# Store away some stats for the text table
+		dirstats[count]=round(fdata.mean, digits=2)
+
+		count = count + 1
+	}
+	rstats=rbind(rstats, dirstats)
+	rstats_names=rbind(rstats_names, datasetname)
+}
+
+rstats=cbind(rstats_names, rstats)
+unts=c("Kb", "Kb")
+
+# If we have only 2 sets of results, then we can do some more
+# stats math for the text table
+if (length(resultdirs) == 2) {
+	# This is a touch hard wired - but we *know* we only have two
+	# datasets...
+	diff=c("diff")
+	val = ((as.double(rstats[1,2]) / as.double(rstats[2,2])) * 100) - 100
+	diff[2] = round(val, digits=2)
+	val = ((as.double(rstats[1,3]) / as.double(rstats[2,3])) * 100) - 100
+	diff[3] = round(val, digits=2)
+	rstats=rbind(rstats, diff)
+
+	unts[3]="%"
+}
+
+rstats=cbind(rstats, unts)
+
+# Set up the text table headers
+colnames(rstats)=c("Results", resultsfilesshort, "Units")
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+
+# plot how samples varioed over  'time'
+point_plot <- ggplot() +
+	geom_point( data=data, aes(Runtime, Result, color=variant), position=position_dodge(0.1)) +
+	xlab("Dataset") +
+	ylab("Size (Kb)") +
+	ggtitle("Average PSS footprint", subtitle="per container") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+master_plot = grid.arrange(
+	point_plot,
+	stats_plot,
+	nrow=1,
+	ncol=2 )
+

--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -1,0 +1,77 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+title: "Kata Containers metrics report"
+author: "Auto generated"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+output:
+  pdf_document:
+urlcolor: blue
+---
+
+```{r setup, include=FALSE}
+#Set these opts to get pdf images which fit into beamer slides better
+opts_chunk$set(dev = 'pdf')
+# Pick up any env set by the invoking script, such as the root dir of the
+# results data tree
+source("/inputdir/Env.R")
+```
+\pagebreak
+
+# Introduction
+This report compares the metrics between multiple sets of data generated from
+the [Kata Containers report generation scripts](github.com/kata-containers/tests/metrics/report/README.md).
+
+This report was generated using the data from the **`r resultdirs`** results directories.
+
+\pagebreak
+
+# Container PSS footprint
+This [test](https://github.com/kata-containers/tests/blob/master/metrics/density/docker_memory_usage.sh)
+measures the PSS footprint of all the container runtime components whilst running a number
+of parallel containers. The results are the mean footprint proportion for a single
+container.
+
+```{r, echo=FALSE, fig.cap="Memory PSS footprint"}
+source('memory-footprint.R')
+```
+\pagebreak
+
+# Container scaling system footprint
+This [test](https://github.com/kata-containers/tests/blob/master/metrics/density/footprint_data.sh)
+measures the system memory footprint impact whilst running an increasing number
+of containers. For this test, [KSM](https://en.wikipedia.org/wiki/Kernel_same-page_merging)
+ is enabled. The results show how system memory is consumed for different sized
+containers, and their average system memory footprint cost and density (how many
+containers you can fit per Gb) is calculated.
+
+```{r, echo=FALSE, fig.cap="System Memory density"}
+test_name_extra="-ksm"
+source('footprint-density.R')
+rm(test_name_extra)
+```
+\pagebreak
+
+# Container Docker boot lifecycle times
+This [test](https://github.com/kata-containers/tests/blob/master/metrics/time/launch_times.sh)
+uses the `date` command on the host and in the container, as well as data from the container
+kernel `dmesg`, to ascertain how long different phases of the create/boot/run/delete
+Docker container lifecycle take for the first launched container.
+
+To decode the stats table, the prefixes are 'to(`2`)' and '`i`n'. The suffixes are '`k`ernel', '`w`orkload' and '`q`uit'. 'tot' is the total time for a complete container start-to-finished cycle.
+
+```{r, echo=FALSE, fig.cap="Execution lifecycle times"}
+source('lifecycle-time.R')
+```
+\pagebreak
+
+# Test setup details
+
+This table describes the test system details, as derived from the information contained
+in the test results files.
+
+
+```{r, echo=FALSE, fig.cap="System configuration details"}
+source('dut-details.R')
+```


### PR DESCRIPTION
Add a set of scripts that can be used to gather metrics data and then generate a consumable report for 1-n sets of gathered data.
Can be used to assess a single setup, or to compare multiple setups or sets of gathered data.