### PR TITLE
test: Add entropy test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 TIMEOUT := 60
 
 # union for 'make test'
-UNION := functional docker crio docker-compose docker-stability openshift kubernetes swarm vm-factory ramdisk
+UNION := functional docker crio docker-compose docker-stability openshift kubernetes swarm vm-factory entropy ramdisk
 
 # skipped test suites for docker integration tests
 SKIP :=
@@ -100,6 +100,11 @@ network:
 ramdisk:
 	bash -f integration/ramdisk/ramdisk.sh
 
+entropy:
+	bash -f .ci/install_bats.sh
+	cd integration/entropy && \
+	bats entropy_test.bats
+
 test: ${UNION}
 
 check: checkcommits log-parser
@@ -112,6 +117,7 @@ check: checkcommits log-parser
 	docker \
 	docker-compose \
 	docker-stability \
+	entropy \
 	functional \
 	ginkgo \
 	kubernetes \

--- a/integration/entropy/entropy_test.bats
+++ b/integration/entropy/entropy_test.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# The main purpose of this test is to print
+# the entropy level inside the container after
+# we installed the haveged package. We need to
+# verify that the entropy level is not < 1000
+# https://wiki.archlinux.org/index.php/Haveged
+
+source /etc/os-release || source /usr/lib/os-release
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+# Environment variables
+IMAGE="busybox"
+# This the minimum entropy level produced
+# by haveged is 1000 see https://wiki.archlinux.org/index.php/Haveged
+# Less than 1000 could potentially slow down cryptographic
+# applications see https://www.suse.com/support/kb/doc/?id=7011351
+ENTROPY_LEVEL="1000"
+
+setup() {
+	clean_env
+
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	# Check if haveged package is installed
+	check_package=$(which haveged | wc -l)
+
+	# Install haveged package if is not installed
+	if [ $check_package -eq 0 ]; then
+		case "$ID" in
+			ubuntu )
+				sudo -E apt install -y haveged
+				;;
+			fedora )
+				sudo -E dnf -y install haveged
+				;;
+			centos )
+				sudo -E yum install -y haveged
+				;;
+			opensuse-* | sled | sles )
+				sudo -E zypper install -y haveged
+				;;
+		esac
+		sudo systemctl start haveged
+	fi
+}
+
+@test "check entropy level" {
+	run docker run --rm --runtime=${RUNTIME} ${IMAGE} sh -c "cat /proc/sys/kernel/random/entropy_avail"
+	echo "$output"
+	[ "$output" -ge ${ENTROPY_LEVEL} ]
+}
+
+teardown() {
+	clean_env
+
+	# Check that processes are not running
+	run check_processes
+	echo "$output"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The main purpose of this test is to print the entropy level
inside the container after we installed the haveged package.
We need to verify that the entropy level is not < 1000
https://wiki.archlinux.org/index.php/Haveged.

Fixes #734

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>