### PR TITLE
metrics: report: optimise Dockerfile image creation

### DIFF
--- a/metrics/report/report_dockerfile/Dockerfile
+++ b/metrics/report/report_dockerfile/Dockerfile
@@ -9,29 +9,29 @@
 #  - pandoc
 #  - The report generation R files and helper scripts
 
-# I would have liked to have used from base rocker/verse, but that
-# does not have all the tools we need, and it seems that apt install
-# does not simply work - texlive for instance did not install.
-#
-# So, build up our image by hand then...
-FROM ubuntu
+# Start with the base rocker tidyverse.
+# We would have used the 'verse' base, that already has some of the docs processing
+# installed, but I could not figure out how to add in the extra bits we needed to
+# the lite tex version is uses.
+FROM rocker/tidyverse
 
 # Version of the Dockerfile
-LABEL DOCKERFILE_VERSION="1.0"
+LABEL DOCKERFILE_VERSION="1.1"
 
 # Without this some of the package installs stop to try and ask questions...
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-	apt-get install -y tzdata r-base pandoc texlive
+# Install the extra doc processing parts we need for our Rmarkdown PDF flow.
+RUN apt-get update -qq && \
+  apt-get install -y \
+    texlive-latex-base \
+    texlive-fonts-recommended \
+    latex-xcolor
 
-# R packages get built from source, and can take some time, so split them
-# into individual RUNs so we can make some later modifications without maybe taking
-# the full image rebuild hit.
-RUN Rscript -e "install.packages('tidyverse')"
-RUN Rscript -e "install.packages('knitr')"
-RUN Rscript -e "install.packages('gridExtra')"
-RUN Rscript -e "install.packages('ggpubr')"
+# Install the extra R packages we need.
+RUN install2.r --error --deps TRUE \
+	gridExtra \
+	ggpubr
 
 # Pull in our actual worker scripts
 COPY . /scripts


### PR DESCRIPTION
We were creating the Rmarkdown processing docker image pretty
much by hand (with apt and R installs), but this takes a lot of
time, particularly for the R parts, as they install from source.
Change the Dockerfile to use the official 'tidyverse' base, and
then install the R parts using the install2.r, which uses binaries
where possible. This speeds up the first-time image build.

Fixes: #862

Signed-off-by: Graham Whaley <graham.whaley@intel.com>