### PR TITLE
CI: KATA_RUNIME default must be kata-runtime

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-export KATA_RUNTIME=${KATA_RUNTIME:-cc}
+export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 
 # If we fail for any reason a message will be displayed
 die(){


### PR DESCRIPTION
Instead of making cc the default value of this environment
variable, the default must be kata-runtime.

Fixes #600.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>