### PR TITLE
log-parser: Add installation steps before usage in README

### DIFF
--- a/cmd/log-parser/README.md
+++ b/cmd/log-parser/README.md
@@ -92,7 +92,12 @@ To merge all logs:
    ```
    $ sudo chown $USER *.log
    ```
-1. Run the script:
+1. To install the program:
+   ```
+   $ go get -d github.com/kata-containers/tests
+   $ pushd $GOPATH/src/github.com/kata-containers/tests/cmd/log-parser && make install && popd
+   ```
+1. To run the program:
    ```
    $ kata-log-parser proxy.log runtime.log shim.log
    ```


### PR DESCRIPTION
The README for kata-log-parser does not mention
how to install the tool before its usage. Improve the 
README by including those steps. 

Fixes: #696

 Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com