### PR TITLE
metrics: ci: enable cloud instance metrics CI

### DIFF
--- a/cmd/checkmetrics/baseline/density-CI.toml
+++ b/cmd/checkmetrics/baseline/density-CI.toml
@@ -1,0 +1,43 @@
+# This file contains current expected footprint/density figures utilised
+# by the metrics CI system when running in a cloud instance.
+
+# Footprint from https://github.com/kata-containers/tests/blob/master/metrics/density/docker_memory_usage.sh
+# when KSM is *disabled*
+[[metric]]
+# The test name entry dictates the results file that is checked.
+name = "memory-footprint"
+# If no Type set, then we default to json
+#type = "json"
+description = "measure container average footprint"
+checkvar = ".Results | .[] | .average.Result"
+checktype = "mean"
+midval = 137500.0
+minpercent = 5.0
+maxpercent = 5.0
+
+# Footprint from https://github.com/kata-containers/tests/blob/master/metrics/density/docker_memory_usage.sh
+# when KSM is *enabled*
+[[metric]]
+# The test name entry dictates the results file that is checked.
+name = "memory-footprint-ksm"
+type = "json"
+description = "measure container average footprint with KSM"
+checkvar = ".Results | .[] | .average.Result"
+checktype = "mean"
+midval = 46355.0
+minpercent = 5.0
+maxpercent = 5.0
+
+# Memory footprint *inside* the container - that is, how much memory inside the container
+# was consumed by 'the system'.
+[[metric]]
+# The test name entry dictates the results file that is checked.
+name = "memory-footprint-inside-container"
+type = "json"
+description = "measure container footprint inside the container"
+checkvar = ".Results | .[] | .memavailable.Result"
+checktype = "mean"
+midval = 1991324.0
+minpercent = 5.0
+maxpercent = 5.0
+


### PR DESCRIPTION
If we are on a known noisy/time variant system then we can still
run some metrics that are nominally time insensitive (like the
footprint/density tests). Modify the scripts so we can set an
env var to notify we are on such a system, and thus adapt the
tests we run, and how we locate a correct checkmetrics file to
use to check the results.

Fixes: #698

Signed-off-by: Graham Whaley <graham.whaley@intel.com>