### PR TITLE
CI: Add vendor check to static checks script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -73,8 +73,8 @@ Parameters:
 
   help      : Show usage.
   repo-name : GitHub URL of repo to check in form "github.com/user/repo"
-              (equivalent to "--repo $URL").
-  true      : Specify as "true" if testing the a specific branch, else assume a
+              (equivalent to "--repo \$URL").
+  true      : Specify as "true" if testing a specific branch, else assume a
               PR branch (equivalent to "--all").
 
 Notes:

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -20,6 +20,7 @@ script_name=${0##*/}
 repo=""
 specific_branch="false"
 force="false"
+branch=${branch:-master}
 
 typeset -A long_options
 
@@ -31,6 +32,7 @@ long_options=(
 	[golang]="Check '.go' files"
 	[help]="Display usage statement"
 	[licenses]="Check licenses"
+	[branch]="Specify upstream branch to compare against (default '$branch')"
 	[all]="Force checking of all changes, including files in the base branch"
 	[repo:]="Specify GitHub URL of repo to use (github.com/user/repo)"
 	[versions]="Check versions files"
@@ -596,6 +598,7 @@ main()
 	do
 		case "$1" in
 			--all) specific_branch="true" ;;
+			--branch) branch="$2"; shift ;;
 			--commits) func=check_commits ;;
 			--docs) func=check_docs ;;
 			--files) func=check_files ;;

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -595,6 +595,7 @@ main()
 	while [ $# -gt 1 ]
 	do
 		case "$1" in
+			--all) specific_branch="true" ;;
 			--commits) func=check_commits ;;
 			--docs) func=check_docs ;;
 			--files) func=check_files ;;
@@ -602,7 +603,6 @@ main()
 			--golang) func=check_go ;;
 			-h|--help) usage; exit 0 ;;
 			--licenses) func=check_license_headers ;;
-			--all) specific_branch="true" ;;
 			--repo) repo="$2"; shift ;;
 			--versions) func=check_versions ;;
 			--) shift; break ;;

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -110,9 +110,9 @@ pkg_to_path()
 	go list -f '{{.Dir}}' "$pkg"
 }
 
-# Obtain a list of the files the PR changed, ignoring vendor files.
+# Obtain a list of the files the PR changed.
 # Returns the information in format "${filter}\t${file}".
-get_pr_changed_file_details()
+get_pr_changed_file_details_full()
 {
 	# List of filters used to restrict the types of file changes.
 	# See git-diff-tree(1) for further info.
@@ -138,7 +138,14 @@ get_pr_changed_file_details()
 		-r \
 		--name-status \
 		--diff-filter="${filters}" \
-		"origin/${branch}" HEAD | grep -v "vendor/"
+		"origin/${branch}" HEAD
+}
+
+# Obtain a list of the files the PR changed, ignoring vendor files.
+# Returns the information in format "${filter}\t${file}".
+get_pr_changed_file_details()
+{
+	get_pr_changed_file_details_full | grep -v "vendor/"
 }
 
 check_commits()


### PR DESCRIPTION
Add a new test (and `--vendor` option) to the static checks script that
detects if the user modified vendored files directly without updating
the vendor control file.

Also contains a few minor fixes, including one to set the crucial `$branch` variable when running standalone.

Fixes #818.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
