### PR TITLE
CI: Do not require license header for text files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -341,16 +341,16 @@ check_license_headers()
 		--exclude=".git/*" \
 		--exclude=".gitignore" \
 		--exclude="Gopkg.lock" \
+		--exclude="LICENSE" \
 		--exclude="protocols/grpc/*.pb.go" \
 		--exclude="vendor/*" \
-		--exclude="LICENSE" \
 		--exclude="VERSION" \
+		--exclude="*.jpg" \
 		--exclude="*.json" \
 		--exclude="*.md" \
+		--exclude="*.png" \
 		--exclude="*.toml" \
 		--exclude="*.yaml" \
-		--exclude="*.png" \
-		--exclude="*.jpg" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -350,6 +350,7 @@ check_license_headers()
 		--exclude="*.md" \
 		--exclude="*.png" \
 		--exclude="*.toml" \
+		--exclude="*.txt" \
 		--exclude="*.yaml" \
 		-EL "\<${pattern}\>" \
 		$files || true)


### PR DESCRIPTION
Update the static check script to ignore text files when looking for
files that require a license header.

The `*.txt` extension is a generic file type so we cannot require a header since:

- We don't know what the file represents - it might be human-readable text or some other format without a unique file extension.
- Existing `*.md` doc files don't require a license header.

Also, semi-sorted the list of file patterns.

Fixes #769.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>