### PR TITLE
static-checks: limit gometalinter concurrency

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -249,6 +249,8 @@ check_go()
 
 	[ "$TRAVIS_GO_VERSION" != "tip" ] && linter_args+=" --enable=gofmt"
 
+	linter_args+=" --concurrency=$(nproc)"
+
 	linter_args+=" --enable=misspell"
 	linter_args+=" --enable=vet"
 	linter_args+=" --enable=ineffassign"


### PR DESCRIPTION
The default concurrency is 16 and it is quite likely to oom even on
a system with 4GB memory. Set it to `nproc` so that it scales
automatically. And it allow `make check` to run on developer's
local environment more easily.

Fixes: #758

Signed-off-by: Peng Tao <bergwolf@gmail.com>