### PR TITLE
teardown: Remove uncompressed log files before archiving them

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -125,6 +125,7 @@ collect_logs()
 
 		local prefix
 
+		# Compress log files
 		for prefix in $prefixes
 		do
 			gzip -9 "$prefix"*
@@ -132,6 +133,9 @@ collect_logs()
 
 		# The procenv logs are tiny so don't require chunking
 		gzip -9 "${procenv_user_log_path}" "${procenv_root_log_path}"
+
+		# Remove *.log files, which contain the uncompressed data.
+		rm -f *".log"
 
 		popd
 	else

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -110,6 +110,9 @@ collect_logs()
 		prefixes+=" ${crio_log_prefix}"
 		prefixes+=" ${docker_log_prefix}"
 		prefixes+=" ${kubelet_log_prefix}"
+		prefixes+=" ${ksm_throttler_log_prefix}"
+		prefixes+=" ${vc_throttler_log_prefix}"
+		prefixes+=" ${kernel_log_prefix}"
 
 		[ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
 


### PR DESCRIPTION
the `teardown.sh` collects and compresses log files, so that
jenkins can archive them, but we are also archiving the
uncompressed files, meaning that we are using more space
than the needed. With this, we remove the uncompressed log
files and save more space in the jenkins master.

Also, kernel, kata-vc-throttler and kata-ksm-throttler logs
will now be compressed.
