### PR TITLE
CI: Don't run log-parser in strict mode

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -175,23 +175,6 @@ check_log_files()
 	cmd="kata-log-parser"
 	args="--debug --check-only --error-if-no-records"
 
-	local -r runtime="kata-runtime"
-	local -r have_runtime=$(command -v "$runtime" || true)
-
-	if [ -n "$have_runtime" ]
-	then
-		local -r image=$($runtime kata-env --json | jq -S '.Image.Path' | tr -d '"')
-
-		if [ -n "$image" ]
-		then
-			info "runtime configured for image so enabling $cmd strict log checking"
-			args+=" --strict"
-		else
-			info "runtime configured for initrd so cannot enable $cmd strict log checking"
-			info "(see https://github.com/kata-containers/agent/issues/255)"
-		fi
-	fi
-
 	{ $cmd $args $logs; ret=$?; } || true
 
 	local errors=0


### PR DESCRIPTION
Undo part of [1] which erroneously enabled the log parsers strict mode:
this cannot be used (still) due to the kernel console output corrupting
the agent log output [2].

Fixes #640.

[1] - https://github.com/kata-containers/tests/pull/543
[2] - https://github.com/kata-containers/agent/issues/255

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>