### PR TITLE
CI: Add nemu 

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -23,6 +23,9 @@ echo "Install Kata Containers Kernel"
 if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	echo "Install Firecracker"
 	"${cidir}/install_firecracker.sh"
+elif [ "$KATA_HYPERVISOR" == "nemu" ]; then
+	echo "Install Nemu"
+	"${cidir}/install_nemu.sh"
 else
 	echo "Install Qemu"
 	"${cidir}/install_qemu.sh"

--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+source /etc/os-release || source /usr/lib/os-release
+
+versions_file="${cidir}/../versions.yaml"
+arch=$("${cidir}"/kata-arch.sh -d)
+
+install_nemu() {
+	local nemu_repo=$(get_version "assets.hypervisor.nemu.url")
+	local nemu_version=$(get_version "assets.hypervisor.nemu.version")
+	case "$arch" in
+	x86_64)
+		local nemu_bin="qemu-system-${arch}_virt"
+		;;
+	aarch64)
+		local nemu_bin="qemu-system-${arch}"
+		;;
+	*)
+		die "Unsupported architecture: $arch"
+		;;
+	esac
+
+	curl -LO "${nemu_repo}/releases/download/${nemu_version}/${nemu_bin}"
+	sudo install -o root -g root -m 0755 "${nemu_bin}" "/usr/local/bin"
+	rm -rf "${nemu_bin}"
+}
+
+install_firmware() {
+	local firmware="OVMF.fd"
+	local firmware_repo=$(get_version "assets.hypervisor.nemu-ovmf.url")
+	local firmware_version=$(get_version "assets.hypervisor.nemu-ovmf.version")
+	local firmware_dir="/usr/share/nemu/firmware"
+
+	sudo mkdir -p "${firmware_dir}"
+	curl -LO "${firmware_repo}/releases/download/${firmware_version}/${firmware}"
+	sudo install -o root -g root -m 0644 "${firmware}" "${firmware_dir}"
+	rm -f "${firmware}"
+}
+
+install_nemu
+install_firmware

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -43,6 +43,9 @@ chronic sudo -E yum install -y libtool libtool-ltdl-devel device-mapper-persiste
 echo "Install qemu dependencies"
 chronic sudo -E yum install -y libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel
 
+echo "Install nemu dependencies"
+chronic sudo -E yum install -y brlapi
+
 echo "Install kernel dependencies"
 chronic sudo -E yum -y install elfutils-libelf-devel flex
 

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -28,6 +28,9 @@ echo "Install qemu dependencies"
 chronic sudo -E dnf -y install libcap-devel libattr-devel \
 	libcap-ng-devel zlib-devel pixman-devel librbd-devel
 
+echo "Install nemu dependencies"
+chronic sudo -E dnf -y install brlapi
+
 echo "Install kernel dependencies"
 chronic sudo -E dnf -y install elfutils-libelf-devel flex
 

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -23,6 +23,9 @@ chronic sudo -E apt install -y libtool automake autotools-dev autoconf bc alien 
 echo "Install qemu dependencies"
 chronic sudo -E apt install -y libcap-dev libattr1-dev libcap-ng-dev librbd-dev
 
+echo "Install nemu dependencies"
+chronic sudo -E apt install -y libbrlapi0.6
+
 echo "Install kernel dependencies"
 chronic sudo -E apt install -y libelf-dev flex
 

--- a/integration/netmon/netmon_test.bats
+++ b/integration/netmon/netmon_test.bats
@@ -14,6 +14,10 @@ CONTAINER_NAME="containerA"
 PAYLOAD_ARGS="tail -f /dev/null"
 
 setup() {
+	if [ "$KATA_HYPERVISOR" == "nemu" ]; then
+		skip " issue: https://github.com/kata-containers/runtime/issues/1003"
+	fi
+
 	clean_env
 
 	# Check that processes are not running
@@ -28,6 +32,10 @@ setup() {
 }
 
 @test "test netmon" {
+	if [ "$KATA_HYPERVISOR" == "nemu" ]; then
+		skip " issue: https://github.com/kata-containers/runtime/issues/1003"
+	fi
+
 	# Create network
 	docker network create $NETWORK_NAME
 
@@ -65,6 +73,10 @@ setup() {
 }
 
 teardown() {
+	if [ "$KATA_HYPERVISOR" == "nemu" ]; then
+		skip " issue: https://github.com/kata-containers/runtime/issues/1003"
+	fi
+
 	clean_env
 
 	extract_kata_env


### PR DESCRIPTION
Add script to install nemu.
Modify setup.sh to install nemu instead of
qemu when the USE_NEMU=true envar is found.
Also update runtime's configuration with correct
nemu path, machine type and firmware when running
with nemu.

Fixes #807.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>