### PR TITLE
CI: tests: reduce output by using chronic

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -20,6 +20,7 @@ This directory contains scripts used by the [Kata Containers](https://github.com
 | `install_*` | Install various parts of the system and dependencies. |
 | `jenkins_job_build.sh` | Called by the [Jenkins CI](https://github.com/kata-containers/ci) to trigger a CI run. |
 | `kata-arch.sh` | Displays architecture name in various formats. |
+| `kata_chronic.sh` | Runs commands under `chronic`, whilst generating a heartbeat ticker. |
 | `kata-doc-to-script.sh` | Convert a [Github-Flavoured Markdown](https://github.github.com/gfm/) document to a shell script. |
 | `kata-find-stale-skips.sh` | Find skipped tests that can be unskipped. |
 | `kata-simplify-log.sh` | Simplify a logfile to make it easer to `diff(1)`. |

--- a/.ci/kata_chronic.sh
+++ b/.ci/kata_chronic.sh
@@ -10,6 +10,7 @@
 
 cmdLine=$@
 
+echo "TESTING [${cmdLine[@]}"
 eval chronic "${cmdLine[@]}" &
 cmdPid="$!"
 

--- a/.ci/kata_chronic.sh
+++ b/.ci/kata_chronic.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Use chronic to mute the output of a command, unless it errors.
+# But, to prevent system timeouts from complete inactivity, periodically
+# output '.'s to keep the system looking alive...
+
+cmdLine=$@
+
+eval chronic "${cmdLine[@]}" &
+cmdPid="$!"
+
+(
+	sleepval=10
+	echoval=60
+	count=0
+	while true; do
+		printf ".";sleep ${sleepval};
+		((count+=${sleepval}))
+		printf $count
+		((count%${echoval} == 0)) && printf ":\n" && count=0
+	done
+)&
+
+printerPid="$!"
+
+wait "$cmdPid"
+ret=$?
+printf "\n"
+kill "$printerPid"
+
+# And return the exit code from the sub-command
+exit "$ret"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+ifeq ($(CI),true)
+V              = @
+else
+V              = 1
+endif
+Q              = $(V:1=)
+QUIET_TEST     = $(Q:@=@echo    '     TEST    '$@;./.ci/kata_chronic.sh )
+
 # The time limit in seconds for each test
 TIMEOUT := 60
 
@@ -39,78 +47,74 @@ functional: ginkgo
 ifeq (${RUNTIME},)
 	$(error RUNTIME is not set)
 else
-	./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-	bash sanity/check_sanity.sh
+	$(QUIET_TEST) ./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	$(QUIET_TEST) bash sanity/check_sanity.sh
 endif
 
 docker: ginkgo
 ifeq ($(RUNTIME),)
 	$(error RUNTIME is not set)
 else
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-	bash sanity/check_sanity.sh
+	$(QUIET_TEST) ./ginkgo --succinct --trace -focus "${FOCUS}" -skip "${SKIP}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	$(QUIET_TEST) bash sanity/check_sanity.sh
 endif
 
 crio:
-	bash .ci/install_bats.sh
-	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
+	$(QUIET_TEST) bash .ci/install_bats.sh
+	$(QUIET_TEST) bash -c "RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh"
 
 docker-compose:
-	bash .ci/install_bats.sh
-	cd integration/docker-compose && \
-	bats docker-compose.bats
+	$(QUIET_TEST) bash .ci/install_bats.sh
+	$(QUIET_TEST) bats ./integration/docker-compose/docker-compose.bats
 
 docker-stability:
-	systemctl is-active --quiet docker || sudo systemctl start docker
-	cd integration/stability && \
-	export ITERATIONS=2 && export MAX_CONTAINERS=20 && chronic ./soak_parallel_rm.sh
+	$(QUIET_TEST) bash -c "systemctl is-active --quiet docker || sudo systemctl start docker"
+	$(QUIET_TEST) bash -c "ITERATIONS=2 MAX_CONTAINERS=20 ./integration/stability/soak_parallel_rm.sh"
 
 kubernetes:
-	bash -f .ci/install_bats.sh
-	bash -f integration/kubernetes/run_kubernetes_tests.sh
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bash -f integration/kubernetes/run_kubernetes_tests.sh
 
 swarm:
-	systemctl is-active --quiet docker || sudo systemctl start docker
-	bash -f .ci/install_bats.sh
-	cd integration/swarm && \
-	bats swarm.bats
+	$(QUIET_TEST) bash -c "systemctl is-active --quiet docker || sudo systemctl start docker"
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bats integration/swarm/swarm.bats
 
 cri-containerd:
-	bash integration/containerd/cri/integration-tests.sh
+	$(QUIET_TEST) bash integration/containerd/cri/integration-tests.sh
 
 log-parser:
-	make -C cmd/log-parser
+	$(QUIET_TEST) make -C cmd/log-parser
 
 openshift:
-	bash -f .ci/install_bats.sh
-	bash -f integration/openshift/run_openshift_tests.sh
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bash -f integration/openshift/run_openshift_tests.sh
 
 pentest:
-	bash -f pentest/all.sh
+	$(QUIET_TEST) bash -f pentest/all.sh
 
 vm-factory:
-	bash -f integration/vm_factory/vm_templating_test.sh
+	$(QUIET_TEST) bash -f integration/vm_factory/vm_templating_test.sh
 
 
 network:
-	systemctl is-active --quiet docker || sudo systemctl start docker
-	bash -f .ci/install_bats.sh
-	bats integration/network/macvlan/macvlan_driver.bats
-	bats integration/network/ipvlan/ipvlan_driver.bats
-	bats integration/network/disable_net/net_none.bats
+	$(QUIET_TEST) bash -c "systemctl is-active --quiet docker || sudo systemctl start docker"
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bats integration/network/macvlan/macvlan_driver.bats
+	$(QUIET_TEST) bats integration/network/ipvlan/ipvlan_driver.bats
+	$(QUIET_TEST) bats integration/network/disable_net/net_none.bats
 
 ramdisk:
-	bash -f integration/ramdisk/ramdisk.sh
+	$(QUIET_TEST) bash -f integration/ramdisk/ramdisk.sh
 
 entropy:
-	bash -f .ci/install_bats.sh
-	cd integration/entropy && \
-	bats entropy_test.bats
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bats integration/entropy/entropy_test.bats
 
 netmon:
-	systemctl is-active --quiet docker || sudo systemctl start docker
-	bash -f .ci/install_bats.sh
-	bats integration/netmon/netmon_test.bats
+	$(QUIET_TEST) bash -c "systemctl is-active --quiet docker || sudo systemctl start docker"
+	$(QUIET_TEST) bash -f .ci/install_bats.sh
+	$(QUIET_TEST) bats integration/netmon/netmon_test.bats
 
 test: ${UNION}
 


### PR DESCRIPTION
We only really want to see the tests that fail. Wrap the
test invocations in chronic to reduce the output.

Fixes: #809

Signed-off-by: Graham Whaley <graham.whaley@intel.com>