### PR TITLE
cmd/kata-manager: Remove debug output

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -391,8 +391,6 @@ setup()
 	if [ -z "$kata_repos_base" ]; then
 		kata_repos_base="$HOME/go"
 	fi
-
-	echo "kata_repos_base=$kata_repos_base"
 }
 
 parse_args()


### PR DESCRIPTION
Remove a stray `echo`.

Fixes #847.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>