### PR TITLE
CI: add force flag to install_go.sh

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -69,7 +69,7 @@ branch=
 # This ensures:
 # - We have latest changes in install_go.sh
 # - We got get changes if versions.yaml changed.
-${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p
+${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p -f
 
 # Make sure runc is default runtime.
 # This is needed in case a new image creation.


### PR DESCRIPTION
force flag will be used in the CI scripts to remove the
current golang version and install the correct one.
This is useful on baremetal machines where golang is already
installed and versions differ from the one needed to test kata.

Fixes: #857.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>