### PR TITLE
metrics: json: fix invalid and misleading JSON output

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -19,9 +19,9 @@ extract_kata_env(){
 
 	toml="$(kata-runtime kata-env)"
 
-	# Actually the path to the runtime config - we don't know what runtime docker is
-	# actually using...
-	RUNTIME_PATH=$(awk '/^\[Runtime\]$/ {foundit=1} /^    Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+	# The runtime path itself, for kata-runtime, will be contained in the `kata-env`
+	# section. For other runtimes we do not know where the runtime Docker is using lives.
+	RUNTIME_CONFIG_PATH=$(awk '/^\[Runtime\]$/ {foundit=1} /^    Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 	RUNTIME_VERSION=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Semver =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 	RUNTIME_COMMIT=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Commit =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -45,9 +45,9 @@ EOF
 
 	local json="$(cat << EOF
 	"env" : {
-		"Runtime": "$RUNTIME_PATH",
 		"RuntimeVersion": "$RUNTIME_VERSION",
 		"RuntimeCommit": "$RUNTIME_COMMIT",
+		"RuntimeConfig": "$RUNTIME_CONFIG_PATH",
 		"Hypervisor": "$HYPERVISOR_PATH",
 		"HypervisorVersion": "$HYPERVISOR_VERSION",
 		"Proxy": "$PROXY_PATH",

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -105,6 +105,9 @@ run_workload() {
 
 		# And we can then work out how much time it took to get to the kernel
 		to_kernel_period=$(bc <<<"scale=3; $(ns_to_s $workload_period) - $kernel_period")
+	else
+		kernel_period="0.0"
+		to_kernel_period="0.0"
 	fi
 
 	# And store the results...


### PR DESCRIPTION
Under some conditions we generated invalid JSON for some launch time data.
The runtime 'path' was also the path to the config file, not the runtime itself.
Correct both of those.