### PR TITLE
tests: Verify processes (hypervisor, shim and proxy)

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -10,10 +10,14 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/crio_skip_tests.sh"
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
 crio_repository="github.com/kubernetes-incubator/cri-o"
 crio_repository_path="$GOPATH/src/${crio_repository}"
+
+# Check no processes are left behind
+check_processes
 
 # devicemapper device and options
 LVM_DEVICE=${LVM_DEVICE:-/dev/vdb}

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
+
 export KUBECONFIG=/etc/kubernetes/admin.conf
 sudo -E kubeadm reset --cri-socket=/var/run/crio/crio.sock
 
@@ -26,3 +29,6 @@ sudo ip link set dev cni0 down
 sudo ip link set dev flannel.1 down
 sudo ip link del cni0
 sudo ip link del flannel.1
+
+# Check no processes are left behind
+check_processes

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -9,6 +9,10 @@ set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
+
+# Check no processes are left behind
+check_processes
 
 # The next workaround is to be able to communicate between pods
 # Issue: https://github.com/kubernetes/kubernetes/issues/40182

--- a/integration/openshift/init.sh
+++ b/integration/openshift/init.sh
@@ -10,6 +10,10 @@ set -e
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/openshiftrc"
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
+
+# Check no processes are left behind
+check_processes
 
 echo "Start crio service"
 sudo systemctl start crio

--- a/integration/openshift/teardown.sh
+++ b/integration/openshift/teardown.sh
@@ -9,9 +9,13 @@ set -e
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/openshiftrc"
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 
 echo "Terminate Openshift master and node processes"
 pgrep openshift | xargs sudo kill -9
 
 echo "Stop cri-o service"
 sudo systemctl stop crio
+
+# Check no processes are left behind
+check_processes

--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -10,6 +10,10 @@
 source ${BATS_TEST_DIRNAME}/../../metrics/lib/common.bash
 
 setup() {
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
 	clean_env
 }
 
@@ -372,4 +376,8 @@ setup() {
 
 teardown() {
 	clean_env
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/swarm/swarm.bats
+++ b/integration/swarm/swarm.bats
@@ -23,13 +23,8 @@ number_of_retries=5
 
 setup() {
 	# Check that processes are not running
-	run check_processes ${PROXY_PATH}
-	[ "$status" -eq 0 ]
-
-	run check_processes ${SHIM_PATH}
-	[ "$status" -eq 0 ]
-
-	run check_processes ${HYPERVISOR_PATH}
+	run check_processes
+	echo "$output"
 	[ "$status" -eq 0 ]
 
 	interfaces=$(basename -a /sys/class/net/*)
@@ -69,13 +64,8 @@ teardown() {
 	docker service remove "${SERVICE_NAME}"
 	docker swarm leave --force
 
-	# Check that processes are not left by Swarm
-	run check_processes ${PROXY_PATH}
-	[ "$status" -eq 0 ]
-
-	run check_processes ${SHIM_PATH}
-	[ "$status" -eq 0 ]
-
-	run check_processes ${HYPERVISOR_PATH}
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
 	[ "$status" -eq 0 ]
 }

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -246,16 +246,12 @@ kill_processes_before_start() {
 # Normally used to look for errant processes, and hence prints
 # a warning
 check_processes() {
-	process=$1
-
-	[[ -z "${process}" ]] && return 0
-
-	pgrep -f "$process"
-	if [ $? -eq 0 ]; then
-		warning "Found unexpected ${process} present"
-		ps -ef | grep $process
-		return 1
-	fi
+	general_processes=( ${PROXY_PATH} ${HYPERVISOR_PATH} ${SHIM_PATH} )
+	for i in "${general_processes[@]}"; do
+		if pgrep -f "$i"; then
+			die "Found unexpected ${i} present"
+		fi
+	done
 }
 
 # Generate a random name - generally used when creating containers, but can


### PR DESCRIPTION
Verify that processes (hypervisor, shim and proxy) are not running before
and after running tests like swarm, popular docker images, kubernetes,
cri-o and openshift.

Fixes #725

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>