### PR TITLE
CI: add support for ppc64le to install_yq

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -71,6 +71,9 @@ function install_yq() {
 	"aarch64")
 		goarch=arm64
 		;;
+	"ppc64le")
+		goarch=ppc64le
+		;;
 	"x86_64")
 		goarch=amd64
 		;;


### PR DESCRIPTION
Needed now that we have a travis job for ppc64le.

Fixes #859.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>