### PR TITLE
tests: Use overlay for CRI-O when running on zuul

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -83,6 +83,10 @@ if [ "$ID" == "fedora" ] || [ "$ID" == "centos" ]; then
 	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
 fi
 
+if [ "$ZUUL" = true ]; then
+	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
+fi
+
 echo "Ensure crio service is stopped before running the tests"
 if systemctl is-active --quiet crio; then
 	sudo systemctl stop crio


### PR DESCRIPTION
When running on Zuul, we might not get a block device
for testing CRI-O using devicemapper driver. This depends
on the region where the zuul slave is launched. Instead,
use overlay storage driver.

Fixes: #779

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>