### PR TITLE
tests: Enable docker run integration test.

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -253,7 +253,6 @@ var _ = Describe("run host networking", func() {
 
 	Context("Run with host networking", func() {
 		It("should error out", func() {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/652")
 			args = []string{"--name", id, "-d", "--net=host", DebianImage, "sh"}
 			_, stderr, exitCode = dockerRun(args...)
 			Expect(exitCode).NotTo(Equal(0))


### PR DESCRIPTION
Enable docker integration test that verifies than when a host networking
is requested the runtime fails.

Fixes #833

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>