### PR TITLE
tests: Add versions.yaml in order to support nginx working image

### DIFF
--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -8,7 +8,9 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	nginx_image="nginx:1.14"
+	versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
+	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
+	nginx_image="nginx:$nginx_version"
 	busybox_image="busybox"
 	service_name="nginx-service"
 	export KUBECONFIG=/etc/kubernetes/admin.conf

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -23,11 +23,6 @@ ITERATIONS="${ITERATIONS:-5}"
 # We choose 2G, as that is one of the default VM sizes for Kata
 MEM_CUTOFF="${MEM_CUTOFF:-(2*1024*1024*1024)}"
 
-# The default container/workload we run for testing
-# nginx has show up issues in the past, for whatever reason, so
-# let's default to that
-PAYLOAD="${PAYLOAD:-nginx:1.14}"
-
 # do we need a command argument for this payload?
 COMMAND="${COMMAND:-}"
 
@@ -147,8 +142,8 @@ go() {
 	while true; do {
 		check_all_running
 
-		echo "Run $RUNTIME: $PAYLOAD: $COMMAND"
-		docker run --runtime=${RUNTIME} -tid ${PAYLOAD} ${COMMAND}
+		echo "Run $RUNTIME: $nginx_image: $COMMAND"
+		docker run --runtime=${RUNTIME} -tid ${nginx_image} ${COMMAND}
 
 		((how_many++))
 		if (( ${how_many} >= ${MAX_CONTAINERS} )); then
@@ -200,10 +195,14 @@ init() {
 		check_kata_components=0
 	fi
 
+	versions_file="${cidir}/../../versions.yaml"
+	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
+	nginx_image="nginx:$nginx_version"
+
 	# Pull nginx image
-	docker pull ${PAYLOAD}
+	docker pull ${nginx_image}
 	if [ $? != 0 ]; then
-		die "Unable to retry docker image ${PAYLOAD}"
+		die "Unable to retry docker image ${nginx_image}"
 	fi
 }
 

--- a/metrics/network/network-metrics-nginx-ab-benchmark.sh
+++ b/metrics/network/network-metrics-nginx-ab-benchmark.sh
@@ -16,8 +16,6 @@ source "${SCRIPT_PATH}/../lib/common.bash"
 
 # Ports where it will run
 port="${port:-80:80}"
-# Image name
-image="${image:-nginx:1.14}"
 # Url
 url="${url:-localhost:80}"
 # Number of requests to perform
@@ -74,7 +72,7 @@ EOF
 
 function nginx_ab_networking {
 	# Launch nginx container
-	docker run -d -p $port $image
+	docker run -d -p $port $nginx_image
 	echo >&2 "WARNING: sleeping for $start_time seconds to let the container start correctly"
 	sleep "$start_time"
 	ab -s ${socket_time} -n ${requests} -r -c ${concurrency_value} http://${url}/ > $TMP_FILE
@@ -149,7 +147,10 @@ function main() {
 
 	# Initialize/clean environment
 	init_env
-	check_images "$image"
+	versions_file="${SCRIPT_PATH}/../../versions.yaml"
+	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
+	nginx_image="nginx:$nginx_version"
+	check_images "$nginx_image"
 
 	concurrency $concurrency_value
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+docker_images:
+  description: "Docker hub images used for testing"
+
+  nginx:
+    description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
+    url: "https://hub.docker.com/_/nginx/"
+    version: "1.14"


### PR DESCRIPTION
With versions.yaml we will be able to specify which nginx version is
working.

Fixes #700

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>