### PR TITLE
ci: Add support  for new CI job (k8s + containerd)

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -41,7 +41,7 @@ if [ -n "$CI" ]; then
 	sudo mv /etc/cni/net.d/10-containerd-net.conflist  "$cni_test_dir"
 fi
 
-cat | sudo tee /etc/systemd/system/containerd.service  << EOT
+cat <<EOT | sudo tee /etc/systemd/system/containerd.service
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
@@ -62,6 +62,12 @@ ExecStart=/usr/local/bin/containerd
 [Install]
 WantedBy=containerd.target
 EOT
+
+sudo mkdir -p  /etc/systemd/system/kubelet.service.d/
+cat << EOF | sudo tee  /etc/systemd/system/kubelet.service.d/0-containerd.conf
+[Service]                                                 
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+EOF
 
 sudo systemctl daemon-reload
 

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -41,4 +41,28 @@ if [ -n "$CI" ]; then
 	sudo mv /etc/cni/net.d/10-containerd-net.conflist  "$cni_test_dir"
 fi
 
+cat | sudo tee /etc/systemd/system/containerd.service  << EOT
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=containerd-installation.service
+[Service]
+Restart=always
+RestartSec=5
+Delegate=yes
+KillMode=process
+OOMScoreAdjust=-999
+LimitNOFILE=1048576
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+ExecStartPre=/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+[Install]
+WantedBy=containerd.target
+EOT
+
+sudo systemctl daemon-reload
+
 popd  >> /dev/null

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -126,5 +126,14 @@ crio_service_file="${cidir}/data/crio.service"
 echo "Install crio service (${crio_service_file})"
 sudo install -m0444 "${crio_service_file}" "${service_path}"
 
+kubelet_service_dir="/etc/systemd/system/kubelet.service.d/"
+
+sudo mkdir -p "${kubelet_service_dir}"
+
+cat <<EOF| sudo tee "${kubelet_service_dir}/0-crio.conf"
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"
+EOF
+
 echo "Reload systemd services"
 sudo systemctl daemon-reload

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -28,7 +28,3 @@ curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
 chronic sudo -E apt update
 chronic sudo -E apt install -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 
-echo "Modify kubelet systemd configuration to use CRI-O"
-k8s_systemd_file="/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-sudo sed -i '/KUBELET_AUTHZ_ARGS=/a Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --runtime-request-timeout=30m"' "$k8s_systemd_file"
-sudo systemctl daemon-reload

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -135,6 +135,13 @@ ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p
 #   directly.
 # - If the repo is not "tests", call the repo-specific script (which is
 #   expected to call the script of the same name in the "tests" repo).
+if [  "$CI_JOB" == "CRI_CONTAINERD_K8S" ]; then
+	# This job only tests containerd + k8s
+	export CRI_CONTAINERD="yes"
+	export KUBERNETES="yes"
+	export CRIO="no"
+	export OPENSHIFT="no"
+fi
 .ci/setup.sh
 
 # Run the static analysis tools

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -16,8 +16,18 @@ check_gopath
 
 export RUNTIME="kata-runtime"
 
-echo "INFO: Running checks"
-sudo -E PATH="$PATH" bash -c "make check"
+export CI_JOB="${CI_JOB:-default}"
 
-echo "INFO: Running functional and integration tests ($PWD)"
-sudo -E PATH="$PATH" bash -c "make test"
+case "${CI_JOB}" in
+	"CRI_CONTAINERD_K8S")
+		echo "INFO: Containerd checks"
+		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		;;
+	*)
+		echo "INFO: Running checks"
+		sudo -E PATH="$PATH" bash -c "make check"
+
+		echo "INFO: Running functional and integration tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make test"
+		;;
+esac

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,6 +22,7 @@ case "${CI_JOB}" in
 	"CRI_CONTAINERD_K8S")
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
 	*)
 		echo "INFO: Running checks"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -5,94 +5,115 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
-check_gopath
-apply_depends_on
-
 arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_KATA="${INSTALL_KATA:-yes}"
 
-echo "Set up environment"
-if [ "$ID" == ubuntu ];then
-	bash -f "${cidir}/setup_env_ubuntu.sh"
-elif [ "$ID" == fedora ];then
-	bash -f "${cidir}/setup_env_fedora.sh"
-elif [ "$ID" == centos ];then
-	bash -f "${cidir}/setup_env_centos.sh"
-else
-	die "ERROR: Unrecognised distribution."
-	exit 1
-fi
-
-sudo systemctl start haveged
-
-if ! command -v docker > /dev/null; then
-        "${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
-fi
-
-# If on CI, check that docker version is the one defined
-# in versions.yaml. If there is a different version installed,
-# install the correct version..
-docker_version=$(get_version "externals.docker.version")
-docker_version=${docker_version/v}
-docker_version=${docker_version/-*}
-if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
-	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
-fi
-
-case "$arch" in
-	x86_64)
-	if [ "$CI" == true ] && grep -q "N" /sys/module/kvm_intel/parameters/nested 2> /dev/null; then
-		echo "enable Nested Virtualization"
-		sudo modprobe -r kvm_intel
-		sudo modprobe kvm_intel nested=1
-		if grep -q "N" /sys/module/kvm_intel/parameters/nested 2> /dev/null; then
-			die "Failed to find or enable Nested virtualization"
-		fi
-	fi
-	;;
-	aarch64)
-	info "CI running in bare machine"
-	;;
-	*)
-	die "Unsupported architecture: $arch"
-	;;
-esac
-
-if [ "${INSTALL_KATA}" == "yes" ];then
-	echo "Install Kata sources"
-	bash -f ${cidir}/install_kata.sh
-fi
-
-echo "Install CNI plugins"
-bash -f "${cidir}/install_cni_plugins.sh"
-
 # values indicating whether related intergration tests have been supported
-CRIO="true"
-KUBERNETES="true"
-OPENSHIFT="true"
+CRIO="${CRIO:-yes}"
+CRI_CONTAINERD="${CRI_CONTAINERD:-no}"
+KUBERNETES="${KUBERNETES:-yes}"
+OPENSHIFT="${OPENSHIFT:-yes}"
 
-# load arch-specific lib file
-if [ -f "${cidir}/${arch}/lib_setup_${arch}.sh" ]; then
-        source "${cidir}/${arch}/lib_setup_${arch}.sh"
-fi
+setup_distro_env() {
+	echo "Set up environment"
+	if [ "$ID" == centos ]; then
+		bash -f "${cidir}/setup_env_centos.sh"
+	elif [ "$ID" == fedora ]; then
+		bash -f "${cidir}/setup_env_fedora.sh"
+	elif [ "$ID" == ubuntu ]; then
+		bash -f "${cidir}/setup_env_ubuntu.sh"
+	else
+		die "ERROR: Unrecognised distribution: ${ID}."
+		exit 1
+	fi
+	sudo systemctl start haveged
+}
 
-[ "${CRIO}" = "true" ] && echo "Install CRI-O" && bash -f "${cidir}/install_crio.sh"
+install_docker() {
+	if ! command -v docker >/dev/null; then
+		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
+	fi
+	# If on CI, check that docker version is the one defined
+	# in versions.yaml. If there is a different version installed,
+	# install the correct version..
+	docker_version=$(get_version "externals.docker.version")
+	docker_version=${docker_version/v/}
+	docker_version=${docker_version/-*/}
+	if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
+		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
+	fi
+}
 
-[ "${KUBERNETES}" = "true" ] && echo "Install Kubernetes" && bash -f "${cidir}/install_kubernetes.sh"
+enable_nested_virtualization() {
+	case "$arch" in
+	x86_64)
+		if [ "$CI" == true ] && grep -q "N" /sys/module/kvm_intel/parameters/nested 2>/dev/null; then
+			echo "enable Nested Virtualization"
+			sudo modprobe -r kvm_intel
+			sudo modprobe kvm_intel nested=1
+			if grep -q "N" /sys/module/kvm_intel/parameters/nested 2>/dev/null; then
+				die "Failed to find or enable Nested virtualization"
+			fi
+		fi
+		;;
+	aarch64)
+		info "CI running in bare machine"
+		;;
+	*)
+		die "Unsupported architecture: $arch"
+		;;
+	esac
+}
 
-[ "${OPENSHIFT}" = "true" ] && echo "Install Openshift" && bash -f "${cidir}/install_openshift.sh"
+install_kata() {
+	if [ "${INSTALL_KATA}" == "yes" ]; then
+		echo "Install Kata sources"
+		bash -f ${cidir}/install_kata.sh
+	fi
+}
 
-echo "Disable systemd-journald rate limit"
-sudo crudini --set /etc/systemd/journald.conf Journal RateLimitInterval 0s
-sudo crudini --set /etc/systemd/journald.conf Journal RateLimitBurst 0
-sudo systemctl restart systemd-journald
+install_extra_tools() {
+	echo "Install CNI plugins"
+	bash -f "${cidir}/install_cni_plugins.sh"
 
-echo "Drop caches"
-sync
-sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"
+	# load arch-specific lib file
+	if [ -f "${cidir}/${arch}/lib_setup_${arch}.sh" ]; then
+		source "${cidir}/${arch}/lib_setup_${arch}.sh"
+	fi
+
+	[ "${CRIO}" = "yes" ] && echo "Install CRI-O" && bash -f "${cidir}/install_crio.sh"
+
+	[ "${CRI_CONTAINERD}" = "yes" ] && echo "Install cri-containerd" && bash -f "${cidir}/install_cri_containerd.sh"
+
+	[ "${KUBERNETES}" = "yes" ] && echo "Install Kubernetes" && bash -f "${cidir}/install_kubernetes.sh"
+
+	[ "${OPENSHIFT}" = "yes" ] && echo "Install Openshift" && bash -f "${cidir}/install_openshift.sh"
+}
+
+main() {
+	check_gopath
+	apply_depends_on
+	setup_distro_env
+	install_docker
+	enable_nested_virtualization
+	install_kata
+	install_extra_tools
+	echo "Disable systemd-journald rate limit"
+	sudo crudini --set /etc/systemd/journald.conf Journal RateLimitInterval 0s
+	sudo crudini --set /etc/systemd/journald.conf Journal RateLimitBurst 0
+	sudo systemctl restart systemd-journald
+
+	echo "Drop caches"
+	sync
+	sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"
+
+}
+main $*

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -89,13 +89,25 @@ install_extra_tools() {
 		source "${cidir}/${arch}/lib_setup_${arch}.sh"
 	fi
 
-	[ "${CRIO}" = "yes" ] && echo "Install CRI-O" && bash -f "${cidir}/install_crio.sh"
+	[ "${CRIO}" = "yes" ] &&
+		echo "Install CRI-O" &&
+		bash -f "${cidir}/install_crio.sh" ||
+		echo "CRI-O not installed"
 
-	[ "${CRI_CONTAINERD}" = "yes" ] && echo "Install cri-containerd" && bash -f "${cidir}/install_cri_containerd.sh"
+	[ "${CRI_CONTAINERD}" = "yes" ] &&
+		echo "Install cri-containerd" &&
+		bash -f "${cidir}/install_cri_containerd.sh" ||
+		echo "containerd not installed"
 
-	[ "${KUBERNETES}" = "yes" ] && echo "Install Kubernetes" && bash -f "${cidir}/install_kubernetes.sh"
+	[ "${KUBERNETES}" = "yes" ] &&
+		echo "Install Kubernetes" &&
+		bash -f "${cidir}/install_kubernetes.sh" ||
+		echo "Kubernetes not installed"
 
-	[ "${OPENSHIFT}" = "yes" ] && echo "Install Openshift" && bash -f "${cidir}/install_openshift.sh"
+	[ "${OPENSHIFT}" = "yes" ] &&
+		echo "Install Openshift" &&
+		bash -f "${cidir}/install_openshift.sh" ||
+		echo "Openshift not installed"
 }
 
 main() {

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 TIMEOUT := 60
 
 # union for 'make test'
-UNION := functional docker crio docker-compose docker-stability openshift kubernetes swarm cri-containerd vm-factory
+UNION := functional docker crio docker-compose docker-stability openshift kubernetes swarm vm-factory
 
 # skipped test suites for docker integration tests
 SKIP :=

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ swarm:
 	bats swarm.bats
 
 cri-containerd:
-	bash -f .ci/install_cri_containerd.sh
 	bash integration/containerd/cri/integration-tests.sh
 
 log-parser:

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -45,9 +45,10 @@ if ip a show "$cni_interface"; then
 	sudo ip link del "$cni_interface"
 fi
 
-echo "Start crio service"
+echo "Start ${cri_runtime} service"
 sudo systemctl start ${cri_runtime}
 
+echo "Init cluster using ${cri_runtime_socket}"
 sudo -E kubeadm init --pod-network-cidr 10.244.0.0/16 --cri-socket="unix://${cri_runtime_socket}"
 export KUBECONFIG=/etc/kubernetes/admin.conf
 

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -20,6 +20,8 @@ setup() {
 }
 
 @test "Check CPU constraints" {
+	issue="https://github.com/kata-containers/tests/issues/794"
+	[ "${CRI_RUNTIME}" == "containerd" ] && skip "test not working with ${CRI_RUNTIME} see: ${issue}"
 	wait_time=120
 	sleep_time=5
 

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -20,6 +20,8 @@ setup() {
 }
 
 @test "Check UTS and IPC namespaces" {
+	issue="https://github.com/kata-containers/tests/issues/793"
+	[ "${CRI_RUNTIME}" == "containerd" ] && skip "test not working with ${CRI_RUNTIME} see: ${issue}"
 	wait_time=120
 	sleep_time=5
 


### PR DESCRIPTION
Handle the case when `"$CI_JOB" == "CRI_CONTAINERD_K8S"` this should be set by the CI to indicate K8s + containerd testing should be done.