### PR TITLE
ci: Use uname program to determine machine architecture

### DIFF
--- a/.ci/kata-arch.sh
+++ b/.ci/kata-arch.sh
@@ -91,7 +91,7 @@ main()
 		shift
 	done
 
-	local -r arch=$(arch)
+	local -r arch=$(uname -m)
 
 	case "$type" in
 		default) echo "$arch";;


### PR DESCRIPTION
The arch program is disabled by default during the coreutils build
process.  To follow the project's recommendation for equivalent
functionality, switching to using the uname program as a more
forward-looking option for determining the architecture of a machine.

This change has been tested on Ubuntu, CentOS, Fedora, and OpenSUSE.
It enables Kata Containers tests to run on Clear Linux.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>