### PR TITLE
tests: Add sanity test after running integration and functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ifeq (${RUNTIME},)
 	$(error RUNTIME is not set)
 else
 	./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	bash sanity/check_sanity.sh
 endif
 
 docker: ginkgo
@@ -47,6 +48,7 @@ ifeq ($(RUNTIME),)
 	$(error RUNTIME is not set)
 else
 	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	bash sanity/check_sanity.sh
 endif
 
 crio:

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -7,6 +7,9 @@
 # This file contains common functions that
 # are being used by our metrics and integration tests
 
+# Place where virtcontainers keeps its active pod info
+VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
+
 die(){
 	msg="$*"
 	echo "ERROR: $msg" >&2
@@ -47,6 +50,27 @@ check_processes() {
 			die "Found unexpected ${i} present"
 		fi
 	done
+}
+
+# Checks that pods were not left
+check_pods() {
+	if [ -d ${VC_POD_DIR} ]; then
+		# Verify that pods were not left
+		pods_number=$(ls ${VC_POD_DIR} | wc -l)
+		if [ ${pods_number} -ne 0 ]; then
+			die "${pods_number} pods left and found at ${VC_POD_DIR}"
+		fi
+	else
+		echo "Not ${VC_POD_DIR} directory found"
+	fi
+}
+
+# Check that runtimes are not running, they should be transient
+check_runtimes() {
+	runtime_number=$(ps --no-header -C ${RUNTIME} | wc -l)
+	if [ ${runtime_number} -ne 0 ]; then
+		die "Unexpected runtime ${RUNTIME} running"
+	fi
 }
 
 # Clean environment, this function will try to remove all

--- a/sanity/check_sanity.sh
+++ b/sanity/check_sanity.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This will verify that before running integration and functional tests,
+# processes like hypervisor, shim and proxy are not running. It will
+# also check that not pod information is left and that we do not have
+# runtimes running as they should be transient.
+
+set -e
+
+cidir=$(dirname "$0")
+
+source "${cidir}/../lib/common.bash"
+
+main() {
+	# Check no processes are left behind
+	check_processes
+
+	# Verify that pods were not left
+	check_pods
+
+	# Verify that runtime is not running
+	check_runtimes
+}
+
+main


### PR DESCRIPTION
This will verify that processes like shim, hypervisor and proxy are not
left as well as that we do not have pods or runtimes running after
running our functional and integration tests.

Fixes #800

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>