### PR TITLE
CI: fix static-checks for stable branches

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -133,9 +133,10 @@ ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p
 # Run the static analysis tools
 if [ -z "${METRICS_CI}" ]
 then
-	master_branch=""
-	[ -z "$pr_number" ] && master_branch="true"
-	.ci/static-checks.sh "$kata_repo" "$master_branch"
+	specific_branch=""
+	# If not a PR, we are testing on stable or master branch.
+	[ -z "$pr_number" ] && specific_branch="true"
+	.ci/static-checks.sh "$kata_repo" "$specific_branch"
 fi
 
 if [ -n "$pr_number" ]

--- a/integration/swarm/swarm.bats
+++ b/integration/swarm/swarm.bats
@@ -40,8 +40,9 @@ setup() {
 	interfaces=$(basename -a /sys/class/net/*)
 	swarm_interface_arg=""
 	for i in ${interfaces[@]}; do
-		if [ "$(cat /sys/class/net/${i}/operstate)" == "up" ]; then
-			swarm_interface_arg="--advertise-addr ${i}"
+		check_ip_address=$(ip a show dev ${i} | awk '/inet / {print $2}' | cut -d'/' -f1)
+		if [ "$(cat /sys/class/net/${i}/operstate)" == "up" ] && [ -n "${check_ip_address}" ]; then
+			swarm_interface_arg="--advertise-addr ${check_ip_address}"
 			break;
 		fi
 	done


### PR DESCRIPTION
This fix will allow static-checks.sh tool to compare
the file diffs with the correct branch instead of
doing it with master.

Fixes #651.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>