### PR TITLE
metrics report update series

### DIFF
--- a/metrics/report/report_dockerfile/dut-details.R
+++ b/metrics/report/report_dockerfile/dut-details.R
@@ -7,18 +7,30 @@
 
 suppressMessages(suppressWarnings(library(tidyr)))	# for gather().
 library(tibble)
+library(plyr)						# rbind.fill
 							# So we can plot multiple graphs
 library(gridExtra)					# together.
 suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
 suppressMessages(library(jsonlite))			# to load the data.
 
+# A list of all the known results files we might find the information inside.
 resultsfiles=c(
 	"boot-times.json",
 	"footprint-busybox-ksm.json",
 	"footprint-elasticsearch-ksm.json",
 	"footprint-mysql-ksm.json",
 	"memory-footprint.json",
-	"memory-footprint-ksm.json"
+	"memory-footprint-ksm.json",
+	"fio-randread-16k.json",
+	"fio-randread-32k.json",
+	"fio-randread-4k.json",
+	"fio-randread-64k.json",
+	"fio-randread-8k.json",
+	"fio-randwrite-16k.json",
+	"fio-randwrite-32k.json",
+	"fio-randwrite-4k.json",
+	"fio-randwrite-64k.json",
+	"fio-randwrite-8k.json"
 	)
 
 data=c()
@@ -79,7 +91,17 @@ for (currentdir in resultdirs) {
 			dirstats=cbind(dirstats, "Host DistVer"=as.character(fdata$'kata-env'$Host$Distro$Version))
 			dirstats=cbind(dirstats, "Host Model"=as.character(fdata$'kata-env'$Host$CPU$Model))
 			dirstats=cbind(dirstats, "Host Krnl"=as.character(fdata$'kata-env'$Host$Kernel))
+			dirstats=cbind(dirstats, "runtime"=as.character(fdata$test$runtime))
 
+			break
+		} else {
+			if (length(fdata$'runc-env') != 0 ) {
+				dirstats=tibble("Run Ver"=as.character(fdata$'runc-env'$Version$Semver))
+				dirstats=cbind(dirstats, "Run SHA"=as.character(fdata$'runc-env'$Version$Commit))
+				dirstats=cbind(dirstats, "runtime"=as.character(fdata$test$runtime))
+			} else {
+				dirstats=tibble("runtime"="Unknown")
+			}
 			break
 		}
 	}
@@ -88,7 +110,8 @@ for (currentdir in resultdirs) {
 		warning(paste("No valid data found for directory ", currentdir))
 	}
 
-	stats=rbind(stats, dirstats)
+	# use plyr rbind.fill so we can combine disparate version info frames
+	stats=rbind.fill(stats, dirstats)
 	stats_names=rbind(stats_names, datasetname)
 }
 

--- a/metrics/report/report_dockerfile/dut-details.R
+++ b/metrics/report/report_dockerfile/dut-details.R
@@ -122,7 +122,7 @@ spun_stats = as_tibble(cbind(What=names(stats), t(stats)))
 
 # Build us a text table of numerical results
 stats_plot = suppressWarnings(ggtexttable(data.frame(spun_stats, check.names=FALSE),
-	theme=ttheme(base_size=8),
+	theme=ttheme(base_size=6),
 	rows=NULL
 	))
 

--- a/metrics/report/report_dockerfile/fio-writes.R
+++ b/metrics/report/report_dockerfile/fio-writes.R
@@ -33,18 +33,28 @@ stats=c()
 rstats=c()
 rstats_names=c()
 
+
+# Where to store up the stats for the tables
+write_bw_stats=c()
+write_iops_stats=c()
+write_lat95_stats=c()
+write_lat99_stats=c()
+
 # For each set of results
 for (currentdir in resultdirs) {
-	dirstats=c()
+	bw_dirstats=c()
+	iops_dirstats=c()
+	lat95_dirstats=c()
+	lat99_dirstats=c()
+	# Derive the name from the test result dirname
+	datasetname=basename(currentdir)
+
 	for (resultsfile in resultsfiles) {
 		fname=paste(inputdir, currentdir, resultsfile, sep="")
 		if ( !file.exists(fname)) {
 			#warning(paste("Skipping non-existent file: ", fname))
 			next
 		}
-
-		# Derive the name from the test result dirname
-		datasetname=basename(currentdir)
 
 		# Import the data
 		fdata=fromJSON(fname)
@@ -83,12 +93,51 @@ for (currentdir in resultdirs) {
 		mdata=cbind(mdata, runtime=rep(datasetname, length(mdata[, "write_bw_mps"]) ))
 		mdata=cbind(mdata, blocksize=rep(blocksize, length(mdata[, "write_bw_mps"]) ))
 
+		# Extract the stats tables
+		bw_dirstats=rbind(bw_dirstats, round(mdata$write_bw_mps, digits=1))
+		# Rowname hack to get the blocksize recorded
+		rownames(bw_dirstats)[nrow(bw_dirstats)]=blocksize
+
+		iops_dirstats=rbind(iops_dirstats, round(mdata$iops_tot, digits=1))
+		rownames(iops_dirstats)[nrow(iops_dirstats)]=blocksize
+
+		# And do the 95 and 99 percentiles as tables as well
+		lat95_dirstats=rbind(lat95_dirstats, round(mean(clat$clat_ns.95.000000)/1000000, digits=1))
+		rownames(lat95_dirstats)[nrow(lat95_dirstats)]=blocksize
+		lat99_dirstats=rbind(lat99_dirstats, round(mean(clat$clat_ns.99.000000)/1000000, digits=1))
+		rownames(lat99_dirstats)[nrow(lat99_dirstats)]=blocksize
+
 		# Store away as single sets
 		data2=rbind(data2, mdata)
 		all_ldata=rbind(all_ldata, ldata)
 		all_ldata2=rbind(all_ldata2, ldata2)
 	}
+
+	# Collect up for each dir we process into a column
+	write_bw_stats=cbind(write_bw_stats, bw_dirstats)
+	colnames(write_bw_stats)[ncol(write_bw_stats)]=datasetname
+
+	write_iops_stats=cbind(write_iops_stats, iops_dirstats)
+	colnames(write_iops_stats)[ncol(write_iops_stats)]=datasetname
+
+	write_lat95_stats=cbind(write_lat95_stats, lat95_dirstats)
+	colnames(write_lat95_stats)[ncol(write_lat95_stats)]=datasetname
+	write_lat99_stats=cbind(write_lat99_stats, lat99_dirstats)
+	colnames(write_lat99_stats)[ncol(write_lat99_stats)]=datasetname
 }
+
+# To get a nice looking table, we need to extract the rownames into their
+# own column
+write_bw_stats=cbind(Bandwidth=rownames(write_bw_stats), write_bw_stats)
+write_bw_stats=cbind(write_bw_stats, Units=rep("MB/s", nrow(write_bw_stats)))
+
+write_iops_stats=cbind(IOPS=rownames(write_iops_stats), write_iops_stats)
+write_iops_stats=cbind(write_iops_stats, Units=rep("IOP/s", nrow(write_iops_stats)))
+
+write_lat95_stats=cbind('lat 95pc'=rownames(write_lat95_stats), write_lat95_stats)
+write_lat95_stats=cbind(write_lat95_stats, Units=rep("ms", nrow(write_lat95_stats)))
+write_lat99_stats=cbind('lat 99pc'=rownames(write_lat99_stats), write_lat99_stats)
+write_lat99_stats=cbind(write_lat99_stats, Units=rep("ms", nrow(write_lat99_stats)))
 
 # lineplot of total bandwidth across blocksizes.
 write_bw_line_plot <- ggplot() +
@@ -174,3 +223,35 @@ master_plot = grid.arrange(
 	nrow=2,
 	ncol=2 )
 
+# A bit of an odd tweak to force a pagebreak between the pictures and
+# the tables. This only works because we have a `results='asis'` in the Rmd
+# R fragment.
+cat("\n\n\\pagebreak\n")
+
+write_bw_stats_plot = suppressWarnings(ggtexttable(write_bw_stats,
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+
+write_iops_stats_plot = suppressWarnings(ggtexttable(write_iops_stats,
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+
+write_lat95_stats_plot = suppressWarnings(ggtexttable(write_lat95_stats,
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+write_lat99_stats_plot = suppressWarnings(ggtexttable(write_lat99_stats,
+	theme=ttheme(base_size=10),
+	rows=NULL
+	))
+
+# and then the statistics tables
+stats_plot = grid.arrange(
+	write_bw_stats_plot,
+	write_iops_stats_plot,
+	write_lat95_stats_plot,
+	write_lat99_stats_plot,
+	nrow=4,
+	ncol=1 )

--- a/metrics/report/report_dockerfile/footprint-density.R
+++ b/metrics/report/report_dockerfile/footprint-density.R
@@ -40,12 +40,15 @@ for (currentdir in resultdirs) {
 		# Import the data
 		fdata=fromJSON(fname)
 
-		testname=paste(datasetname, fdata$Config$payload, sep="-")
+		payload=fdata$Config$payload
+		testname=paste(datasetname, payload)
 
 		cdata=data.frame(avail_mb=as.numeric(fdata$Results$system$avail)/(1024*1024))
 		cdata=cbind(cdata, avail_decr=as.numeric(fdata$Results$system$avail_decr))
 		cdata=cbind(cdata, count=seq_len(length(cdata[, "avail_mb"])))
 		cdata=cbind(cdata, testname=rep(testname, length(cdata[, "avail_mb"]) ))
+		cdata=cbind(cdata, payload=rep(payload, length(cdata[, "avail_mb"]) ))
+		cdata=cbind(cdata, dataset=rep(datasetname, length(cdata[, "avail_mb"]) ))
 
 		# Gather our statistics
 		sdata=data.frame(num_containers=length(cdata[, "avail_mb"]))
@@ -83,8 +86,8 @@ stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
 
 # plot how samples varioed over  'time'
 line_plot <- ggplot() +
-	geom_point( data=data, aes(count, avail_mb, color=testname)) +
-	geom_line( data=data, aes(count, avail_mb, color=testname)) +
+	geom_point( data=data, aes(count, avail_mb, group=testname, color=payload, shape=dataset)) +
+	geom_line( data=data, aes(count, avail_mb, group=testname, color=payload)) +
 	xlab("Containers") +
 	ylab("System Avail (Mb)") +
 	ggtitle("System Memory free") +

--- a/metrics/report/report_dockerfile/memory-footprint.R
+++ b/metrics/report/report_dockerfile/memory-footprint.R
@@ -74,7 +74,7 @@ for (currentdir in resultdirs) {
 }
 
 rstats=cbind(rstats_names, rstats)
-unts=c("Kb", "Kb")
+unts=rep("Kb", length(resultdirs))
 
 # If we have only 2 sets of results, then we can do some more
 # stats math for the text table

--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -75,13 +75,15 @@ This test measures using separate random read and write tests.
 
 ## Reads
 
-```{r, echo=FALSE, fig.cap="Storage I/O Reads"}
+```{r, echo=FALSE, fig.cap="Storage I/O Reads", results='asis'}
 source('fio-reads.R')
 ```
 
+\pagebreak
+
 ## Writes
 
-```{r, echo=FALSE, fig.cap="Storage I/O Writes"}
+```{r, echo=FALSE, fig.cap="Storage I/O Writes", results='asis'}
 source('fio-writes.R')
 ```
 \pagebreak

--- a/metrics/storage/fio.sh
+++ b/metrics/storage/fio.sh
@@ -68,7 +68,7 @@ FIO_TIMEBASED=${FIO_TIMEBASED:-1}
 #  And 60s seems a good balance to get us repeatable numbers in not too long a time.
 FIO_RUNTIME=${FIO_RUNTIME:-60}
 #  By default we have no ramp (warmup) time.
-FIO_RAMPTIME=${FIO_RUNTIME:-0}
+FIO_RAMPTIME=${FIO_RAMPTIME:-0}
 #  Drop the caches in the guest using fio. Note, we need CAP_SYS_ADMIN in the container
 #  for this to work.
 FIO_INVALIDATE=${FIO_INVALIDATE:-1}


### PR DESCRIPTION
A series of metrics report related updates, including:

- Add stats tables to fio pages
- Improve colour usage on system density graph
- Enable system info tables for `runc`
- A couple of other minor related bug/warn fixes