### PR TITLE
ci: skip memory integration tests on aarch64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -21,7 +21,9 @@ docker:
     - Update number of CPUs
     - Hot plug CPUs
     - Update CPU constraints
+    - memory constraints
+    - Hotplug memory when create containers
+    - run container and update its memory constraints
   Context:
     - remove bind-mount source before container exits
-    - run container exceeding memory constraints
   It:


### PR DESCRIPTION
Since the new feature: memory hotplug, which uses the `(qemu) device_add pcdimm,id=dimm1,memdev=mem1` to limit memory on runtime, is not availble on arm platform, for now we just have to resort to skip relevant tests in aarch64.

Fixes: #879

Signed-off-by: Penny Zheng penny.zheng@arm.com