### PR TITLE
integration/docker: modify testcase of memory constraints update

### DIFF
--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -142,8 +142,8 @@ var _ = Describe("memory constraints", func() {
 			_, _, exitCode = dockerRun(args...)
 			Expect(exitCode).To(BeZero())
 
-			// 256 MB
-			memSize = fmt.Sprintf("%d", 256*1024*1024)
+			// 640 MB: 512MB + 128MB
+			memSize = fmt.Sprintf("%d", 640*1024*1024)
 
 			args = []string{"--memory", memSize, "--memory-reservation", memSize}
 			if useSwap {


### PR DESCRIPTION
In test integration/docker/mem_test.go, we run a docker with
512M memory, and update it with 256MB. But we don't support
memory hot remove in kata-runtime update interface now. So we
should change the memory constraints update.

Fixes #723

Signed-off-by: Clare Chen <clare.chenhui@huawei.com>