### PR TITLE
ci: build/install: [RFC] enable versioned builds from ci scripts

### DIFF
--- a/.ci/install_agent.sh
+++ b/.ci/install_agent.sh
@@ -11,4 +11,4 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/agent"
+build_and_install "github.com/kata-containers/agent" "" "$KATA_VERSION"

--- a/.ci/install_proxy.sh
+++ b/.ci/install_proxy.sh
@@ -11,4 +11,4 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/proxy"
+build_and_install "github.com/kata-containers/proxy" "" "$KATA_VERSION"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -33,7 +33,7 @@ runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
-build_and_install "github.com/kata-containers/runtime"
+build_and_install "github.com/kata-containers/runtime" "" "$KATA_VERSION"
 
 # Check system supports running Kata Containers
 kata_runtime_path=$(command -v kata-runtime)

--- a/.ci/install_shim.sh
+++ b/.ci/install_shim.sh
@@ -11,4 +11,4 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/shim"
+build_and_install "github.com/kata-containers/shim" "" "$KATA_VERSION"


### PR DESCRIPTION
Enable the build and install of kata components of a specified version, or default to HEAD if none is specified.