### PR TITLE
CI: Use specific version of xurls utility

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -35,7 +35,7 @@ function build() {
 		bash -f autogen.sh
 	fi
 
-	make
+	make ${make_target}
 
 	popd
 }

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -25,7 +25,7 @@ function build() {
 	make_target="$2"
 	project_dir="${GOPATH}/src/${github_project}"
 
-	[ -d "${project_dir}" ] || go get "${github_project}" || true
+	[ -d "${project_dir}" ] || go get -d "${github_project}" || true
 
 	pushd "${project_dir}"
 
@@ -37,7 +37,12 @@ function build() {
 		fi
 	fi
 
-	make ${make_target}
+	if [ -f Makefile ]; then
+		make ${make_target}
+	else
+		# install locally (which is what "go get" does by default)
+		go install ./...
+	fi
 
 	popd
 }

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -20,14 +20,23 @@ info() {
 	echo -e "INFO: $*"
 }
 
-function build() {
+function build_version() {
 	github_project="$1"
 	make_target="$2"
+	version="$3"
+
+	[ -z "${version}" ] && die "need version to build"
+
 	project_dir="${GOPATH}/src/${github_project}"
 
 	[ -d "${project_dir}" ] || go get -d "${github_project}" || true
 
 	pushd "${project_dir}"
+
+	if [ "$version" != "HEAD" ]; then
+		info "Using ${github_project} version ${version}"
+		git checkout -b "${version}" "${version}"
+	fi
 
 	info "Building ${github_project}"
 	if [ ! -f Makefile ]; then
@@ -45,6 +54,13 @@ function build() {
 	fi
 
 	popd
+}
+
+function build() {
+	github_project="$1"
+	make_target="$2"
+
+	build_version "${github_project}" "${make_target}" "HEAD"
 }
 
 function build_and_install() {

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -31,8 +31,10 @@ function build() {
 
 	info "Building ${github_project}"
 	if [ ! -f Makefile ]; then
-		info "Run autogen.sh to generate Makefile"
-		bash -f autogen.sh
+		if [ -f autogen.sh ]; then
+			info "Run autogen.sh to generate Makefile"
+			bash -f autogen.sh
+		fi
 	fi
 
 	make ${make_target}

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -385,7 +385,16 @@ check_docs()
 	if [ ! "$(command -v $cmd)" ]
 	then
 		info "Installing $cmd utility"
-		go get -u "github.com/mvdan/xurls/cmd/${cmd}"
+
+		local version
+		local url
+		local dir
+
+		version=$(get_test_version "externals.xurls.version")
+		url=$(get_test_version "externals.xurls.url")
+		dir=$(echo "$url"|sed 's!https://!!g')
+
+		build_version "${dir}" "" "${version}"
 	fi
 
 	info "Checking documentation"

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,11 +7,6 @@
 docker_images:
   description: "Docker hub images used for testing"
 
-  nginx:
-    description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
-    url: "https://hub.docker.com/_/nginx/"
-    version: "1.14"
-
   alpine:
     description: "Linux distribution built around busybox and musl libc"
     url: "https://hub.docker.com/_/alpine/"
@@ -21,3 +16,8 @@ docker_images:
     description: "Open source analytics and visualization platform"
     url: "https://hub.docker.com/_/kibana/"
     version: "6.4.0"
+
+  nginx:
+    description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
+    url: "https://hub.docker.com/_/nginx/"
+    version: "1.14"

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,6 +6,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+description: |
+  This file contains test specific version details.
+  For other version details, see the master database:
+
+  https://github.com/kata-containers/runtime/blob/master/versions.yaml
+
 docker_images:
   description: "Docker hub images used for testing"
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -29,3 +29,12 @@ docker_images:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
     version: "1.14"
+
+externals:
+  description: "Third-party projects used specifically for testing"
+
+  xurls:
+    description: |
+      Tool used by the CI to check URLs in documents and code comments.
+    url: "https://mvdan.cc/xurls/cmd/xurls"
+    version: "70405f5eab516c9f7b626d803b043415809499a6"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,3 +1,5 @@
+---
+
 #
 # Copyright (c) 2018 Intel Corporation
 #


### PR DESCRIPTION
Build the version of `xurls` specified in the runtimes versions
database to avoid problems; the latest version of `xurls` requires
golang 1.10.3 but that is not available in the stable branches.

Includes rework to the `.ci/lib.sh` functions to support building a particular version of a package.

Fixes #855.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
