### PR TITLE
metrics: report: Add net-cpu and in-container-mem tests

### DIFF
--- a/metrics/report/grabdata.sh
+++ b/metrics/report/grabdata.sh
@@ -119,6 +119,9 @@ run_density_ksm() {
 	PAYLOAD_ARGS=" "
 	PAYLOAD_RUNTIME_ARGS=" -m 8G"
 	bash density/footprint_data.sh
+
+	# Get a measure for the overhead we take from the container memory
+	bash density/memory_usage_inside_container.sh
 }
 
 run_density() {
@@ -148,7 +151,7 @@ run_storage() {
 }
 
 run_network() {
-	echo "No network tests to run"
+	bash network/cpu_statistics_iperf.sh
 }
 
 # Execute metrics scripts

--- a/metrics/report/report_dockerfile/lifecycle-time.R
+++ b/metrics/report/report_dockerfile/lifecycle-time.R
@@ -99,6 +99,7 @@ rstats_names=rbind(rstats_names, "Units")
 if (length(resultdirs) == 2) {
 	# This is a touch hard wired - but we *know* we only have two
 	# datasets...
+	diff=c()
 	for( i in 1:5) {
 		difference = as.double(rstats[2,i]) - as.double(rstats[1,i])
 		val = 100 * (difference/as.double(rstats[1,i]))

--- a/metrics/report/report_dockerfile/mem-in-cont.R
+++ b/metrics/report/report_dockerfile/mem-in-cont.R
@@ -1,0 +1,143 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Analyse the runtime component memory footprint data.
+
+library(ggplot2)					# ability to plot nicely.
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+testnames=c(
+	"memory-footprint-inside-container"
+)
+
+data=c()
+rstats=c()
+rstats_rows=c()
+rstats_cols=c()
+
+# For each set of results
+for (currentdir in resultdirs) {
+	dirstats=c()
+	# For the two different types of memory footprint measures
+	for (testname in testnames) {
+		# R seems not to like double path slashes '//' ?
+		fname=paste(inputdir, currentdir, testname, '.json', sep="")
+		if ( !file.exists(fname)) {
+			warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+		fdata=fdata[[testname]]
+		# Copy the average result into a shorter, more accesible name
+		fdata$requested=fdata$Results$memrequest$Result
+		fdata$total=fdata$Results$memtotal$Result
+		fdata$free=fdata$Results$memfree$Result
+		fdata$avail=fdata$Results$memavailable$Result
+
+		# And lets work out what % we have 'lost' between the amount requested
+		# and the total the container actually sees.
+		fdata$lost=fdata$requested - fdata$total
+		fdata$pctotal= 100 * (fdata$lost/ fdata$requested)
+
+		fdata$Runtime=rep(datasetname, length(fdata$Result) )
+
+		# Store away the bits we need
+		data=rbind(data, data.frame(
+			Result=fdata$requested,
+			Type="requested",
+			Runtime=fdata$Runtime ))
+			
+		data=rbind(data, data.frame(
+			Result=fdata$total,
+			Type="total",
+			Runtime=fdata$Runtime ))
+			
+		data=rbind(data, data.frame(
+			Result=fdata$free,
+			Type="free",
+			Runtime=fdata$Runtime ))
+
+		data=rbind(data, data.frame(
+			Result=fdata$avail,
+			Type="avail",
+			Runtime=fdata$Runtime ))
+
+		data=rbind(data, data.frame(
+			Result=fdata$lost,
+			Type="lost",
+			Runtime=fdata$Runtime ))
+
+		data=rbind(data, data.frame(
+			Result=fdata$pctotal,
+			Type="% consumed",
+			Runtime=fdata$Runtime ))
+
+		# Store away some stats for the text table
+		dirstats=rbind(dirstats, round(fdata$requested, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$total, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$free, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$avail, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$lost, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$pctotal, digits=2) )
+	}
+	rstats=cbind(rstats, dirstats)
+	rstats_cols=append(rstats_cols, datasetname)
+}
+
+rstats_rows=c("Requested", "Total", "Free", "Avail", "Consumed", "% Consumed")
+
+unts=c("Kb", "Kb", "Kb", "Kb", "Kb", "%")
+rstats=cbind(rstats, unts)
+rstats_cols=append(rstats_cols, "Units")
+
+# If we have only 2 sets of results, then we can do some more
+# stats math for the text table
+if (length(resultdirs) == 2) {
+	# This is a touch hard wired - but we *know* we only have two
+	# datasets...
+	diff=c()
+	# Just the first three entries - meaningless for the pctotal entry
+	for (n in 1:5) {
+		difference = (as.double(rstats[n,2]) - as.double(rstats[n,1]))
+		val = 100 * (difference/as.double(rstats[n,1]))
+		diff=rbind(diff, round(val, digits=2))
+	}
+
+	# Add a blank entry for the other entries
+	diff=rbind(diff, "")
+	rstats=cbind(rstats, diff)
+	rstats_cols=append(rstats_cols, "Diff %")
+}
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
+	theme=ttheme(base_size=10),
+	rows=rstats_rows, cols=rstats_cols
+	))
+
+bardata <- subset(data, Type %in% c("requested", "total", "free", "avail"))
+# plot how samples varioed over  'time'
+barplot <- ggplot() +
+	geom_bar(data=bardata, aes(Type, Result, fill=Runtime), stat="identity", position="dodge") +
+	xlab("Measure") +
+	ylab("Size (Kb)") +
+	ggtitle("In-container memory statistics") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+master_plot = grid.arrange(
+	barplot,
+	stats_plot,
+	nrow=2,
+	ncol=1 )
+

--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -53,6 +53,19 @@ rm(test_name_extra)
 ```
 \pagebreak
 
+# Memory used inside container
+This [test](https://github.com/kata-containers/tests/blob/master/metrics/density/memory_usage_inside_container.sh)
+measures the memory inside a container taken by the container runtime. It shows the difference between the amount of memory requested for the container, and the amount the container can actually 'see'.
+
+The *% Consumed* is the key row in the table, which compares the *Requested* against *Total* values.
+
+
+```{r, echo=FALSE, fig.cap="System Memory density"}
+source('mem-in-cont.R')
+```
+\pagebreak
+
+
 # Container Docker boot lifecycle times
 This [test](https://github.com/kata-containers/tests/blob/master/metrics/time/launch_times.sh)
 uses the `date` command on the host and in the container, as well as data from the container
@@ -85,6 +98,19 @@ source('fio-reads.R')
 
 ```{r, echo=FALSE, fig.cap="Storage I/O Writes", results='asis'}
 source('fio-writes.R')
+```
+\pagebreak
+
+# Network CPU costs
+
+Measure CPU costs whilst performing a fixed bandwidth container
+to container network test using
+this [test](https://github.com/kata-containers/tests/blob/master/metrics/network/cpu_statistics_iperf.sh).
+As local container-to-container networking is a pure local software activity, this test
+is a reasonable way to show changes in network stack processing costs.
+
+```{r, echo=FALSE, fig.cap="Storage I/O Writes", results='asis'}
+source('network-cpu.R')
 ```
 \pagebreak
 

--- a/metrics/report/report_dockerfile/network-cpu.R
+++ b/metrics/report/report_dockerfile/network-cpu.R
@@ -1,0 +1,133 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Analyse the runtime component memory footprint data.
+
+library(ggplot2)					# ability to plot nicely.
+							# So we can plot multiple graphs
+library(gridExtra)					# together.
+suppressMessages(suppressWarnings(library(ggpubr)))	# for ggtexttable.
+suppressMessages(library(jsonlite))			# to load the data.
+
+testnames=c(
+	"cpu-information"
+)
+
+resultsfilesshort=c(
+	"CPU"
+)
+
+data=c()
+rstats=c()
+rstats_rows=c()
+rstats_cols=c()
+
+Gdenom = (1000.0 * 1000.0 * 1000.0)
+
+# For each set of results
+for (currentdir in resultdirs) {
+	dirstats=c()
+	# For the two different types of memory footprint measures
+	for (testname in testnames) {
+		# R seems not to like double path slashes '//' ?
+		fname=paste(inputdir, currentdir, testname, '.json', sep="")
+		if ( !file.exists(fname)) {
+			warning(paste("Skipping non-existent file: ", fname))
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+		datasetvariant=resultsfilesshort[count]
+
+		# Import the data
+		fdata=fromJSON(fname)
+		fdata=fdata[[testname]]
+		# Copy the average result into a shorter, more accesible name
+		fdata$ips=fdata$Results$"instructions per cycle"$Result
+		fdata$Gcycles=fdata$Results$cycles$Result / Gdenom
+		fdata$Ginstructions=fdata$Results$instructions$Result / Gdenom
+		fdata$variant=rep(datasetvariant, length(fdata$Result) )
+		fdata$Runtime=rep(datasetname, length(fdata$Result) )
+
+		# Store away the bits we need
+		data=rbind(data, data.frame(
+			Result=fdata$ips,
+			Type="ips",
+			Runtime=fdata$Runtime,
+			variant=fdata$variant ) )
+		data=rbind(data, data.frame(
+			Result=fdata$Gcycles,
+			Type="Gcycles",
+			Runtime=fdata$Runtime,
+			variant=fdata$variant ) )
+		data=rbind(data, data.frame(
+			Result=fdata$Ginstructions,
+			Type="Ginstr",
+			Runtime=fdata$Runtime,
+			variant=fdata$variant ) )
+
+		# Store away some stats for the text table
+		dirstats=rbind(dirstats, round(fdata$ips, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$Gcycles, digits=2) )
+		dirstats=rbind(dirstats, round(fdata$Ginstructions, digits=2) )
+	}
+	rstats=cbind(rstats, dirstats)
+	rstats_cols=append(rstats_cols, datasetname)
+}
+
+rstats_rows=c("IPS", "GCycles", "GInstr")
+
+unts=c("Ins/Cyc", "G", "G")
+rstats=cbind(rstats, unts)
+rstats_cols=append(rstats_cols, "Units")
+
+# If we have only 2 sets of results, then we can do some more
+# stats math for the text table
+if (length(resultdirs) == 2) {
+	# This is a touch hard wired - but we *know* we only have two
+	# datasets...
+	diff=c()
+	for (n in 1:3) {
+		difference = (as.double(rstats[n,2]) - as.double(rstats[n,1]))
+		val = 100 * (difference/as.double(rstats[n,1]))
+		diff=rbind(diff, round(val, digits=2))
+	}
+	rstats=cbind(rstats, diff)
+	rstats_cols=append(rstats_cols, "Diff %")
+}
+
+# Build us a text table of numerical results
+stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
+	theme=ttheme(base_size=10),
+	rows=rstats_rows, cols=rstats_cols
+	))
+
+# plot how samples varioed over  'time'
+ipsdata <- subset(data, Type %in% c("ips"))
+ips_plot <- ggplot() +
+	geom_bar(data=ipsdata, aes(Type, Result, fill=Runtime), stat="identity", position="dodge") +
+	xlab("Measure") +
+	ylab("IPS") +
+	ggtitle("Instructions Per Cycle") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+cycdata <- subset(data, Type %in% c("Gcycles", "Ginstr"))
+cycles_plot <- ggplot() +
+	geom_bar(data=cycdata, aes(Type, Result, fill=Runtime), stat="identity", position="dodge", show.legend=FALSE) +
+	xlab("Measure") +
+	ylab("Count (G)") +
+	ggtitle("Cycles and Instructions") +
+	ylim(0, NA) +
+	theme(axis.text.x=element_text(angle=90))
+
+master_plot = grid.arrange(
+	ips_plot,
+	cycles_plot,
+	stats_plot,
+	nrow=2,
+	ncol=2 )
+


### PR DESCRIPTION
Add the network-cpu and in-container-memory consumption tests to the reportgen.
This will allow us to try and identify any:
 -  network CPU work related overheads
 - in-container memory overhead changes.