### PR TITLE
CI: Fix xurls URL

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -385,7 +385,7 @@ check_docs()
 	if [ ! "$(command -v $cmd)" ]
 	then
 		info "Installing $cmd utility"
-		go get -u "mvdan.cc/xurls/cmd/$cmd"
+		go get -u "github.com/mvdan/xurls/cmd/${cmd}"
 	fi
 
 	info "Checking documentation"


### PR DESCRIPTION
The `xurls` tool used by the static checker seems to have changed its
URL so switch to the (hopefully more reliable!) github one.

Fixes: #835.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>