### PR TITLE
metrics: fast footprint

### DIFF
--- a/metrics/density/README.md
+++ b/metrics/density/README.md
@@ -1,0 +1,58 @@
+# Kata Containers density metrics tests
+
+* [Kata Containers density metrics tests](#kata-containers-density-metrics-tests)
+   * [docker_memory_usage](#docker_memory_usage)
+   * [fast_footprint](#fast_footprint)
+   * [footprint_data](#footprint_data)
+   * [memory_usage_inside_container](#memory_usage_inside_container)
+
+This directory contains a number of tests to help measure container
+memory footprint. Some measures are based around the
+[PSS](https://en.wikipedia.org/wiki/Proportional_set_size) of the runtime
+components, and others look at the system level (`free` and `/proc/meminfo`
+for instance) impact.
+
+## `docker_memory_usage`
+
+This test measures the PSS footprint of the runtime components whilst
+launching a number of small ([busybox](https://hub.docker.com/_/busybox/)) containers.
+
+## `fast_footprint`
+
+This test takes system level resource measurements after launching a number of
+containers in parallel and optionally waiting for KSM to settle its memory
+compaction cycles.
+
+The script is quite configurable via environment variables, including:
+
+* Which container workload to run.
+* How many containers to launch.
+* How many containers are launched in parallel.
+* How long to wait until taking the measures.
+
+See the script itself for more details.
+
+This test shares many config options with the `footprint_data` test. Thus, referring
+to the [footprint test documentation](footprint_data.md) may be useful.
+
+> *Note:* If this test finds KSM is enabled on the host, it will wait for KSM
+> to 'settle' before taking the final measurement. If your KSM is not configured
+> to process all the allocated VM memory fast enough, the test will hit a timeout
+> and proceed to take the final measurement anyway.
+
+## `footprint_data`
+
+Similar to the `fast_footprint` test, but this test launches the containers
+sequentially and takes a system level measurement between each launch. Thus,
+this test provides finer grained information on system scaling, but takes
+significantly longer to run than the `fast_footprint` test. If you are only
+interested in the final figure or the average impact, you may be better running
+the `fast_footprint` test.
+
+For more details see the [footprint test documentation](footprint_data.md).
+
+## `memory_usage_inside_container`
+
+Measures the memory statistics *inside* the container. This allows evaluation of
+the overhead the VM kernel and rootfs are having on the memory that was requested
+by the container co-ordination system, and thus supplied to the VM.

--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -50,20 +50,6 @@ Usage: $0 <count> <wait_time> [auto]
 EOF
 }
 
-# See if KSM is enabled.
-# If so, ammend the test name to reflect that
-check_for_ksm(){
-	if [ ! -f ${KSM_ENABLE_FILE} ]; then
-		return
-	fi
-
-	ksm_on=$(< ${KSM_ENABLE_FILE})
-
-	if [ $ksm_on == "1" ]; then
-		TEST_NAME="${TEST_NAME} ksm"
-	fi
-}
-
 # This function measures the PSS average
 # memory about the child process of each
 # docker-containerd-shim instance in the

--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -200,59 +200,6 @@ EOF
 	metrics_json_end_array "Raw results"
 }
 
-
-# Wait for KSM to settle down, or timeout waiting
-# The basic algorithm is to look at the pages_shared value
-# at the end of every 'full scan', and if the value
-# has changed very little, then we are done (because we presume
-# a full scan has managed to do few new merges)
-#
-# arg1 - timeout in seconds
-wait_ksm_settle(){
-	local t pcnt
-	local oldscan=-1 newscan
-	local oldpages=-1 newpages
-
-	oldscan=$(cat /sys/kernel/mm/ksm/full_scans)
-
-	# Go around the loop until either we see a small % change
-	# between two full_scans, or we timeout
-	for ((t=0; t<$1; t++)); do
-
-		newscan=$(cat /sys/kernel/mm/ksm/full_scans)
-		if (( newscan != oldscan )); then
-			echo -e "\nnew full_scan ($oldscan to $newscan)"
-
-			newpages=$(cat /sys/kernel/mm/ksm/pages_shared)
-			# Do we have a previous scan to compare with
-			echo "check pages $oldpages to $newpages"
-			if (( oldpages != -1 )); then
-				# avoid divide by zero problems
-				if (( $oldpages > 0 )); then
-					pcnt=$(( 100 - ((newpages * 100) / oldpages) ))
-					# abs()
-					pcnt=$(( $pcnt * -1 ))
-
-					echo "$oldpages to $newpages is ${pcnt}%"
-
-					if (( $pcnt <= 5 )); then
-						echo "KSM stabilised at ${t}s"
-						return
-					fi
-				else
-					echo "$oldpages KSM pages... waiting"
-				fi
-			fi
-			oldscan=$newscan
-			oldpages=$newpages
-		else
-			echo -n "."
-		fi
-		sleep 1
-	done
-	echo "Timed out after ${1}s waiting for KSM to settle"
-}
-
 # Try to work out the 'average memory footprint' of a container.
 get_docker_memory_usage(){
 	hypervisor_mem=0

--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -161,21 +161,6 @@ function cleanup() {
 	docker kill $(docker ps -qa)
 }
 
-# See if KSM is enabled.
-# If so, ammend the test name to reflect that
-# FIXME - needs refactoring - see https://github.com/kata-containers/tests/issues/519
-check_for_ksm(){
-	if [ ! -f ${KSM_ENABLE_FILE} ]; then
-		return
-	fi
-
-	ksm_on=$(< ${KSM_ENABLE_FILE})
-
-	if [ $ksm_on == "1" ]; then
-		TEST_NAME="${TEST_NAME} ksm"
-	fi
-}
-
 # helper function to get USS of prcess in arg1
 function get_proc_uss() {
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')

--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -1,0 +1,550 @@
+#!/bin/bash
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# A script to gather memory 'footprint' information as we launch more
+# and more containers
+# It allows configuration of a number of things:
+# - which container workload we run
+# - which container runtime we run with
+# - when do we terminate the test (cutoff points)
+#
+# There are a number of things we may wish to add to this script later:
+# - sanity check that the correct number of runtime components (qemu, shim etc.)
+#  are running at all times
+# - some post-processing scripts to generate stats and graphs
+#
+# The script gathers information about both user and kernel space consumption
+# Output is into a .json file, named using some of the config component names
+# (such as footprint-busybox.json)
+
+# Pull in some common, useful, items
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../lib/common.bash"
+
+# Note that all vars that can be set from outside the script (that is,
+# passed in the ENV), use the ':-' setting to allow being over-ridden
+
+# Default sleep, in seconds, to let containers come up and finish their
+# initialisation before we take the measures. Some of the larger
+# containers can take a number of seconds to get running.
+PAYLOAD_SLEEP="${PAYLOAD_SLEEP:-10}"
+
+# How long, in seconds, do we wait for KSM to 'settle down', before we
+# timeout and just continue anyway.
+KSM_WAIT_TIME="${KSM_WAIT_TIME:-300}"
+
+# How long, in seconds, do we poll for docker to complete launching all the
+# containers?
+DOCKER_POLL_TIMEOUT="${DOCKER_POLL_TIMEOUT:-300}"
+
+# How many containers do we launch in parallel before taking the PAYLOAD_SLEEP
+# nap
+PARALLELISM="${PARALLELISM:-10}"
+
+### The default config - run a small busybox image
+# Define what we will be running (app under test)
+#  Default is we run busybox, as a 'small' workload
+PAYLOAD="${PAYLOAD:-busybox}"
+PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
+PAYLOAD_RUNTIME_ARGS="${PAYLOAD_RUNTIME_ARGS:- -m 2G}"
+
+
+#########################
+### Below are a couple of other examples of workload configs:
+#  mysql is a more medium sized workload
+#PAYLOAD="${PAYLOAD:-mysql}"
+# Disable the aio use, or you can only run ~24 containers under runc, as you run out
+# of handles in the kernel. Disable log-bin as it hits a file resize fail error.
+#PAYLOAD_ARGS="${PAYLOAD_ARGS:- --innodb_use_native_aio=0 --disable-log-bin}"
+#PAYLOAD_RUNTIME_ARGS="${PAYLOAD_RUNTIME_ARGS:- -m 4G -e MYSQL_ALLOW_EMPTY_PASSWORD=1}"
+#
+#  elasticsearch is a large workload
+#PAYLOAD="${PAYLOAD:-elasticsearch}"
+#PAYLOAD_ARGS="${PAYLOAD_ARGS:-}"
+#PAYLOAD_RUNTIME_ARGS="${PAYLOAD_RUNTIME_ARGS:- -m 8G}"
+#########################
+
+###
+# which RUNTIME we use is picked up from the env in
+# common.bash. You can over-ride by setting RUNTIME in your env
+
+###
+# Define the cutoff checks for when we stop running the test
+  # Run up to this many containers
+NUM_CONTAINERS="${NUM_CONTAINERS:-200}"
+  # Run until we have consumed this much memory (from MemFree)
+MAX_MEMORY_CONSUMED="${MAX_MEMORY_CONSUMED:-256*1024*1024*1024}"
+  # Run until we have this much MemFree left
+MIN_MEMORY_FREE="${MIN_MEMORY_FREE:-2*1024*1024*1024}"
+
+# These paths come from the lib common.bash init sequence
+#PROXY_PATH
+#SHIM_PATH
+#HYPERVISOR_PATH
+
+# We monitor dockerd as we know it can grow as we run containers
+DOCKERD_PATH="${DOCKERD_PATH:-/usr/bin/dockerd}"
+
+# Tools we need to have installed in order to operate
+REQUIRED_COMMANDS="smem awk"
+
+# If we 'dump' the system caches before we measure then we get less
+# noise in the results - they show more what our un-reclaimable footprint is
+DUMP_CACHES="${DUMP_CACHES:-1}"
+
+# Affects the name of the file to store the results in
+TEST_NAME="${TEST_NAME:-fast-footprint-${PAYLOAD}}"
+
+############# end of configurable items ###################
+
+# vars to remember where we started so we can calc diffs
+base_mem_avail=0
+base_mem_free=0
+
+# dump the kernel caches, so we get a more precise (or just different)
+# view of what our footprint really is.
+function dump_caches() {
+	sudo bash -c "echo 3 > /proc/sys/vm/drop_caches"
+}
+
+function init() {
+	check_cmds $REQUIRED_COMMANDS
+	check_images "$PAYLOAD"
+
+	# Modify the test name if running with KSM enabled
+	check_for_ksm
+
+	# Use the common init func to get to a known state
+	init_env
+
+	# Prepare to start storing results
+	metrics_json_init
+
+	# Store up baseline measures
+	base_mem_avail=$(free -b | head -2 | tail -1 | awk '{print $7}')
+	base_mem_free=$(get_memfree)
+
+	# Store our configuration for this run
+	save_config
+}
+
+save_config(){
+	metrics_json_start_array
+
+	local json="$(cat << EOF
+	{
+		"testname": "${TEST_NAME}",
+		"payload": "${PAYLOAD}",
+		"payload_args": "${PAYLOAD_ARGS}",
+		"payload_runtime_args": "${PAYLOAD_RUNTIME_ARGS}",
+		"payload_sleep": ${PAYLOAD_SLEEP},
+		"ksm_settle_time": ${KSM_WAIT_TIME},
+		"num_containers": ${NUM_CONTAINERS},
+		"parallelism": ${PARALLELISM},
+		"max_memory_consumed": "${MAX_MEMORY_CONSUMED}",
+		"min_memory_free": "${MIN_MEMORY_FREE}",
+		"dockerd_path": "${DOCKERD_PATH}",
+		"dump_caches": "${DUMP_CACHES}"
+	}
+EOF
+)"
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Config"
+}
+
+function cleanup() {
+	# Finish storing the results
+	metrics_json_save
+
+	docker kill $(docker ps -qa)
+}
+
+# See if KSM is enabled.
+# If so, ammend the test name to reflect that
+# FIXME - needs refactoring - see https://github.com/kata-containers/tests/issues/519
+check_for_ksm(){
+	if [ ! -f ${KSM_ENABLE_FILE} ]; then
+		return
+	fi
+
+	ksm_on=$(< ${KSM_ENABLE_FILE})
+
+	if [ $ksm_on == "1" ]; then
+		TEST_NAME="${TEST_NAME} ksm"
+	fi
+}
+
+# helper function to get USS of prcess in arg1
+function get_proc_uss() {
+	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')
+	((item*=1024))
+	echo $item
+}
+
+# helper function to get PSS of process in arg1
+function get_proc_pss() {
+	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $5}')
+	((item*=1024))
+	echo $item
+}
+
+# Get the USS footprint of the VM runtime runtime components
+function grab_vm_uss() {
+	proxy=$(get_proc_uss $PROXY_PATH)
+	shim=$(get_proc_uss $SHIM_PATH)
+	qemu=$(get_proc_uss $HYPERVISOR_PATH)
+
+	total=$((proxy + shim + qemu))
+
+	local json="$(cat << EOF
+		"uss": {
+			"proxy": $proxy,
+			"shim": $shim,
+			"qemu": "$qemu",
+			"total": $total,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+# Get the PSS footprint of the VM runtime components
+function grab_vm_pss() {
+	proxy=$(get_proc_pss $PROXY_PATH)
+	shim=$(get_proc_pss $SHIM_PATH)
+	qemu=$(get_proc_pss $HYPERVISOR_PATH)
+
+	total=$((proxy + shim + qemu))
+
+	local json="$(cat << EOF
+		"pss": {
+			"proxy": $proxy,
+			"shim": $shim,
+			"qemu": "$qemu",
+			"total": $total,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+# Get the PSS footprint of dockerd - we know it can
+# grow in size as we launch containers, so let's try to
+# account for it
+function grab_dockerd_pss() {
+	item=$(get_proc_pss $DOCKERD_PATH)
+
+	local json="$(cat << EOF
+		"dockerd": {
+			"pss": $item,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+# Get the PSS for the whole of userspace (all processes)
+#  This allows us to see if we had any impact on the rest of the system, for instance
+#  dockerd grows as we launch containers, so we should account for that in our total
+#  memory breakdown
+function grab_all_pss() {
+	item=$(sudo smem -t | tail -1 | awk '{print $5}')
+	((item*=1024))
+
+	local json="$(cat << EOF
+		"all_pss": {
+			"pss": $item,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+function grab_user_smem() {
+	# userspace
+	item=$(sudo smem -w | head -5 | tail -1 | awk '{print $3}')
+	((item*=1024))
+
+	local json="$(cat << EOF
+		"user_smem": {
+			"userspace": $item,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+function grab_slab() {
+	# Grabbing slab total from meminfo is easier than doing the math
+	# on slabinfo
+	item=$(fgrep "Slab:" /proc/meminfo | awk '{print $2}')
+	((item*=1024))
+
+	local json="$(cat << EOF
+		"slab": {
+			"slab": $item,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+function get_memfree() {
+	mem_free=$(sudo smem -w | head -6 | tail -1 | awk '{print $4}')
+	((mem_free*=1024))
+	echo $mem_free
+}
+
+function grab_system() {
+
+	# avail memory, from 'free'
+	local avail=$(free -b | head -2 | tail -1 | awk '{print $7}')
+	local avail_decr=$((base_mem_avail-avail))
+
+	# cached memory, from 'free'
+	local cached=$(free -b | head -2 | tail -1 | awk '{print $6}')
+
+	# free memory from smem
+	local smem_free=$(get_memfree)
+	local free_decr=$((base_mem_free-item))
+
+	# Anon pages
+	local anon=$(fgrep "AnonPages:" /proc/meminfo | awk '{print $2}')
+	((anon*=1024))
+
+	# Mapped pages
+	local mapped=$(egrep "^Mapped:" /proc/meminfo | awk '{print $2}')
+	((mapped*=1024))
+
+	# Cached
+	local meminfo_cached=$(grep "^Cached:" /proc/meminfo | awk '{print $2}')
+	((meminfo_cached*=1024))
+
+	local json="$(cat << EOF
+		"system": {
+			"avail": $avail,
+			"avail_decr": $avail_decr,
+			"cached": $cached,
+			"smem_free": $smem_free,
+			"free_decr": $free_decr,
+			"anon": $anon,
+			"mapped": $mapped,
+			"meminfo_cached": $meminfo_cached,
+			"Units": "KB"
+		}
+EOF
+)"
+
+	metrics_json_add_array_fragment "$json"
+}
+
+function grab_stats() {
+	# If configured, dump the caches so we get a more stable
+	# view of what our static footprint really is
+	if [[ "$DUMP_CACHES" ]] ; then
+		dump_caches
+	fi
+
+	# user space data
+		# USS taken by CC components
+	grab_vm_uss
+		# PSS taken all userspace
+	grab_vm_pss
+		# PSS taken all userspace
+	grab_all_pss
+		# PSS taken by dockerd
+	grab_dockerd_pss
+		# user as reported by smem
+	grab_user_smem
+
+	# System overview data
+		# System free and cached
+	grab_system
+
+	# kernel data
+		# The 'total kernel space taken' we can work out as:
+		# ktotal = ((free-avail)-user)
+		# So, we don't grab that number from smem, as that is what it does
+		# internally anyhow.
+		# Still try to grab any finer kernel details that we can though
+
+		# totals from slabinfo
+	grab_slab
+
+	metrics_json_close_array_element
+}
+
+function check_limits() {
+	mem_free=$(get_memfree)
+	if ((mem_free <= MIN_MEMORY_FREE)); then
+		echo 1
+		return
+	fi
+
+	mem_consumed=$((base_mem_avail-mem_free))
+	if ((mem_consumed >= MAX_MEMORY_CONSUMED)); then
+		echo 1
+		return
+	fi
+
+	echo 0
+}
+
+launch_containers() {
+	local parloops leftovers
+
+	(( parloops=${NUM_CONTAINERS}/${PARALLELISM} ))
+	(( leftovers=${NUM_CONTAINERS} - (${parloops}*${PARALLELISM}) ))
+
+	echo "Launching ${parloops}x${PARALLELISM} containers + ${leftovers} etras"
+
+	local iter n
+	for iter in $(seq 1 $parloops); do
+		echo "Launch iteration ${iter}"
+		for n in $(seq 1 $PARALLELISM); do
+			docker run --rm -d --runtime=$RUNTIME $PAYLOAD_RUNTIME_ARGS $PAYLOAD $PAYLOAD_ARGS &
+		done
+
+		if [[ $PAYLOAD_SLEEP ]]; then
+			sleep $PAYLOAD_SLEEP
+		fi
+
+		# check if we have hit one of our limits and need to wrap up the tests
+		if (($(check_limits))); then
+			echo "Ran out of resources, check_limits failed"
+			return
+		fi
+	done
+
+	for n in $(seq 1 $leftovers); do
+		docker run --rm -d --runtime=$RUNTIME $PAYLOAD_RUNTIME_ARGS $PAYLOAD $PAYLOAD_ARGS &
+	done
+}
+
+wait_containers() {
+	local t numcontainers
+	# nap 3s between checks
+	local step=3
+
+	for ((t=0; t<${DOCKER_POLL_TIMEOUT}; t+=step)); do
+
+		numcontainers=$(docker ps -qa | wc -l)
+
+		if (( numcontainers >=  ${NUM_CONTAINERS} )); then
+			echo "All containers now launched (${t}s)"
+				return
+		else
+			echo "Waiting for containers to launch (${numcontainers} at ${t}s)"
+		fi
+		sleep ${step}
+	done
+
+	echo "Timed out waiting for containers to launch (${t}s)"
+	cleanup
+	die "Timed out waiting for containers to launch (${t}s)"
+}
+
+function go() {
+	# Init the json cycle for this save
+	metrics_json_start_array
+
+	# Grab the first set of stats before we run any containers.
+	grab_stats
+
+	launch_containers
+	wait_containers
+
+	if [ $ksm_on == "1" ]; then
+		echo "Wating for KSM to settle..."
+		wait_ksm_settle ${KSM_WAIT_TIME}
+	fi
+
+	grab_stats
+
+	# Wrap up the results array
+	metrics_json_end_array "Results"
+}
+
+function show_vars()
+{
+	echo -e "\nEvironment variables:"
+	echo -e "\tName (default)"
+	echo -e "\t\tDescription"
+	echo -e "\tPAYLOAD (${PAYLOAD})"
+	echo -e "\t\tThe docker image to run"
+	echo -e "\tPAYLOAD_ARGS (${PAYLOAD_ARGS})"
+	echo -e "\t\tAny arguments passed into the docker image"
+	echo -e "\tPAYLOAD_RUNTIME_ARGS (${PAYLOAD_RUNTIME_ARGS})"
+	echo -e "\t\tAny extra arguments passed into the docker 'run' command"
+	echo -e "\tPAYLOAD_SLEEP (${PAYLOAD_SLEEP})"
+	echo -e "\t\tSeconds to sleep between launch and measurement, to allow settling"
+	echo -e "\tKSM_WAIT_TIME (${KSM_WAIT_TIME})"
+	echo -e "\t\tSeconds to wait for KSM to settle before we take the final measure"
+	echo -e "\tDOCKER_POLL_TIMEOUT (${DOCKER_POLL_TIMEOUT})"
+	echo -e "\t\tSeconds to poll for docker to finish launching containers"
+	echo -e "\tPARALLELISM (${PARALLELISM})"
+	echo -e "\t\tNumber of containers we launch in parallel"
+	echo -e "\tNUM_CONTAINERS (${NUM_CONTAINERS})"
+	echo -e "\t\tThe total number of containers to run"
+	echo -e "\tMAX_MEMORY_CONSUMED (${MAX_MEMORY_CONSUMED})"
+	echo -e "\t\tThe maximum amount of memory to be consumed before terminating"
+	echo -e "\tMIN_MEMORY_FREE (${MIN_MEMORY_FREE})"
+	echo -e "\t\tThe minimum amount of memory allowed to be free before terminating"
+	echo -e "\tDOCKERD_PATH (${DOCKERD_PATH})"
+	echo -e "\t\tThe path to the Docker 'dockerd' binary (for 'smem' measurements)"
+	echo -e "\tDUMP_CACHES (${DUMP_CACHES})"
+	echo -e "\t\tA flag to note if the system caches should be dumped before capturing stats"
+	echo -e "\tTEST_NAME (${TEST_NAME})"
+	echo -e "\t\tCan be set to over-ride the default JSON results filename"
+
+}
+
+function help()
+{
+	usage=$(cat << EOF
+Usage: $0 [-h] [options]
+   Description:
+	Launch a series of workloads and take memory metric measurements after
+	each launch.
+   Options:
+        -h,    Help page.
+EOF
+)
+	echo "$usage"
+	show_vars
+}
+
+function main() {
+
+	local OPTIND
+	while getopts "h" opt;do
+		case ${opt} in
+		h)
+		    help
+		    exit 0;
+		    ;;
+		esac
+	done
+	shift $((OPTIND-1))
+
+	init
+	go
+	cleanup
+}
+
+main "$@"
+

--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -161,7 +161,7 @@ function cleanup() {
 	docker kill $(docker ps -qa)
 }
 
-# helper function to get USS of prcess in arg1
+# helper function to get USS of process in arg1
 function get_proc_uss() {
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')
 	((item*=1024))

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -146,12 +146,7 @@ function cleanup() {
 	# Finish storing the results
 	metrics_json_save
 
-	# This is what we have for now from the generics.
-	# Expect this to be improved (the generics) soon...
-
 	docker kill $(docker ps -qa)
-
-#	kill_processes_before_start
 }
 
 # helper function to get USS of process in arg1
@@ -333,7 +328,7 @@ EOF
 function grab_stats() {
 	# If configured, dump the caches so we get a more stable
 	# view of what our static footprint really is
-	if [[ DUMP_CACHES ]] ; then
+	if [[ "$DUMP_CACHES" ]] ; then
 		dump_caches
 	fi
 

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -154,21 +154,6 @@ function cleanup() {
 #	kill_processes_before_start
 }
 
-# See if KSM is enabled.
-# If so, ammend the test name to reflect that
-# FIXME - needs refactoring - see https://github.com/kata-containers/tests/issues/519
-check_for_ksm(){
-	if [ ! -f ${KSM_ENABLE_FILE} ]; then
-		return
-	fi
-
-	ksm_on=$(< ${KSM_ENABLE_FILE})
-
-	if [ $ksm_on == "1" ]; then
-		TEST_NAME="${TEST_NAME} ksm"
-	fi
-}
-
 # helper function to get USS of prcess in arg1
 function get_proc_uss() {
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -154,14 +154,14 @@ function cleanup() {
 #	kill_processes_before_start
 }
 
-# helper function to get USS of prcess in arg1
+# helper function to get USS of process in arg1
 function get_proc_uss() {
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $4}')
 	((item*=1024))
 	echo $item
 }
 
-# helper function to get PSS of prcess in arg1
+# helper function to get PSS of process in arg1
 function get_proc_pss() {
 	item=$(sudo smem -t -P "^$1" | tail -1 | awk '{print $5}')
 	((item*=1024))

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -324,6 +324,20 @@ disable_ksm(){
 	sudo bash -c "echo 0 > ${KSM_ENABLE_FILE}"
 }
 
+# See if KSM is enabled.
+# If so, amend the test name to reflect that
+check_for_ksm(){
+	if [ ! -f ${KSM_ENABLE_FILE} ]; then
+		return
+	fi
+
+	ksm_on=$(< ${KSM_ENABLE_FILE})
+
+	if [ $ksm_on == "1" ]; then
+		TEST_NAME="${TEST_NAME} ksm"
+	fi
+}
+
 # Wait for KSM to settle down, or timeout waiting
 # The basic algorithm is to look at the pages_shared value
 # at the end of every 'full scan', and if the value

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -324,4 +324,56 @@ disable_ksm(){
 	sudo bash -c "echo 0 > ${KSM_ENABLE_FILE}"
 }
 
+# Wait for KSM to settle down, or timeout waiting
+# The basic algorithm is to look at the pages_shared value
+# at the end of every 'full scan', and if the value
+# has changed very little, then we are done (because we presume
+# a full scan has managed to do few new merges)
+#
+# arg1 - timeout in seconds
+wait_ksm_settle(){
+	local t pcnt
+	local oldscan=-1 newscan
+	local oldpages=-1 newpages
+
+	oldscan=$(cat /sys/kernel/mm/ksm/full_scans)
+
+	# Go around the loop until either we see a small % change
+	# between two full_scans, or we timeout
+	for ((t=0; t<$1; t++)); do
+
+		newscan=$(cat /sys/kernel/mm/ksm/full_scans)
+		if (( newscan != oldscan )); then
+			echo -e "\nnew full_scan ($oldscan to $newscan)"
+
+			newpages=$(cat /sys/kernel/mm/ksm/pages_shared)
+			# Do we have a previous scan to compare with
+			echo "check pages $oldpages to $newpages"
+			if (( oldpages != -1 )); then
+				# avoid divide by zero problems
+				if (( $oldpages > 0 )); then
+					pcnt=$(( 100 - ((newpages * 100) / oldpages) ))
+					# abs()
+					pcnt=$(( $pcnt * -1 ))
+
+					echo "$oldpages to $newpages is ${pcnt}%"
+
+					if (( $pcnt <= 5 )); then
+						echo "KSM stabilised at ${t}s"
+						return
+					fi
+				else
+					echo "$oldpages KSM pages... waiting"
+				fi
+			fi
+			oldscan=$newscan
+			oldpages=$newpages
+		else
+			echo -n "."
+		fi
+		sleep 1
+	done
+	echo "Timed out after ${1}s waiting for KSM to settle"
+}
+
 common_init


### PR DESCRIPTION
Add a system level footprint test, that should be faster to run than the
existing footprint_data.sh test. It should be faster as it:
- launches containers in parallel, not just linearly
- does not take measurements after each launch, just at the start and end