### PR TITLE
CI: Fix optional /usr/lib/os-release

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -19,7 +19,7 @@ source "${script_dir}/lib.sh"
 cri_containerd_version=$(get_version "externals.cri-containerd.version")
 containerd_version=$(get_version "externals.cri-containerd.meta.containerd-version")
 
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 echo "Set up environment"
 if [ "$ID" == centos ];then

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -9,7 +9,7 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 echo "Get CRI-O sources"
 crio_repo="github.com/kubernetes-incubator/cri-o"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -10,7 +10,7 @@ set -o nounset
 set -o pipefail
 
 cidir=$(dirname "$0")
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 echo "Install kata-containers image"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -11,7 +11,7 @@ set -o pipefail
 
 cidir=$(dirname "$0")
 
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 ARCH="$(${cidir}/kata-arch.sh -d)"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
-source "/etc/os-release"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 kernel_repo_name="packaging"
 kernel_repo_owner="kata-containers"

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -13,7 +13,7 @@ source "${cidir}/lib.sh"
 echo "Install Kubernetes components"
 
 cidir=$(dirname "$0")
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 kubernetes_version=$(get_version "externals.kubernetes.version")
 
 if [ "$ID" != "ubuntu" ]; then

--- a/.ci/install_openshift.sh
+++ b/.ci/install_openshift.sh
@@ -8,7 +8,7 @@
 set -e
 
 cidir=$(dirname "$0")
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 if [ "$ID" != "fedora" ] && [ "$CI" == true ]; then

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -9,7 +9,7 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 CURRENT_QEMU_COMMIT=$(get_version "assets.hypervisor.qemu-lite.commit")
 PACKAGED_QEMU="qemu-lite"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -10,7 +10,7 @@ set -e
 cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 # Modify the runtimes build-time defaults
 

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-source "/etc/os-release"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 # Signify to all scripts that they are running in a CI environment
 [ -z "${KATA_DEV_MODE}" ] && export CI=true

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -8,7 +8,7 @@
 set -e
 
 cidir=$(dirname "$0")
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 check_gopath

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -8,11 +8,15 @@
 set -e
 
 cidir=$(dirname "$0")
-source "/etc/os-release"
+source "/etc/os-release" || "source /usr/lib/os-release"
 source "${cidir}/lib.sh"
 
 # Obtain CentOS version
-centos_version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f2)
+if [ -f /etc/os-release ]; then
+  centos_version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f2)
+else
+  centos_version=$(grep VERSION_ID /usr/lib/os-release | cut -d '"' -f2)
+fi
 
 # Check EPEL repository is enabled on CentOS
 if [ -z $(yum repolist | grep "Extra Packages") ]; then

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -8,7 +8,7 @@
 set -e
 
 cidir=$(dirname "$0")
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 echo "Install chronic"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -8,7 +8,7 @@
 set -e
 
 cidir=$(dirname "$0")
-source "/etc/os-release"
+source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
 
 echo "Update apt repositories"

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -9,7 +9,7 @@ DOCKER_BIN=docker
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 SCRIPT_NAME=${0##*/}
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 force=false
 ctr_manager=""

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -350,7 +350,7 @@ cmd_reset_config()
 
 setup()
 {
-	source /etc/os-release
+	source /etc/os-release || source /usr/lib/os-release
 
 	distro=$ID
 }

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -44,7 +44,7 @@ die() {
 }
 
 ci_config() {
-	source /etc/os-release
+	source /etc/os-release || source /usr/lib/os-release
 	ID=${ID:-""}
 	if [ "$ID" == ubuntu ] &&  [ -n "${CI}" ] ;then
 		# https://github.com/kata-containers/tests/issues/352
@@ -55,7 +55,7 @@ ci_config() {
 }
 
 ci_cleanup() {
-	source /etc/os-release
+	source /etc/os-release || source /usr/lib/os-release
 	ID=${ID:-""}
 	if [ "$ID" == ubuntu ] &&  [ -n "${CI}" ] ;then
 		[ -f "${kata_config}" ] && sudo rm "${kata_config}"

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -10,7 +10,7 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/crio_skip_tests.sh"
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 
 crio_repository="github.com/kubernetes-incubator/cri-o"
 crio_repository_path="$GOPATH/src/${crio_repository}"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 kubernetes_dir=$(dirname $0)
 
 # Currently, Kubernetes tests only work on Ubuntu.

--- a/integration/openshift/run_openshift_tests.sh
+++ b/integration/openshift/run_openshift_tests.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-source /etc/os-release
+source /etc/os-release || source /usr/lib/os-release
 openshift_dir=$(dirname $0)
 
 # Currently, the CI runs Openshift tests on Fedora.


### PR DESCRIPTION
Fixes #589

Low hanging fruit 😄  @grahamwhaley @jodh-intel @jcvenegas PTAL

Adding "|| source /usr/lib/os-release" to all the lines with "source /etc/os-release"

Signed-off-by: Ricardo Aravena <raravena@branch.io>