### PR TITLE
tests: Check netmon process for the soak parallel test

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -36,6 +36,8 @@ extract_kata_env(){
 	HYPERVISOR_VERSION=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 
 	INITRD_PATH=$(awk '/^\[Initrd\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+	NETMON_PATH=$(awk '/^\[Netmon\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 }
 
 # Checks that processes are not running


### PR DESCRIPTION
This will enable the network monitor process at the configuration file as
well that it will verify that the number of netmons that are being launched
by this test are properly deleted.

Fixes #727

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>