### PR TITLE
k8s: skip k8s memory test

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -29,6 +29,7 @@ setup() {
 }
 
 @test "Running within memory constraints" {
+	skip "https://github.com/kata-containers/tests/issues/680"	
 	memory_limit_size="200Mi"
 	allocated_size="150M"
 	wait_time=120


### PR DESCRIPTION
Currenlty the test 'running within memory constraints' has
been frequently failing in the CI. Disable it for having a
working CI until we find the root cause.
More info on: https://github.com/kata-containers/tests/issues/680

Fixes: #689.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>