### PR TITLE
ci: Exclude all *.pb.go files from gometalinter checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -244,7 +244,7 @@ check_go()
 	#
 	# Note that "--exclude=" patterns are *not* anchored meaning this will apply
 	# anywhere in the tree.
-	linter_args+=" --exclude=\"protocols/grpc/.*\.pb\.go\""
+	linter_args+=" --exclude=\".*\.pb\.go\""
 
 	# When running the linters in a CI environment we need to disable them all
 	# by default and then explicitly enable the ones we are care about. This is


### PR DESCRIPTION
Any *.pb.go file means auto-generated file. Therefore, there's no
reason to check the validity of those files with the gometalinter.

Fixes #853

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>