### PR TITLE
tests: Add ipvlan driver tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ vm-factory:
 
 network:
 	bash -f .ci/install_bats.sh
-	cd integration/network/macvlan && \
-	bats macvlan_driver.bats
+	bats integration/network/macvlan/macvlan_driver.bats
+	bats integration/network/ipvlan/ipvlan_driver.bats
 
 ramdisk:
 	bash -f integration/ramdisk/ramdisk.sh

--- a/integration/network/ipvlan/ipvlan_driver.bats
+++ b/integration/network/ipvlan/ipvlan_driver.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
+
+# Environment variables
+IMAGE="debian"
+NETWORK_DRIVER="ipvlan"
+SUBNET_ADDR="10.54.10.0/24"
+FIRST_CONTAINER_NAME="containerA"
+SECOND_CONTAINER_NAME="containerB"
+FIRST_IP="10.54.10.2"
+SECOND_IP="10.54.10.3"
+PACKET_NUMBER="5"
+PAYLOAD="tail -f /dev/null"
+
+setup() {
+	clean_env
+
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	docker_configuration_path="/etc/docker"
+	# Check if directory exists
+	if [ ! -d $docker_configuration_path ]; then
+		sudo mkdir $docker_configuration_path
+	fi
+
+	# Check if daemon.json exists
+	docker_configuration_file=$docker_configuration_path/daemon.json
+	if [ -f $docker_configuration_file ]; then
+		# Check experimental flag is enabled
+		check_flag=$(grep '"experimental"\|true' $docker_configuration_file | wc -l)
+		if  [ $check_flag -eq 0 ]; then
+			# Enabling experimental flag at existing /etc/docker/daemon.json
+			sed -i "2 i \  \"\experimental\"\: true," $docker_configuration_file
+		fi
+	else
+		# Enabling experimental flag at /etc/docker/daemon.json
+		echo '{"experimental":true}' | sudo tee $docker_configuration_file
+	fi
+
+	# Restart docker
+	sudo systemctl restart docker
+}
+
+@test "ping container with ipvlan driver with mode l2" {
+	NETWORK_NAME="ipvlan2"
+	NETWORK_MODE="l2"
+
+	# Create network
+	docker network create -d ${NETWORK_DRIVER} --subnet=${SUBNET_ADDR} \
+		-o ipvlan_mode=${NETWORK_MODE} ${NETWORK_NAME}
+
+	# Run the first container
+	docker run -d --runtime=kata-runtime --network=${NETWORK_NAME} --ip=${FIRST_IP} \
+		--name=${FIRST_CONTAINER_NAME} --runtime=runc ${IMAGE} sh -c ${PAYLOAD}
+
+	# Run the second container
+	docker run -d --runtime=kata-runtime --network=${NETWORK_NAME} --ip=${SECOND_IP} \
+		--name=${SECOND_CONTAINER_NAME} --runtime=runc ${IMAGE} sh -c ${PAYLOAD}
+
+	# Ping to the first container
+	run docker exec ${SECOND_CONTAINER_NAME} sh -c "ping -c ${PACKET_NUMBER} ${FIRST_IP}"
+	[ "$status" -eq 0 ]
+}
+
+@test "ping container with ipvlan driver with mode l3" {
+	NETWORK_NAME="ipvlan3"
+	NETWORK_MODE="l3"
+
+	# Create network
+	docker network  create -d ${NETWORK_DRIVER} --subnet=${SUBNET_ADDR} \
+		-o ipvlan_mode=${NETWORK_MODE} ${NETWORK_NAME}
+
+	# Run the first container
+	docker run -d --runtime=kata-runtime --network=${NETWORK_NAME} --ip=${FIRST_IP} \
+		--name=${FIRST_CONTAINER_NAME} --runtime=runc ${IMAGE} sh -c ${PAYLOAD}
+
+	# Run the second container
+	docker run -d --runtime=kata-runtime --network=${NETWORK_NAME} --ip=${SECOND_IP} \
+		--name=${SECOND_CONTAINER_NAME} --runtime=runc ${IMAGE} sh -c ${PAYLOAD}
+
+	# Ping to the first container
+	run docker exec ${SECOND_CONTAINER_NAME} sh -c "ping -c ${PACKET_NUMBER} ${FIRST_IP}"
+	[ "$status" -eq 0 ]
+}
+
+teardown() {
+	clean_env
+
+	# Remove network
+	docker network rm ${NETWORK_NAME}
+
+	# Remove experimental flag
+	check_which_flag=$(grep -c -x '{"experimental":true}' $docker_configuration_file)
+	if [ $check_which_flag -eq 1 ]; then
+		rm -f $docker_configuration_path
+	else
+		sed -i 's|"experimental": true,||' $docker_configuration_file
+	fi
+
+	# Restart daemon to avoid issues in
+	# docker that says `start too quickly`
+	sudo systemctl daemon-reload
+
+	sudo systemctl restart docker
+
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Now that https://github.com/kata-containers/runtime/pull/852 has been merged,
we need to test docker integration tests with ipvlan driver with l2 and l3 mode.

Fixes #861

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>