### PR TITLE
metrics: report: fio latency: improve lat graph

### DIFF
--- a/metrics/report/report_dockerfile/fio-reads.R
+++ b/metrics/report/report_dockerfile/fio-reads.R
@@ -175,6 +175,7 @@ read_iops_line_plot <- ggplot() +
 # 95 and 99 percentile box plot
 read_clat_box_plot <- ggplot() +
 	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
+	stat_summary( data=all_ldata, aes(blocksize, percentile, group=runtime, color=runtime), fun.y=mean, geom="line") +
 	ylim(0, NA) +
 	ggtitle("Random Read completion latency", subtitle="95&98 percentiles, boxplot over jobs") +
 	xlab("Blocksize") +

--- a/metrics/report/report_dockerfile/fio-writes.R
+++ b/metrics/report/report_dockerfile/fio-writes.R
@@ -175,6 +175,7 @@ write_iops_line_plot <- ggplot() +
 # the blocksizes.
 write_clat_box_plot <- ggplot() +
 	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
+	stat_summary( data=all_ldata, aes(blocksize, percentile, group=runtime, color=runtime), fun.y=mean, geom="line") +
 	ylim(0, NA) +
 	ggtitle("Random Write completion latency", subtitle="95&98 Percentiles, boxplot across jobs") +
 	xlab("Blocksize") +


### PR DESCRIPTION
The fio 95/99 percentile boxplot fio results are quite hard
to read, especially if the data is noisy. Try to improve
the readability by joining the mean points across the
boxplot.

Fixes: #885

Signed-off-by: Graham Whaley <graham.whaley@intel.com>