### PR TITLE
CI: Really fix xurls URL issue

### DIFF
--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -101,9 +101,11 @@ case "$(arch)" in
 		;;
 esac
 
+archive="go${go_version}.linux-${goarch}.tar.gz"
+
 info "Download go version ${go_version}"
-curl -OL "https://storage.googleapis.com/golang/go${go_version}.linux-${goarch}.tar.gz"
+curl -OL "https://storage.googleapis.com/golang/${archive}"
 info "Install go"
 mkdir -p "${install_dest}"
-sudo tar -C "${install_dest}" -xzf "go${go_version}.linux-${goarch}.tar.gz"
+sudo tar -C "${install_dest}" -xzf "${archive}"
 popd

--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -109,3 +109,17 @@ info "Install go"
 mkdir -p "${install_dest}"
 sudo tar -C "${install_dest}" -xzf "${archive}"
 popd
+
+# Make sure we use the golang version we just installed
+goroot="${install_dest}/go"
+
+[ -d "${goroot}" ] || die "failed to find expected golang path ${goroot} (from ${archive})"
+
+export GOROOT="${goroot}"
+
+gorootbin="${GOROOT}/bin"
+[ -d "${gorootbin}" ] || die "failed to find expected golang binary path ${gorootbin} (from ${archive})"
+
+export PATH="${gorootbin}:$PATH"
+
+info "Using golang binary $(command -v go) version $(go version)"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -385,7 +385,7 @@ check_docs()
 	if [ ! "$(command -v $cmd)" ]
 	then
 		info "Installing $cmd utility"
-		go get -u "github.com/mvdan/xurls/cmd/${cmd}"
+		go get -u -v "mvdan.cc/xurls/cmd/${cmd}" 2>&1
 	fi
 
 	info "Checking documentation"


### PR DESCRIPTION
Effectively reverted #839 as the real problem appears to be that although the CI is *downloading and installing* the correct version of golang, it's not actually *using* it.

I noticed this because xurls has recently changed the minimum golang version needed to run it to 1.10.3+:

- https://github.com/mvdan/xurls/blob/master/README.md

Testing locally, the old `go get` for xurls works fine but not with versions of go < 1.10.3.

However, although this PR resolves the issue in this repo, we still need to update golang to 1.10.3+ so this PR will fail until the following one lands:

- https://github.com/kata-containers/runtime/pull/744
