### PR TITLE
metrics: Remove parallel test option in iperf3 tests

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -456,7 +456,6 @@ Usage: $0 "[options]"
 		-b      Run all bandwidth tests
 		-h      Shows help
 		-j      Run jitter tests
-		-l      Run parallel connection tests
 		-p      Run all PPS tests
 EOF
 )"


### PR DESCRIPTION
Currently the help function have the option -l for parallel tests,
however, this option has been removed as iperf3 does not handle
parallel testing.

Fixes #729

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>