### PR TITLE
ci: increase go test timeout

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -20,7 +20,7 @@ long_options=(
 #
 # KATA_GO_TEST_TIMEOUT can be set to any value accepted by
 # "go test -timeout X"
-timeout_value=${KATA_GO_TEST_TIMEOUT:-10s}
+timeout_value=${KATA_GO_TEST_TIMEOUT:-30s}
 
 # -race flag is supported only on amd64/x86_64 arch , hence 
 # enabling the flag depending on the arch.


### PR DESCRIPTION
We've hit more go test timeout in CI. CI already cost 10s of minutes,
there is no reason not to tolerant a bit more time just for `go test`.

Fixes: #703

Signed-off-by: Peng Tao <bergwolf@gmail.com>