### PR TITLE
tests: Define Alpine version in the proper versions.yaml

### DIFF
--- a/metrics/density/memory_usage_inside_container.sh
+++ b/metrics/density/memory_usage_inside_container.sh
@@ -15,7 +15,9 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../lib/common.bash"
 
 TEST_NAME="memory footprint inside container"
-IMAGE="alpine:3.7"
+VERSIONS_FILE="${SCRIPT_PATH}/../../versions.yaml"
+ALPINE_VERSION=$("${GOPATH}/bin/yq" read "$VERSIONS_FILE" "docker_images.alpine.version")
+IMAGE="alpine:$ALPINE_VERSION"
 CMD="cat /proc/meminfo"
 TMP_FILE=$(mktemp meminfo.XXXXXXXXXX || true)
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -11,3 +11,8 @@ docker_images:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
     version: "1.14"
+
+  alpine:
+    description: "Linux distribution built around busybox and musl libc"
+    url: "https://hub.docker.com/_/alpine/"
+    version: "3.7"


### PR DESCRIPTION
For docker integration tests and memory tests, we are using a specific version
for the Alpine image. This version should be placed at versions.yaml in our
repository.

Fixes #795

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>