### PR TITLE
CI: use correct branch for testing stable branches

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -60,6 +60,17 @@ pr_number=
 
 if [ -n "$pr_number" ]
 then
+	if [ "${kata_repo}" != "${tests_repo}" ]
+	then
+		# Use the correct branch for testing.
+		# 'tests' repository branch should have the same name
+		# of the kata repository branch where the change is
+		# going to be merged.
+		pushd "${test_repo_dir}"
+		git fetch origin && git checkout "${ghprbTargetBranch}"
+		popd
+	fi
+
 	pr_branch="PR_${pr_number}"
 
 	# Create a separate branch for the PR. This is required to allow
@@ -79,6 +90,17 @@ else
 	# GIT_BRANCH env variable is set by the jenkins Github Plugin.
 	remote="${GIT_BRANCH/\/*/}"
 	branch="${GIT_BRANCH/*\//}"
+
+	if [ "${kata_repo}" != "${tests_repo}" ]
+	then
+		# Use the correct branch for testing.
+		# 'tests' repository branch should have the same name
+		# as the kata repository branch that will be tested.
+		pushd "${test_repo_dir}"
+		git fetch "$remote" && git checkout "$branch"
+		popd
+	fi
+
 	git fetch "$remote" && git checkout "$branch" && git reset --hard "$GIT_BRANCH"
 fi
 


### PR DESCRIPTION
With this patch, we will use the correct branch of the
tests repository to test changes of other repositories,
as we cannot use master branch to test a stable branch from
another repository.

E.g. We must use 'kata-containers/tests' stable-1.1 branch
for testing changes of the 'kata-containers/runtime'
stable-1.1 branch.

Fixes: #625.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>