### PR TITLE
CI: Make static check ignore local URLs

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -466,6 +466,10 @@ check_docs()
 				info "ignoring new (but correct) URL: $url" && continue
 		fi
 
+		# Ignore local URLs. The only time these are used is in
+		# examples (meaning these URLs won't exist).
+		echo "$url" | grep -q "^file://" && continue
+
 		# Ignore the install guide URLs that contain a shell variable
 		echo "$url" | grep -q "\\$" && continue
 


### PR DESCRIPTION
Update the static check script to ignore `file://` URLs which won't
exist (since they only appear in examples).

Fixes #837.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>