### PR TITLE
ci: Static checks for license should ignore any *.pb.go file

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -352,7 +352,6 @@ check_license_headers()
 		--exclude=".gitignore" \
 		--exclude="Gopkg.lock" \
 		--exclude="LICENSE" \
-		--exclude="protocols/grpc/*.pb.go" \
 		--exclude="vendor/*" \
 		--exclude="VERSION" \
 		--exclude="*.jpg" \
@@ -363,6 +362,7 @@ check_license_headers()
 		--exclude="*.toml" \
 		--exclude="*.txt" \
 		--exclude="*.yaml" \
+		--exclude="*.pb.go" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
All *.pb.go files are generated files from *.proto files. There is no
reason to ignore only the ones from protocols/grpc subdirectory.

Fixes #851

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>