### PR TITLE
metrics: Check subdir exists while running makereport script

### DIFF
--- a/metrics/report/makereport.sh
+++ b/metrics/report/makereport.sh
@@ -23,6 +23,12 @@ GUESTINPUTDIR="/inputdir/"
 GUESTOUTPUTDIR="/outputdir/"
 
 setup() {
+	echo "Checking subdirectories"
+	check_subdir="$(cd ${HOSTINPUTDIR}; ls -dx */ > /dev/null 2>&1 | wc -l)"
+	if [ $check_subdir -eq 0 ]; then
+		die "Subdirectory not found at metrics/results to store JSON results"
+	fi
+
 	echo "Checking Dockerfile"
 	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
 


### PR DESCRIPTION
To avoid the issue of ls: cannot access '*/': No such file or directory,
while running the ./makereport.sh, we need to check that there is a
subdirectory at least in metrics/results

Fixes #737

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>