### PR TITLE
CI: Specify tmpdir for running golang unit tests

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -246,8 +246,11 @@ main()
 
 	[ -z "$test_packages" ] && echo "INFO: no golang code to test" && exit 0
 
+	# directory to use for temporary files
+	golang_tmp=$(mktemp -d)
+
 	# KATA_GO_TEST_FLAGS can be set to change the flags passed to "go test".
-	go_test_flags=${KATA_GO_TEST_FLAGS:-"-v $race -timeout $timeout_value"}
+	go_test_flags=${KATA_GO_TEST_FLAGS:-"-v $race -timeout $timeout_value -outputdir \"${golang_tmp}\""}
 
 	if [ "$1" = "html-coverage" ]; then
 		test_html_coverage
@@ -256,6 +259,8 @@ main()
 	else
 		test_local
 	fi
+
+	[ -d "${golang_tmp}" ] && [ "${golang_tmp}" != "/" ] && rm -rf "${golang_tmp}"
 }
 
 main "$@"

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -26,9 +26,6 @@ timeout_value=${KATA_GO_TEST_TIMEOUT:-30s}
 # enabling the flag depending on the arch.
 [ "$(go env GOARCH)" = "amd64" ] && race="-race"
 
-# KATA_GO_TEST_FLAGS can be set to change the flags passed to "go test".
-go_test_flags=${KATA_GO_TEST_FLAGS:-"-v $race -timeout $timeout_value"}
-
 # Notes:
 #
 # - The vendor filtering is required for versions of go older than 1.9.
@@ -248,6 +245,9 @@ main()
 	fi
 
 	[ -z "$test_packages" ] && echo "INFO: no golang code to test" && exit 0
+
+	# KATA_GO_TEST_FLAGS can be set to change the flags passed to "go test".
+	go_test_flags=${KATA_GO_TEST_FLAGS:-"-v $race -timeout $timeout_value"}
 
 	if [ "$1" = "html-coverage" ]; then
 		test_html_coverage


### PR DESCRIPTION
It is possible for the `go-test.sh` script to fail when attemping to
write to a file as it can already be closed. This problem seems to
relate to the golang `testing` package itself so work around the
problem by specifying an explicit temporary directory for `testing` to
create files in.

Fixes #869.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>