### PR TITLE
CI: Fix teardown for throttler

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -24,6 +24,14 @@ collect_logs()
 	local -r shim_log_path="${log_copy_dest}/${shim_log_filename}"
 	local -r shim_log_prefix="kata-shim_"
 
+	local -r ksm_throttler_log_filename="kata-ksm_throttler.log"
+	local -r ksm_throttler_log_path="${log_copy_dest}/${ksm_throttler_log_filename}"
+	local -r ksm_throttler_log_prefix="kata-ksm_throttler_"
+
+	local -r vc_throttler_log_filename="kata-vc_throttler.log"
+	local -r vc_throttler_log_path="${log_copy_dest}/${vc_throttler_log_filename}"
+	local -r vc_throttler_log_prefix="kata-vc_throttler_"
+
 	local -r crio_log_filename="crio.log"
 	local -r crio_log_path="${log_copy_dest}/${crio_log_filename}"
 	local -r crio_log_prefix="crio_"
@@ -62,6 +70,9 @@ collect_logs()
 		sudo journalctl --no-pager -t kata-runtime > "${kata_runtime_log_path}"
 		sudo journalctl --no-pager -t kata-proxy > "${proxy_log_path}"
 		sudo journalctl --no-pager -t kata-shim > "${shim_log_path}"
+		sudo journalctl --no-pager -u kata-ksm-throttler > "${ksm_throttler_log_path}"
+		sudo journalctl --no-pager -u kata-vc-throttler > "${vc_throttler_log_path}"
+
 		sudo journalctl --no-pager -u crio > "${crio_log_path}"
 		sudo journalctl --no-pager -u docker > "${docker_log_path}"
 		sudo journalctl --no-pager -u kubelet > "${kubelet_log_path}"
@@ -75,6 +86,8 @@ collect_logs()
 		split -b "${subfile_size}" -d "${kata_runtime_log_path}" "${kata_runtime_log_prefix}"
 		split -b "${subfile_size}" -d "${proxy_log_path}" "${proxy_log_prefix}"
 		split -b "${subfile_size}" -d "${shim_log_path}" "${shim_log_prefix}"
+		split -b "${subfile_size}" -d "${ksm_throttler_log_path}" "${ksm_throttler_log_prefix}"
+		split -b "${subfile_size}" -d "${vc_throttler_log_path}" "${vc_throttler_log_prefix}"
 		split -b "${subfile_size}" -d "${crio_log_path}" "${crio_log_prefix}"
 		split -b "${subfile_size}" -d "${docker_log_path}" "${docker_log_prefix}"
 		split -b "${subfile_size}" -d "${kubelet_log_path}" "${kubelet_log_prefix}"
@@ -118,6 +131,12 @@ collect_logs()
 
 		echo "Kata Containers Shim Log:"
 		sudo journalctl --no-pager -t kata-shim
+
+		echo "Kata Containers KSM Throttler Log:"
+		sudo journalctl --no-pager -u kata-ksm-throttler
+
+		echo "Kata Containers Virtcontainers Throttler Log:"
+		sudo journalctl --no-pager -u kata-vc-throttler
 
 		echo "CRI-O Log:"
 		sudo journalctl --no-pager -u crio

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -170,7 +170,8 @@ check_log_files()
 	done
 
 	for unit in \
-		kata-ksm-throttler
+		kata-ksm-throttler \
+		kata-vc-throttler
 	do
 		file="${unit}.log"
 		args="--no-pager -q -o cat -a -u \"${unit}\""

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -152,12 +152,12 @@ check_log_files()
 	make log-parser
 
 	local component
+	local unit
 	local file
 	local args
 	local cmd
 
 	for component in \
-		kata-ksm-throttler \
 		kata-proxy \
 		kata-runtime \
 		kata-shim
@@ -166,6 +166,16 @@ check_log_files()
 		args="--no-pager -q -o cat -a -t \"${component}\""
 
 		cmd="sudo journalctl ${args} > ${file}"
+		eval "$cmd" || true
+	done
+
+	for unit in \
+		kata-ksm-throttler
+	do
+		file="${unit}.log"
+		args="--no-pager -q -o cat -a -u \"${unit}\""
+
+		cmd="sudo journalctl ${args} |grep ^time= > ${file}"
 		eval "$cmd" || true
 	done
 


### PR DESCRIPTION
Change the teardown script to treat the `kata-ksm-throttler` as a systemd unit, not just a tag/identifier.

Also, update the teardown script to include the log for the `kata-vc-throttler` systemd unit and save the throttler logs.

Fixes #747.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>