### PR TITLE
CI: checkout to correct branch on kata-containers repos

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -33,6 +33,10 @@ function clone_and_build() {
 
 	pushd ${project_dir}
 
+	# Override branch if we are testing a PR.
+	[ -z "$pr_number" ] || branch="${target_branch}"
+	git fetch origin && git checkout "${branch}"
+
 	echo "Build ${github_project}"
 	if [ ! -f Makefile ]; then
 		echo "Run autogen.sh to generate Makefile"


### PR DESCRIPTION
When building and installing kata-containers components,
we need to checkout to the specific branch we are testing
instead of doing it with master.

Fixes: #633.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>