### PR TITLE
ci: detect the existence of yq before using filter scheme on aarch64

### DIFF
--- a/.ci/aarch64/filter_docker_aarch64.sh
+++ b/.ci/aarch64/filter_docker_aarch64.sh
@@ -19,6 +19,8 @@ it_skip_flag="docker.It"
 # value for '-skip' in ginkgo
 _skip_options=()
 
+source "${ci_dir}/lib.sh"
+
 filter_and_build()
 {
 	local dependency="$1"
@@ -33,6 +35,8 @@ filter_and_build()
 
 main()
 {
+	# install yq if not exist
+	[ -z "$(command -v yq)" ] && install_yq
 	# build skip option based on Describe block
 	filter_and_build "${describe_skip_flag}"
 

--- a/.ci/aarch64/filter_test_aarch64.sh
+++ b/.ci/aarch64/filter_test_aarch64.sh
@@ -16,8 +16,12 @@ test_filter_flag="test"
 
 _test_union=()
 
+source "${ci_dir}/lib.sh"
+
 main()
 {
+	# install yq if not exist
+	[ -z "$(command -v yq)" ] && install_yq
 	local array_test=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${test_filter_flag}")
 	[ "${array_test}" = "null" ] && return
 	mapfile -t _array_test <<< "${array_test}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -123,7 +123,7 @@ function install_yq() {
 	yq_version=$(basename "${yq_latest_url}")
 
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-	curl -o "${yq_path}" -L ${yq_url}
+	curl -o "${yq_path}" -LSs ${yq_url}
 	chmod +x ${yq_path}
 
 	if ! command -v "${yq_path}" >/dev/null; then


### PR DESCRIPTION
Since that filter schme on aarch64 bare-metal machine would fail if it is lack of yq, we should detect the existence of yq before going into and also install it if it is really missing.

Fixes: #867

Signed-off-by: Penny Zheng penny.zheng@arm.com