### PR TITLE
tests: Unskip volume test for passing a block device.

### DIFF
--- a/integration/docker/volume_test.go
+++ b/integration/docker/volume_test.go
@@ -121,7 +121,6 @@ var _ = Describe("docker volume", func() {
 
 	Context("passing a block device", func() {
 		It("should be mounted", func() {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/677")
 			diskFile, loopFile, err = createLoopDevice()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Now that this issue has been merged https://github.com/kata-containers/runtime/pull/686,
we can enable this volume test.

Fixes #694

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>