### PR TITLE
CI: Add the shimv2 testing cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 TIMEOUT := 60
 
 # union for 'make test'
-UNION := functional docker crio docker-compose network netmon docker-stability oci openshift kubernetes swarm vm-factory entropy ramdisk
+UNION := functional docker crio docker-compose network netmon docker-stability oci openshift kubernetes swarm vm-factory entropy ramdisk shimv2
 
 # skipped test suites for docker integration tests
 SKIP :=
@@ -74,6 +74,10 @@ swarm:
 	bash -f .ci/install_bats.sh
 	cd integration/swarm && \
 	bats swarm.bats
+
+shimv2:
+	bash integration/containerd/shimv2/shimv2-tests.sh
+	bash integration/containerd/shimv2/shimv2-factory-tests.sh
 
 cri-containerd:
 	bash integration/containerd/cri/integration-tests.sh

--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -1,0 +1,28 @@
+#/bin/bash
+#
+# Copyright (c) 2018 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This test will perform several tests to validate kata containers with
+# factory enabled using shimv2 + containerd + cri 
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
+extract_kata_env
+
+if [ -z $INITRD_PATH ]; then
+	echo "Skipping vm templating test as initrd is not set"
+        exit 0
+fi
+
+echo "========================================"
+echo "   start shimv2 with factory testing"
+echo "========================================"
+
+export SHIMV2_TEST=true
+export FACTORY_TEST=true
+
+${SCRIPT_PATH}/../cri/integration-tests.sh
+

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -1,0 +1,22 @@
+#/bin/bash
+#
+# Copyright (c) 2018 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This test will perform several tests to validate kata containers with
+# shimv2 + containerd + cri
+
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+${SCRIPT_PATH}/../../../.ci/install_cri_containerd.sh
+${SCRIPT_PATH}/../../../.ci/install_cni_plugins.sh
+
+export SHIMV2_TEST=true
+
+echo "========================================"
+echo "         start shimv2 testing"
+echo "========================================"
+
+${SCRIPT_PATH}/../cri/integration-tests.sh
+


### PR DESCRIPTION
Add the containerd-shim-kata-v2 testing cases
based on cri+containerd. 

Fixes: #616

Signed-off-by: Fupan Li <lifupan@gmail.com>