### PR TITLE
CI: Make license checker ignore public key files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -359,6 +359,7 @@ check_license_headers()
 		--exclude="*.json" \
 		--exclude="*.md" \
 		--exclude="*.png" \
+		--exclude="*.pub" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \
 		--exclude="*.yaml" \


### PR DESCRIPTION
Update the license checker function in the static checks script to
ignore `*.pub` key files.

Fixes #826.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>