### PR TITLE
CI: skip checkcommits on travis for stable branch

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -634,7 +634,13 @@ main()
 	[ -n "$func" ] && info "running $func function" && eval "$func" && exit 0
 
 	# Run all checks
-	check_commits
+	if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "master" ]
+	then
+		echo "Skipping checkcommits"
+		echo "See issue: https://github.com/kata-containers/tests/issues/632"
+	else
+		check_commits
+	fi
 	check_license_headers
 	check_go
 	check_versions


### PR DESCRIPTION
checkcommits tool is not working on stable branches, when
runnint on travis. Disable until we find a way to run it.
We still run checkcommits on jenkins, then this can be safely
disabled.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>