### PR TITLE
tests: Enable two CRI-O tests

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -51,7 +51,7 @@ IFS=''
 pushd "${crio_repository_path}/test/"
 for i in "${skipCRIOTests[@]}"
 do
-	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/agent/issues/138)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
+	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/tests/issues/714)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
 done
 
 IFS=$OLD_IFS

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,6 +9,4 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
-'test "ctr update resources"'
-'test "ctr resources"'
 );


### PR DESCRIPTION
Now that this issue has been fixed kata-containers/agent#138,
we can enable the test 28 (ctr update) and test 31 (ctr resources) for our CRI-O testing.

Fixes #715

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>