### PR TITLE
cri-o: update repository location

### DIFF
--- a/.ci/data/crio.service
+++ b/.ci/data/crio.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CRI-O daemon
-Documentation=https://github.com/kubernetes-incubator/cri-o
+Documentation=https://github.com/kubernetes-sigs/cri-o
 
 [Service]
 ExecStart=/usr/local/bin/crio --log-level debug

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -12,7 +12,8 @@ source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 
 echo "Get CRI-O sources"
-crio_repo="github.com/kubernetes-incubator/cri-o"
+kubernetes_sigs_org="github.com/kubernetes-sigs"
+crio_repo="${kubernetes_sigs_org}/cri-o"
 go get -d "$crio_repo" || true
 pushd "${GOPATH}/src/${crio_repo}"
 
@@ -45,7 +46,7 @@ if [ ! -e "${GOBIN}/go-md2man" ]; then
 fi
 
 echo "Get CRI Tools"
-critools_repo="github.com/kubernetes-incubator/cri-tools"
+critools_repo="${kubernetes_sigs_org}/cri-tools"
 go get "$critools_repo" || true
 pushd "${GOPATH}/src/${critools_repo}"
 critools_version=$(grep "ENV CRICTL_COMMIT" "${GOPATH}/src/${crio_repo}/Dockerfile" | cut -d " " -f3)

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -359,6 +359,7 @@ check_license_headers()
 		--exclude="*.md" \
 		--exclude="*.png" \
 		--exclude="*.pub" \
+		--exclude="*.service" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \
 		--exclude="*.yaml" \

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_PATH}/crio_skip_tests.sh"
 source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
-crio_repository="github.com/kubernetes-incubator/cri-o"
+crio_repository="github.com/kubernetes-sigs/cri-o"
 crio_repository_path="$GOPATH/src/${crio_repository}"
 
 # Check no processes are left behind


### PR DESCRIPTION
cri-o updated its location from the `kubernetes-incubator` org
to the `kubernetes-sigs`. Althogh the old org URL is
redirecting to the newest, lets update the location to avoid
future issues.

Fixes: #872.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>