### PR TITLE
metrics: add fio storage metrics test

### DIFF
--- a/metrics/report/README.md
+++ b/metrics/report/README.md
@@ -27,6 +27,10 @@ Repeat this process if you want to compare multiple sets of results. Note, the
 report generation scripts process all subfolders of `tests/metrics/results` when
 generating the report.
 
+> **Note:** By default, the `grabdata.sh` script tries to launch some moderately
+> large containers (i.e. 8Gbyte RAM) and may fail to produce some results on a memory
+> constrained system.
+
 ## Report generation
 
 Report generation is provided by the `makereport.sh` script. By default this script 

--- a/metrics/report/grabdata.sh
+++ b/metrics/report/grabdata.sh
@@ -19,9 +19,129 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_DIR}/../lib/common.bash"
 RESULTS_DIR=${SCRIPT_DIR}/../results
 
+# By default we run all the tests
+RUN_ALL=1
+
+help() {
+	usage=$(cat << EOF
+Usage: $0 [-h] [options]
+   Description:
+        This script gathers a number of metrics for use in the
+	report generation script. Which tests are run can be
+	configured on the commandline. Specifically enabling
+	individual tests will disable the 'all' option, unless
+	'all' is also specified last.
+   Options:
+        -a,         Run all tests (default).
+        -d,         Run the density tests.
+        -h,         Print this help.
+        -n,         Run the networking tests.
+        -s,         Run the storage tests.
+        -t,         Run the time tests.
+EOF
+)
+	echo "$usage"
+}
+
 # Set up the initial state
 init() {
 	metrics_onetime_init
+
+	local OPTIND
+	while getopts "adhnst" opt;do
+		case ${opt} in
+		a)	# all
+		    RUN_ALL=1
+		    ;;
+		d)
+		    RUN_DENSITY=1
+		    RUN_ALL=
+		    ;;
+		h)
+		    help
+		    exit 0;
+		    ;;
+		n)
+		    RUN_NETWORK=1
+		    RUN_ALL=
+		    ;;
+		s)
+		    RUN_STORAGE=1
+		    RUN_ALL=
+		    ;;
+		t)
+		    RUN_TIME=1
+		    RUN_ALL=
+		    ;;
+		?)
+		    # parse failure
+		    help
+		    die "Failed to parse arguments"
+		    ;;
+		esac
+	done
+	shift $((OPTIND-1))
+}
+
+run_density_ksm() {
+	echo "Running KSM density tests"
+
+	# Run the memory footprint test - the main test that
+	# KSM affects. Run for 20 containers (that gives us a fair
+	# view of how memory gets shared across containers), and
+	# a default timeout of 300s - if KSM has not settled down
+	# by then, just take the measurement.
+	# 'auto' mode should detect when KSM has settled automatically.
+	bash density/docker_memory_usage.sh 20 300 auto
+
+	# Grab scaling system level footprint data for different sized
+	# container workloads - with KSM enabled.
+
+	# busybox - small container
+	export PAYLOAD_SLEEP="1"
+	export PAYLOAD="busybox"
+	export PAYLOAD_ARGS="tail -f /dev/null"
+	export PAYLOAD_RUNTIME_ARGS=" -m 2G"
+	bash density/footprint_data.sh
+
+	# mysql - medium sized container
+	export PAYLOAD_SLEEP="10"
+	export PAYLOAD="mysql"
+	PAYLOAD_ARGS=" --innodb_use_native_aio=0 --disable-log-bin"
+	PAYLOAD_RUNTIME_ARGS=" -m 4G -e MYSQL_ALLOW_EMPTY_PASSWORD=1"
+	bash density/footprint_data.sh
+
+	# elasticsearch - large container
+	export PAYLOAD_SLEEP="10"
+	export PAYLOAD="elasticsearch"
+	PAYLOAD_ARGS=" "
+	PAYLOAD_RUNTIME_ARGS=" -m 8G"
+	bash density/footprint_data.sh
+}
+
+run_density() {
+	echo "Running non-KSM density tests"
+
+	# Run the density tests - no KSM, so no need to wait for settle
+	# (so set a token 5s wait). Take the measure across 20 containers.
+	bash density/docker_memory_usage.sh 20 5
+}
+
+run_time() {
+	echo "Running time tests"
+	# Run the time tests - take time measures for an ubuntu image, over
+	# 100 'first and only container' launches.
+	# NOTE - whichever container you test here must support a full 'date'
+	# command - busybox based containers (including Alpine) will not work.
+	bash time/launch_times.sh -i ubuntu -n 100
+}
+
+run_storage() {
+	echo "No storage tests to run"
+}
+
+run_network() {
+	echo "No network tests to run"
 }
 
 # Execute metrics scripts
@@ -33,55 +153,36 @@ run() {
 	# rest of the tests, as KSM may introduce some extra noise in the
 	# results by stealing CPU time for instance.
 	if [[ -f ${KSM_ENABLE_FILE} ]]; then
-		save_ksm_settings
-		trap restore_ksm_settings EXIT QUIT KILL
-		set_ksm_aggressive
+		# No point enabling and disabling KSM if we have nothing to test.
+		if [ -n "$RUN_ALL" ] || [ -n "$RUN_DENSITY" ]; then
+			save_ksm_settings
+			trap restore_ksm_settings EXIT QUIT KILL
+			set_ksm_aggressive
 
-		# Run the memory footprint test - the main test that
-		# KSM affects. Run for 20 containers (that gives us a fair
-		# view of how memory gets shared across containers), and
-		# a default timeout of 300s - if KSM has not settled down
-		# by then, just take the measurement.
-		# 'auto' mode should detect when KSM has settled automatically.
-		bash density/docker_memory_usage.sh 20 300 auto
+			run_density_ksm
 
-		# Grab scaling system level footprint data for different sized
-		# container workloads - with KSM enabled.
-
-		# busybox - small container
-		export PAYLOAD_SLEEP="1"
-		export PAYLOAD="busybox"
-		export PAYLOAD_ARGS="tail -f /dev/null"
-		export PAYLOAD_RUNTIME_ARGS=" -m 2G"
-		bash density/footprint_data.sh
-
-		# mysql - medium sized container
-		export PAYLOAD_SLEEP="10"
-		export PAYLOAD="mysql"
-		PAYLOAD_ARGS=" --innodb_use_native_aio=0 --disable-log-bin"
-		PAYLOAD_RUNTIME_ARGS=" -m 4G -e MYSQL_ALLOW_EMPTY_PASSWORD=1"
-		bash density/footprint_data.sh
-
-		# elasticsearch - large container
-		export PAYLOAD_SLEEP="10"
-		export PAYLOAD="elasticsearch"
-		PAYLOAD_ARGS=" "
-		PAYLOAD_RUNTIME_ARGS=" -m 8G"
-		bash density/footprint_data.sh
-
-		# And now ensure KSM is turned off for the rest of the tests
-		disable_ksm
+			# And now ensure KSM is turned off for the rest of the tests
+			disable_ksm
+		fi
+	else
+		echo "No KSM control file, skipping KSM tests"
 	fi
 
-	# Run the time tests - take time measures for an ubuntu image, over
-	# 100 'first and only container' launches.
-	# NOTE - whichever container you test here must support a full 'date'
-	# command - busybox based containers (including Alpine) will not work.
-	bash time/launch_times.sh -i ubuntu -n 100
+	if [ -n "$RUN_ALL" ] || [ -n "$RUN_TIME" ]; then
+		run_time
+	fi
 
-	# Run the density tests - no KSM, so no need to wait for settle
-	# (so set a token 5s wait). Take the measure across 20 containers.
-	bash density/docker_memory_usage.sh 20 5
+	if [ -n "$RUN_ALL" ] || [ -n "$RUN_DENSITY" ]; then
+		run_density
+	fi
+
+	if [ -n "$RUN_ALL" ] || [ -n "$RUN_STORAGE" ]; then
+		run_storage
+	fi
+
+	if [ -n "$RUN_ALL" ] || [ -n "$RUN_NETWORK" ]; then
+		run_network
+	fi
 
 	popd
 }
@@ -92,7 +193,7 @@ finish() {
 	echo "this script again."
 }
 
-init
+init "$@"
 run
 finish
 

--- a/metrics/report/report_dockerfile/fio-reads.R
+++ b/metrics/report/report_dockerfile/fio-reads.R
@@ -1,0 +1,185 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Display details for `fio` random read storage IO tests.
+
+
+library(ggplot2)	# ability to plot nicely
+library(gridExtra)	# So we can plot multiple graphs together
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable
+suppressMessages(library(jsonlite))			# to load the data
+suppressMessages(suppressWarnings(library(tidyr)))	# for gather
+library(tibble)
+
+resultsfiles=c(
+	"fio-randread-128.json",
+	"fio-randread-256.json",
+	"fio-randread-512.json",
+	"fio-randread-1k.json",
+	"fio-randread-2k.json",
+	"fio-randread-4k.json",
+	"fio-randread-8k.json",
+	"fio-randread-16k.json",
+	"fio-randread-32k.json",
+	"fio-randread-64k.json"
+	)
+
+data2=c()
+all_ldata=c()
+all_ldata2=c()
+stats=c()
+rstats=c()
+rstats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="")
+		if ( !file.exists(fname)) {
+			#warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		blocksize=fdata$Raw$'global options'$bs
+
+		# Extract the latency data - it comes as a table of percentiles, so
+		# we have to do a little work...
+		clat=data.frame(clat_ns=fdata$Raw$jobs[[1]]$read$clat_ns$percentile)
+
+		# Generate a clat data set with 'clean' percentile numbers so
+		# we can sensibly plot it later on.
+		clat2=clat
+		colnames(clat2)<-sub("clat_ns.", "", colnames(clat2))
+		colnames(clat2)<-sub("0000", "", colnames(clat2))
+		ldata2=gather(clat2)
+		colnames(ldata2)[colnames(ldata2)=="key"] <- "percentile"
+		colnames(ldata2)[colnames(ldata2)=="value"] <- "ms"
+		ldata2$ms=ldata2$ms/1000000	#ns->ms
+		ldata2=cbind(ldata2, runtime=rep(datasetname, length(ldata2$percentile)))
+		ldata2=cbind(ldata2, blocksize=rep(blocksize, length(ldata2$percentile)))
+
+		# Pull the 95 and 99 percentile numbers for the boxplot
+		# Plotting all values for all runtimes and blocksizes is just way too
+		# noisy to make a meaninful picture, so we use this subset.
+		# Our values fall more in the range of ms...
+		pc95data=tibble(percentile=clat$clat_ns.95.000000/1000000)
+		pc95data=cbind(pc95data, runtime=rep(paste(datasetname, "95pc", sep="-"), length(pc95data$percentile)))
+		pc99data=tibble(percentile=clat$clat_ns.99.000000/1000000)
+		pc99data=cbind(pc99data, runtime=rep(paste(datasetname, "99pc", sep="-"), length(pc95data$percentile)))
+		ldata=rbind(pc95data, pc99data)
+		ldata=cbind(ldata, blocksize=rep(blocksize, length(ldata$percentile)))
+
+		# We want total bandwidth, so that is the sum of the bandwidths
+		# from all the read 'jobs'.
+		mdata=data.frame(read_bw_mps=as.numeric(sum(fdata$Raw$jobs[[1]]$read$bw)/1024))
+		mdata=cbind(mdata, iops_tot=as.numeric(sum(fdata$Raw$jobs[[1]]$read$iops)))
+		mdata=cbind(mdata, runtime=rep(datasetname, length(mdata[, "read_bw_mps"]) ))
+		mdata=cbind(mdata, blocksize=rep(blocksize, length(mdata[, "read_bw_mps"]) ))
+
+		# Collect up as sets across all files and runtimes.
+		data2=rbind(data2, mdata)
+		all_ldata=rbind(all_ldata, ldata)
+		all_ldata2=rbind(all_ldata2, ldata2)
+	}
+}
+
+# Bandwidth line plot
+read_bw_line_plot <- ggplot() +
+	geom_line( data=data2, aes(blocksize, read_bw_mps, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Read total bandwidth") +
+	xlab("Blocksize") +
+	ylab("Bandwidth (MiB/s)") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+# IOPS line plot
+read_iops_line_plot <- ggplot() +
+	geom_line( data=data2, aes(blocksize, iops_tot, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Read total IOPS") +
+	xlab("Blocksize") +
+	ylab("IOPS") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+# 95 and 99 percentile box plot
+read_clat_box_plot <- ggplot() +
+	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Read completion latency", subtitle="95&98 percentiles, boxplot over jobs") +
+	xlab("Blocksize") +
+	ylab("Latency (ms)") +
+	theme(axis.text.x=element_text(angle=90)) +
+	# Use the 'paired' colour matrix as we are setting these up as pairs of
+	# 95 and 99 percentiles, and it is much easier to visually group those to
+	# each runtime if we use this colourmap.
+	scale_colour_brewer(palette="Paired")
+#	it would be nice to use the same legend theme as the other plots on this
+#	page, but because of the number of entries it tends to flow off the picture.
+#	theme(
+#		axis.text.x=element_text(angle=90),
+#		legend.position=c(0.35,0.8),
+#		legend.title=element_text(size=5),
+#		legend.text=element_text(size=5),
+#		legend.background = element_rect(fill=alpha('blue', 0.2))
+#	)
+
+# As the boxplot is actually quite hard to interpret, also show a linegraph
+# of all the percentiles for a single blocksize.
+which_blocksize='4k'
+clat_line_subtitle=paste("For blocksize", which_blocksize, sep=" ")
+single_blocksize=subset(all_ldata2, blocksize==which_blocksize)
+clat_line=aggregate(
+	single_blocksize$ms,
+	by=list(
+		percentile=single_blocksize$percentile,
+		blocksize=single_blocksize$blocksize,
+		runtime=single_blocksize$runtime
+	),
+	FUN=mean
+)
+
+clat_line$percentile=as.numeric(clat_line$percentile)
+
+read_clat_line_plot <- ggplot() +
+	geom_line( data=clat_line, aes(percentile, x, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Read completion latency percentiles", subtitle=clat_line_subtitle) +
+	xlab("Percentile") +
+	ylab("Time (ms)") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+master_plot = grid.arrange(
+	read_bw_line_plot,
+	read_iops_line_plot,
+	read_clat_box_plot,
+	read_clat_line_plot,
+	nrow=2,
+	ncol=2 )
+

--- a/metrics/report/report_dockerfile/fio-writes.R
+++ b/metrics/report/report_dockerfile/fio-writes.R
@@ -1,0 +1,176 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Display details for 'fio' random writes storage IO tests.
+
+
+library(ggplot2)	# ability to plot nicely
+library(gridExtra)	# So we can plot multiple graphs together
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable
+suppressMessages(library(jsonlite))			# to load the data
+suppressMessages(suppressWarnings(library(tidyr)))	# for gather
+library(tibble)
+
+resultsfiles=c(
+	"fio-randwrite-128.json",
+	"fio-randwrite-256.json",
+	"fio-randwrite-512.json",
+	"fio-randwrite-1k.json",
+	"fio-randwrite-2k.json",
+	"fio-randwrite-4k.json",
+	"fio-randwrite-8k.json",
+	"fio-randwrite-16k.json",
+	"fio-randwrite-32k.json",
+	"fio-randwrite-64k.json"
+	)
+
+data2=c()
+all_ldata=c()
+all_ldata2=c()
+stats=c()
+rstats=c()
+rstats_names=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="")
+		if ( !file.exists(fname)) {
+			#warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		blocksize=fdata$Raw$'global options'$bs
+
+		# Extract the latency data - it comes as a table of percentiles, so
+		# we have to do a little work...
+		clat=data.frame(clat_ns=fdata$Raw$jobs[[1]]$write$clat_ns$percentile)
+
+		# Generate a clat data set with 'clean' percentile numbers so
+		# we can sensibly plot it later on.
+		clat2=clat
+		colnames(clat2)<-sub("clat_ns.", "", colnames(clat2))
+		colnames(clat2)<-sub("0000", "", colnames(clat2))
+		ldata2=gather(clat2)
+		colnames(ldata2)[colnames(ldata2)=="key"] <- "percentile"
+		colnames(ldata2)[colnames(ldata2)=="value"] <- "ms"
+		ldata2$ms=ldata2$ms/1000000	#ns->ms
+		ldata2=cbind(ldata2, runtime=rep(datasetname, length(ldata2$percentile)))
+		ldata2=cbind(ldata2, blocksize=rep(blocksize, length(ldata2$percentile)))
+
+		# Pull the 95 and 99 percentiles for the boxplot diagram.
+		# Our values fall more in the range of ms...
+		pc95data=tibble(percentile=clat$clat_ns.95.000000/1000000)
+		pc95data=cbind(pc95data, runtime=rep(paste(datasetname, "95pc", sep="-"), length(pc95data$percentile)))
+		pc99data=tibble(percentile=clat$clat_ns.99.000000/1000000)
+		pc99data=cbind(pc99data, runtime=rep(paste(datasetname, "99pc", sep="-"), length(pc95data$percentile)))
+		ldata=rbind(pc95data, pc99data)
+		ldata=cbind(ldata, blocksize=rep(blocksize, length(ldata$percentile)))
+
+		# We want total bandwidth, so that is the sum of the bandwidths
+		# from all the write 'jobs'.
+		mdata=data.frame(write_bw_mps=as.numeric(sum(fdata$Raw$jobs[[1]]$write$bw)/1024))
+		mdata=cbind(mdata, iops_tot=as.numeric(sum(fdata$Raw$jobs[[1]]$write$iops)))
+		mdata=cbind(mdata, runtime=rep(datasetname, length(mdata[, "write_bw_mps"]) ))
+		mdata=cbind(mdata, blocksize=rep(blocksize, length(mdata[, "write_bw_mps"]) ))
+
+		# Store away as single sets
+		data2=rbind(data2, mdata)
+		all_ldata=rbind(all_ldata, ldata)
+		all_ldata2=rbind(all_ldata2, ldata2)
+	}
+}
+
+# lineplot of total bandwidth across blocksizes.
+write_bw_line_plot <- ggplot() +
+	geom_line( data=data2, aes(blocksize, write_bw_mps, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Write total bandwidth") +
+	xlab("Blocksize") +
+	ylab("Bandwidth (MiB/s)") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+# lineplot of IOPS across blocksizes
+write_iops_line_plot <- ggplot() +
+	geom_line( data=data2, aes(blocksize, iops_tot, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Write total IOPS") +
+	xlab("Blocksize") +
+	ylab("IOPS") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+# boxplot of 95 and 99 percentiles covering the parallel jobs, shown across
+# the blocksizes.
+write_clat_box_plot <- ggplot() +
+	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Write completion latency", subtitle="95&98 Percentiles, boxplot across jobs") +
+	xlab("Blocksize") +
+	ylab("Latency (ms)") +
+	theme(axis.text.x=element_text(angle=90)) +
+	# Use the 'paired' colour matrix as we are setting these up as pairs of
+	# 95 and 99 percentiles, and it is much easier to visually group those to
+	# each runtime if we use this colourmap.
+	scale_colour_brewer(palette="Paired")
+
+
+# completion latency line plot across the percentiles, for a specific blocksize only
+# as otherwise the graph would be far too noisy.
+which_blocksize='4k'
+clat_line_subtitle=paste("For blocksize", which_blocksize, sep=" ")
+single_blocksize=subset(all_ldata2, blocksize==which_blocksize)
+clat_line=aggregate(
+	single_blocksize$ms,
+	by=list(
+		percentile=single_blocksize$percentile,
+		blocksize=single_blocksize$blocksize,
+		runtime=single_blocksize$runtime
+	),
+	FUN=mean
+)
+
+clat_line$percentile=as.numeric(clat_line$percentile)
+
+write_clat_line_plot <- ggplot() +
+	geom_line( data=clat_line, aes(percentile, x, group=runtime, color=runtime)) +
+	ylim(0, NA) +
+	ggtitle("Random Write completion latency percentiles", subtitle=clat_line_subtitle) +
+	xlab("Percentile") +
+	ylab("Time (ms)") +
+	theme(
+		axis.text.x=element_text(angle=90),
+		legend.position=c(0.35,0.8),
+		legend.title=element_text(size=5),
+		legend.text=element_text(size=5),
+		legend.background = element_rect(fill=alpha('blue', 0.2))
+	)
+
+master_plot = grid.arrange(
+	write_bw_line_plot,
+	write_iops_line_plot,
+	write_clat_box_plot,
+	write_clat_line_plot,
+	nrow=2,
+	ncol=2 )
+

--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -66,6 +66,26 @@ source('lifecycle-time.R')
 ```
 \pagebreak
 
+# Storage I/O
+
+Measure storage I/O bandwidth, latency and IOPS using 
+this [test](https://github.com/kata-containers/tests/blob/master/metrics/storage/fio.sh).
+
+This test measures using separate random read and write tests.
+
+## Reads
+
+```{r, echo=FALSE, fig.cap="Storage I/O Reads"}
+source('fio-reads.R')
+```
+
+## Writes
+
+```{r, echo=FALSE, fig.cap="Storage I/O Writes"}
+source('fio-writes.R')
+```
+\pagebreak
+
 # Test setup details
 
 This table describes the test system details, as derived from the information contained

--- a/metrics/storage/README.md
+++ b/metrics/storage/README.md
@@ -1,0 +1,19 @@
+# Kata Containers storage I/O tests
+
+The metrics tests in this directory are designed to be used to assess storage IO.
+
+## `fio` test
+
+The `fio` test utilises the [fio tool](https://github.com/axboe/fio), configured
+to perform measurements upon a single test file.
+
+The test configuration used by the script can be modified by setting a number of
+environment variables to change or over-ride the test defaults.
+Please consult the [source](fio.sh) for more details on the
+which variables are available.
+
+## `blogbench` test
+
+The `blogbench` script is based on the [blogbench program](https://www.pureftpd.org/project/blogbench)
+which is designed to emulate a busy blog server with a number of concurrent threads
+performing a mixture of reads, writes and rewrites.

--- a/metrics/storage/fio.sh
+++ b/metrics/storage/fio.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Description of the test:
+# Use fio to gather storate IO metrics.
+# The fio configuration can be modified via environment variables.
+# This test is only designed to handle a single file and class of job
+# in fio. If you require a more complex fio test then you are probably
+# better off writing that by hand or creating a new metrics test.
+
+set -e
+
+# General env
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../lib/common.bash"
+
+# Items for our local Dockerfile/image creation
+TEST_NAME="fio"
+IMAGE="local-fio"
+DOCKERFILE="${SCRIPT_PATH}/fio_dockerfile/Dockerfile"
+CONTAINER_NAME="fio_test"
+
+# How much RAM and how many (v)CPUs do we give the container under test?
+CONTAINER_RAM=${CONTAINER_RAM:-2G}
+CONTAINER_CPUS=${CONTAINER_CPUS:-1}
+
+# Important paths from the pov of both the host and the guest.
+# Some of them are mapped into both via a docker volume mount.
+HOST_OUTPUT_DIRNAME="${HOST_OUTPUT_DIRNAME:-${SCRIPT_PATH}/fio_output}"
+HOST_INPUT_DIRNAME="${HOST_INPUT_DIRNAME:-${SCRIPT_PATH}/fio_input}"
+# Used on the host side if we do a volume mount test.
+HOST_TEST_DIRNAME="${HOST_TEST_DIRNAME:-/tmp}"
+GUEST_OUTPUT_DIRNAME="/output"
+GUEST_INPUT_DIRNAME="/input"
+
+# This is the dir that fio will actually run the test upon in the container.
+# By default the tests will run on the container 'root mount'. If you set
+# TEST_VOLUME_MOUNT, then we will mount a volume mount over that test directory
+# and the tests will happen on a volume mount.
+TEST_VOLUME_MOUNT=${TEST_VOLUME_MOUNT:-0}
+GUEST_TEST_DIRNAME="/testdir"
+
+# These define which variety of the tests we will run
+#  Which of the read/write/rw tests will we run (we will run all
+#  that are set to 1).
+#
+# By default we do direct random read and write tests (not readwrite)
+FIO_READTEST=${FIO_READTEST:-1}
+FIO_WRITETEST=${FIO_WRITETEST:-1}
+FIO_READWRITETEST=${FIO_READWRITETEST:-0}
+FIO_DIRECT=${FIO_DIRECT:-1}
+FIO_RANDOM=${FIO_RANDOM:-1}
+
+# The blocksizes we will test. We have a separate set for direct or not
+# as direct mode can only use blocksize or larger sizes.
+FIO_BLOCKSIZES="${FIO_BLOCKSIZES:-128 256 512 1k 2k 4k 8k 16k 32k 64k}"
+FIO_DIRECT_BLOCKSIZES="${FIO_DIRECT_BLOCKSIZES:-4k 8k 16k 32k 64k}"
+
+# Other FIO parameters that are tweakable by setting in the environment.
+# Values from here are directly injected into the fio jobfiles used for
+# running the tests.
+FIO_NUMJOBS=${FIO_NUMJOBS:-4}
+#  By default run a time base test
+FIO_TIMEBASED=${FIO_TIMEBASED:-1}
+#  And 60s seems a good balance to get us repeatable numbers in not too long a time.
+FIO_RUNTIME=${FIO_RUNTIME:-60}
+#  By default we have no ramp (warmup) time.
+FIO_RAMPTIME=${FIO_RUNTIME:-0}
+#  Drop the caches in the guest using fio. Note, we need CAP_SYS_ADMIN in the container
+#  for this to work.
+FIO_INVALIDATE=${FIO_INVALIDATE:-1}
+#  Do not use fallocate. Not all the filesystem types we can test (such as 9p) support
+#  this - which can then generate errors in the JSON datastream.
+FIO_FALLOCATE=${FIO_FALLOCATE:-none}
+#  When running 'direct', the file size should not really matter as nothing should be
+#  cached.
+#  If you are running cached (direct=0), then it is likely this whole file will fit in
+#  the buffercache. You can make this filesize larger than the container RAM size to
+#  make a cached test mostly miss the cache - but, depending on the runtime and setup,
+#  you might just end up hitting the host side buffercache. You could of course make the
+#  filesize bigger than the host RAM size... it might take fio some time to create that
+#  testfile though.
+FIO_FILESIZE=${FIO_FILESIZE:-1G}
+FIO_IOENGINE=${FIO_IOENGINE:-libaio}
+FIO_IODEPTH=${FIO_IODEPTH:-16}
+
+# Generate the fio jobfiles into the host directory that will then be shared into
+# the container to run the actual tests.
+#
+# We iterate through the combination of linear/random and read/write/rw and generate
+# all files - even if the test config will not then use them all. it just makes this
+# loop simpler, and the extra file overhead is tiny.
+#
+# Note - the jobfiles *only* contain test-invariant items - that is, anything that
+# changes between each iteration of fio in this test (such as the blocksize and the
+# direct setting) is dynamically set on the fio commandline at runtime.
+generate_jobfiles() {
+	local n
+	local t
+
+	for n in "" rand; do
+		for t in read write rw; do
+			local testtype="${n}$t"
+			local filebase="fio-${testtype}"
+			local filename="${filebase}.job"
+			local destfile="${HOST_INPUT_DIRNAME}/${filename}"
+
+			echo "; Kata metrics auto generated fio job file" > "${destfile}"
+			echo "[global]" >> "${destfile}"
+			echo "directory=$GUEST_TEST_DIRNAME" >> "${destfile}"
+			echo "filename=$filebase" >> "${destfile}"
+			echo "rw=$t" >> "${destfile}"
+			echo "numjobs=$FIO_NUMJOBS" >> "${destfile}"
+			echo "time_based=$FIO_TIMEBASED" >> "${destfile}"
+			echo "runtime=$FIO_RUNTIME" >> "${destfile}"
+			echo "ramp_time=$FIO_RAMPTIME" >> "${destfile}"
+			echo "invalidate=$FIO_INVALIDATE" >> "${destfile}"
+			echo "fallocate=$FIO_FALLOCATE" >> "${destfile}"
+			echo "[file1]" >> "${destfile}"
+			echo "size=$FIO_FILESIZE" >> "${destfile}"
+			echo "ioengine=$FIO_IOENGINE" >> "${destfile}"
+			echo "iodepth=$FIO_IODEPTH" >> "${destfile}"
+		done
+	done
+}
+
+# Initialise the system, including getting the container up and running and
+# disconnected, ready to run the tests via `docker exec`.
+init() {
+	# Check tools/commands dependencies
+	cmds=("docker")
+
+	init_env
+	check_cmds "${cmds[@]}"
+
+	# Ensure our docker image is up to date
+	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
+
+	# Ensure we have the local input and output directories created.
+	mkdir -p ${HOST_OUTPUT_DIRNAME} || true
+	mkdir -p ${HOST_INPUT_DIRNAME} || true
+
+	# We need to set some level of priv enablement to let fio in the
+	# container be able to execute its 'invalidate'.
+	RUNTIME_EXTRA_ARGS="--cap-add=SYS_ADMIN"
+
+	# And set the CPUs and RAM up...
+	RUNTIME_EXTRA_ARGS="${RUNTIME_EXTRA_ARGS} --cpus=${CONTAINER_CPUS}"
+	RUNTIME_EXTRA_ARGS="${RUNTIME_EXTRA_ARGS} -m=${CONTAINER_RAM}"
+
+	# If we are in volume test mode then mount a volume over the top of the testdir
+	# in the container.
+	# Otherwise, the default is to test on the 'root mount'.
+	if [ "$TEST_VOLUME_MOUNT" -eq 1 ]; then
+		RUNTIME_EXTRA_ARGS="${RUNTIME_EXTRA_ARGS} -v ${HOST_TEST_DIRNAME}:${GUEST_TEST_DIRNAME}"
+	fi
+
+	# Go pre-create the fio job files
+	generate_jobfiles
+
+	# Run up the work container, in detached state, ready to then issue 'execs'
+	# to it. Do the input and output volume mounts now.
+	docker run -d --rm --name="${CONTAINER_NAME}" --runtime=$RUNTIME ${RUNTIME_EXTRA_ARGS} -v ${HOST_OUTPUT_DIRNAME}:${GUEST_OUTPUT_DIRNAME} -v ${HOST_INPUT_DIRNAME}:${GUEST_INPUT_DIRNAME} $IMAGE
+}
+
+# Drop the host side caches. We may even want to do this if we are in 'direct' mode as
+# the fio 'direct' applies to the guest, and the container map/mount from the host to the
+# guest might enable host side cacheing (that is an option on QEMU for instance).
+dump_host_caches() {
+	# Make sure we flush things down
+	sync
+	# And then drop the caches
+	sudo bash -c "echo 3 > /proc/sys/vm/drop_caches"
+}
+
+
+# Generate the metrics JSON output files.
+# arg1: the name of the fio generated JSON results file
+# The name of that input file dictates the name of the final metrics
+# json output file as well.
+generate_results() {
+	# Set the TEST_NAME to define the json output file
+	TEST_NAME=${1%.json}
+
+	metrics_json_init
+	metrics_json_start_array
+
+	local json="$(cat << EOF
+	{
+		"testimage" : "${IMAGE}",
+		"container_RAM" : "${CONTAINER_RAM}",
+		"container_CPUS" : "${CONTAINER_CPUS}",
+		"volume_test" : "${TEST_VOLUME_MOUNT}",
+		"readtest" : "${FIO_READTEST}",
+		"writetest" : "${FIO_WRITETEST}",
+		"readwritetest" : "${FIO_READWRITETEST}",
+		"fio_direct" : "${FIO_DIRECT}",
+		"fio_random" : "${FIO_RANDOM}",
+		"fio_blocksize" : "${FIO_BLOCKSIZE}",
+		"fio_numjobs" : "${FIO_NUMJOBS}",
+		"fio_timebased" : "${FIO_TIMEBASED}",
+		"fio_runtime" : "${FIO_RUNTIME}",
+		"fio_invalidate" : "${FIO_INVALIDATE}",
+		"fio_filesize" : "${FIO_FILESIZE}",
+		"fio_ioengine" : "${FIO_IOENGINE}",
+		"fio_iodepth" : "${FIO_IODEPTH}"
+	}
+EOF
+)"
+
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Config"
+
+	# And store the raw JSON emitted by fio itself.
+	metrics_json_start_array
+	# Read in the fio generated results
+	json="$(cat ${HOST_OUTPUT_DIRNAME}/$1)"
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Raw"
+
+	metrics_json_save
+}
+
+# Run the actual tests. Arguments:
+# $1 - Do we set the fio 'direct' parameter
+# $2 - Do we do the random access test (rather than linear test)
+#
+# This function will run all/none of the read/write/rw tests depending on their
+# relevant environment settings.
+run_test() {
+	local dodirect=$1
+	local dorandom=$2
+	local randprefix=""
+	local fioopts="--bs=${FIO_BLOCKSIZE} --output-format=json"
+	local filename=""
+
+	[ "$dorandom" -eq 1 ] && randprefix="rand"
+	[ "$dodirect" -eq 1 ] && fioopts="${fioopts} --direct=1"
+
+	if [ "${FIO_READTEST}" -eq 1 ]; then
+		filebase="fio-${randprefix}read"
+		filename="${filebase}.job"
+		outputfilename="${filebase}-${FIO_BLOCKSIZE}.json"
+		fioopts="${fioopts} --output=${GUEST_OUTPUT_DIRNAME}/$outputfilename"
+		dump_host_caches
+		echo " ${filebase}-${FIO_BLOCKSIZE}"
+		local output=$(docker exec "${CONTAINER_NAME}" fio $fioopts ${GUEST_INPUT_DIRNAME}/$filename)
+		generate_results "$outputfilename"
+	fi
+
+	if [ "${FIO_WRITETEST}" -eq 1 ]; then
+		filebase="fio-${randprefix}write"
+		filename="${filebase}.job"
+		outputfilename="${filebase}-${FIO_BLOCKSIZE}.json"
+		fioopts="${fioopts} --output=${GUEST_OUTPUT_DIRNAME}/$outputfilename"
+		dump_host_caches
+		echo " ${filebase}-${FIO_BLOCKSIZE}"
+		local output=$(docker exec "${CONTAINER_NAME}" fio $fioopts ${GUEST_INPUT_DIRNAME}/$filename)
+		generate_results "$outputfilename"
+	fi
+
+	if [ "${FIO_READWRITETEST}" -eq 1 ]; then
+		filebase="fio-${randprefix}rw"
+		filename="${filebase}.job"
+		outputfilename="${filebase}-${FIO_BLOCKSIZE}.json"
+		fioopts="${fioopts} --output=${GUEST_OUTPUT_DIRNAME}/$outputfilename"
+		dump_host_caches
+		echo " ${filebase}-${FIO_BLOCKSIZE}"
+		local output=$(docker exec "${CONTAINER_NAME}" fio $fioopts ${GUEST_INPUT_DIRNAME}/$filename)
+		generate_results "$outputfilename"
+	fi
+}
+
+main() {
+	# Decide which blocksize set we need
+	if [ "${FIO_DIRECT}" -eq 1 ] ; then
+		local blocksizes="${FIO_DIRECT_BLOCKSIZES}"
+	else
+		local blocksizes="${FIO_BLOCKSIZES}"
+	fi
+	
+	# run the set of tests for each defined blocksize
+	for b in $blocksizes; do
+		FIO_BLOCKSIZE=$b
+		run_test "${FIO_DIRECT}" "${FIO_RANDOM}"
+	done
+}
+
+cleanup() {
+	docker kill "${CONTAINER_NAME}" || true
+	clean_env
+}
+
+init
+main
+cleanup

--- a/metrics/storage/fio_dockerfile/Dockerfile
+++ b/metrics/storage/fio_dockerfile/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Set up an Ubuntu image with the components needed to run `fio`
+FROM ubuntu
+
+# Version of the Dockerfile
+LABEL DOCKERFILE_VERSION="1.0"
+
+# Without this some of the package installs stop to try and ask questions...
+#ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+	apt-get install -y fio && \
+	apt-get remove -y unattended-upgrades
+
+# Pull in our actual worker scripts
+COPY . /scripts
+
+# By default generate the report
+CMD ["/scripts/init.sh"]

--- a/metrics/storage/fio_dockerfile/init.sh
+++ b/metrics/storage/fio_dockerfile/init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+TESTDIR=/testdir
+
+init() {
+	# If the testdir does not exist (that likely means has not been mounted as
+	# a volume), then create it. If it is not a volume then it should be created
+	# on the container root 'writeable overlay' (be that overlayfs, devmapper etc.)
+	if [ ! -d ${TESTDIR} ]; then
+		mkdir -p ${TESTDIR} || true
+	fi
+}
+
+init
+echo "Now pausing forever..."
+tail -f /dev/null


### PR DESCRIPTION
Add an `fio` based storage metrics test.
By default it will perform uncached (O_DIRECT) read and write tests.
It can be configured through environment variables to modify a number of
its parameters (including direct/buffered, random, linear, r/w/rw tests, number of jobs etc.
The one fixed parameter is that it always performs the tests upon a single file.

Also add invocation of the test and use of the resulting data to the report generation scripts.