### PR TITLE
tests: Enable test that processes are not running

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -201,7 +201,6 @@ var _ = Describe("run nonexistent command", func() {
 
 	Context("Running nonexistent command", func() {
 		It("container and its components should not exist", func() {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/366")
 			args = []string{"--rm", "--name", id, Image, "does-not-exist"}
 			_, _, exitCode = dockerRun(args...)
 			Expect(exitCode).NotTo(Equal(0))


### PR DESCRIPTION
Now that issue https://github.com/kata-containers/runtime/issues/366 has
been solved, we can enable the test that check that qemu and kata-proxy
processes are not there after a container failure.

Fixes #844

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>