### PR TITLE
test: Update k8s memory constraints tests

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -29,10 +29,9 @@ setup() {
 }
 
 @test "Running within memory constraints" {
-	skip "https://github.com/kata-containers/tests/issues/680"	
 	memory_limit_size="200Mi"
-	allocated_size="150M"
-	wait_time=120
+	allocated_size="100M"
+	wait_time=300
 	sleep_time=5
 	# Create test .yaml
         sed \


### PR DESCRIPTION
Update the value for allocated size memory for the k8s memory constraint test.  The amount of memory that can be allocated has decreased from 150M to 100M as it looks that the kernel is taking more memory.

Fixes #680

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>