### PR TITLE
CI: run kata-check with sudo

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -36,7 +36,8 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 build_and_install "github.com/kata-containers/runtime"
 
 # Check system supports running Kata Containers
-kata-runtime kata-check
+kata_runtime_path=$(command -v kata-runtime)
+sudo -E PATH=$PATH "$kata_runtime_path" kata-check
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file


### PR DESCRIPTION
If/when https://github.com/kata-containers/runtime/pull/819
gets merged, kata-check will need to run with sudo as
it will try to load the kernel modules if they are not
already loaded.

Fixes: #822.

Depends-on: github.com/kata-containers/runtime#819

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>