### PR TITLE
metrics: Fix launch_times script to emit valid json numbers

### DIFF
--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -104,7 +104,7 @@ run_workload() {
 		kernel_period=$(echo $kernel_last_line | awk '{print $2}' | tr -d "]")
 
 		# And we can then work out how much time it took to get to the kernel
-		to_kernel_period=$(bc <<<"scale=3; $(ns_to_s $workload_period) - $kernel_period")
+		to_kernel_period=$(printf "%0f" $(bc <<<"scale=3; $(ns_to_s $workload_period) - $kernel_period"))
 	else
 		kernel_period="0.0"
 		to_kernel_period="0.0"


### PR DESCRIPTION
Fix the to kernel period time to print valid json numbers.

Fixes #562

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>