### PR TITLE
backport fixes 1.2

### DIFF
--- a/.ci/install_openshift.sh
+++ b/.ci/install_openshift.sh
@@ -20,14 +20,6 @@ fi
 openshift_origin_version=$(get_version "externals.openshift.version")
 openshift_origin_commit=$(get_version "externals.openshift.commit")
 
-echo "Install Skopeo"
-skopeo_repo="github.com/projectatomic/skopeo"
-go get -d "$skopeo_repo" || true
-pushd "$GOPATH/src/$skopeo_repo"
-make binary-local
-sudo -E PATH=$PATH make install-binary
-popd
-
 echo "Install Openshift Origin"
 openshift_repo="github.com/openshift/origin"
 openshift_tarball="openshift-origin-server-${openshift_origin_version}-${openshift_origin_commit}-linux-64bit.tar.gz"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -64,7 +64,7 @@ then
 
 	# Create a separate branch for the PR. This is required to allow
 	# checkcommits to be able to determine how the PR differs from
-	# "master".
+	# the target branch.
 	git fetch origin "pull/${pr_number}/head:${pr_branch}"
 	git checkout "${pr_branch}"
 	git rebase "origin/${ghprbTargetBranch}"
@@ -75,8 +75,11 @@ then
 	# This condition should be removed when we have one runtime.
 	[ -f .gitmodules ] && git submodule update
 else
-	# Othewise we test the master branch
-	git fetch origin && git checkout master && git reset --hard origin/master
+	# Othewise we test an specific branch
+	# GIT_BRANCH env variable is set by the jenkins Github Plugin.
+	remote="${GIT_BRANCH/\/*/}"
+	branch="${GIT_BRANCH/*\//}"
+	git fetch "$remote" && git checkout "$branch" && git reset --hard "$GIT_BRANCH"
 fi
 
 # Install go after repository is cloned and checkout to PR
@@ -108,10 +111,10 @@ fi
 
 if [ -n "$pr_number" ]
 then
-	# Now that checkcommits has run, move the PR commits into the master
-	# branch before running the tests. Having the commits in "master" is
-	# required to ensure coveralls works.
-	git checkout master
+	# Now that checkcommits has run, move the PR commits into the target
+	# branch before running the tests. Having the commits in the target branch
+	# is required to ensure coveralls works.
+	git checkout ${ghprbTargetBranch}
 	git reset --hard "$pr_branch"
 	git branch -D "$pr_branch"
 fi

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -60,6 +60,17 @@ pr_number=
 
 if [ -n "$pr_number" ]
 then
+	if [ "${kata_repo}" != "${tests_repo}" ]
+	then
+		# Use the correct branch for testing.
+		# 'tests' repository branch should have the same name
+		# of the kata repository branch where the change is
+		# going to be merged.
+		pushd "${test_repo_dir}"
+		git fetch origin && git checkout "${ghprbTargetBranch}"
+		popd
+	fi
+
 	pr_branch="PR_${pr_number}"
 
 	# Create a separate branch for the PR. This is required to allow
@@ -79,6 +90,17 @@ else
 	# GIT_BRANCH env variable is set by the jenkins Github Plugin.
 	remote="${GIT_BRANCH/\/*/}"
 	branch="${GIT_BRANCH/*\//}"
+
+	if [ "${kata_repo}" != "${tests_repo}" ]
+	then
+		# Use the correct branch for testing.
+		# 'tests' repository branch should have the same name
+		# as the kata repository branch that will be tested.
+		pushd "${test_repo_dir}"
+		git fetch "$remote" && git checkout "$branch"
+		popd
+	fi
+
 	git fetch "$remote" && git checkout "$branch" && git reset --hard "$GIT_BRANCH"
 fi
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -33,6 +33,10 @@ function clone_and_build() {
 
 	pushd ${project_dir}
 
+	# Override branch if we are testing a PR.
+	[ -z "$pr_number" ] || branch="${target_branch}"
+	git fetch origin && git checkout "${branch}"
+
 	echo "Build ${github_project}"
 	if [ ! -f Makefile ]; then
 		echo "Run autogen.sh to generate Makefile"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -634,7 +634,13 @@ main()
 	[ -n "$func" ] && info "running $func function" && eval "$func" && exit 0
 
 	# Run all checks
-	check_commits
+	if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "master" ]
+	then
+		echo "Skipping checkcommits"
+		echo "See issue: https://github.com/kata-containers/tests/issues/632"
+	else
+		check_commits
+	fi
 	check_license_headers
 	check_go
 	check_versions


### PR DESCRIPTION
openshift: remove skopeo tool
CI: adapt jenkins_job_build to support multiple branches
CI: use correct branch for testing stable branches
CI: checkout to correct branch on kata-containers repos
CI: skip checkcommits on travis for stable branch