### PR TITLE
metrics: report: fix subdir check in makereport

### DIFF
--- a/metrics/report/makereport.sh
+++ b/metrics/report/makereport.sh
@@ -24,9 +24,9 @@ GUESTOUTPUTDIR="/outputdir/"
 
 setup() {
 	echo "Checking subdirectories"
-	check_subdir="$(cd ${HOSTINPUTDIR}; ls -dx */ > /dev/null 2>&1 | wc -l)"
+	check_subdir="$(ls -dx ${HOSTINPUTDIR}/*/ 2> /dev/null | wc -l)"
 	if [ $check_subdir -eq 0 ]; then
-		die "Subdirectory not found at metrics/results to store JSON results"
+		die "No subdirs in [${HOSTINPUTDIR}] to read results from."
 	fi
 
 	echo "Checking Dockerfile"


### PR DESCRIPTION
An early change slide in a stderr re-direct that broke the check
in the good case as well.
Fix that by moving the stderr redirect. Also, drop the chdir as it
is not needed, and can fail in itself.
Whilst here, improve the error message for when we do fail the dir
check.

Fixes: #776

Signed-off-by: Graham Whaley <graham.whaley@intel.com>