### PR TITLE
CI: setup: docker: Delay when we reconfig docker

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -105,6 +105,11 @@ build_image() {
 	# Clone os-builder repository
 	go get -d "${osbuilder_repo}" || true
 
+	# Make sure runc is default runtime.
+	# The image builder with USER_DOCKER=true will not work otherwise.
+	# See https://github.com/clearcontainers/osbuilder/issues/8
+	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r runc -f
+
 	(cd "${GOPATH}/src/${osbuilder_repo}/rootfs-builder" && \
 		sudo -E AGENT_INIT="${AGENT_INIT}" AGENT_VERSION="${agent_commit}" \
 		GOPATH="$GOPATH" USE_DOCKER=true ./rootfs.sh "${OSBUILDER_DISTRO}")

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -71,11 +71,6 @@ branch=
 # - We got get changes if versions.yaml changed.
 ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p -f
 
-# Make sure runc is default runtime.
-# This is needed in case a new image creation.
-# See https://github.com/clearcontainers/osbuilder/issues/8
-"${GOPATH}/src/${tests_repo}/cmd/container-manager/manage_ctr_mgr.sh" docker configure -r runc -f
-
 if [ -n "$pr_number" ]; then
 	export branch="${ghprbTargetBranch}"
 	export pr_branch="PR_${pr_number}"


### PR DESCRIPTION
We were configuring docker to use runc very early on in the jenkins
run script, which would fail if docker was not already installed. And
then later we would install docker in setup.sh.

We only need to set runc as the default runtime if we are going to
do an osbuilder image build, so let's delay that setup until the
point where we need it, by which time docker should have been
installed.

Fixes: #878

Signed-off-by: Graham Whaley <graham.whaley@intel.com>