### PR TITLE
CI: baremetal: make cleanup scripts more generic

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -52,8 +52,15 @@ mkdir -p $(dirname "${kata_repo_dir}")
 
 # If CI running on bare-metal, a few clean-up work before walking into test repo
 if [ "${BAREMETAL}" == true ]; then
+	arch=$("${tests_repo_dir}/.ci/kata-arch.sh")
+	echo "Looking for baremetal cleanup script for arch ${arch}"
 	clean_up_script="${tests_repo_dir}/.ci/${arch}/clean_up_${arch}.sh"
-	[ -f "${clean_up_script}" ] && source "${clean_up_script}"
+	if [ -f "${clean_up_script}" ]; then
+		echo "Running baremetal cleanup script for arch ${arch}"
+		"${clean_up_script}"
+	else
+		echo "No baremetal cleanup script for arch ${arch}"
+	fi
 fi
 
 pushd "${kata_repo_dir}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright (c) 2017-2018 Intel Corporation
+# Copyright (c) 2018 ARM Limited
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -8,6 +9,10 @@
 set -e
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
+
+tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
+source "${lib_script}"
 
 # If we fail for any reason a message will be displayed
 die() {
@@ -186,3 +191,69 @@ function waitForProcess(){
         done
         return 1
 }
+
+kill_stale_process()
+{
+	clean_env
+	extract_kata_env
+	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
+	for stale_process in "${stale_process_union[@]}"; do
+		if pgrep -f "${stale_process}"; then
+			sudo killall -9 "${stale_process}" || true
+		fi
+	done
+}
+
+delete_stale_docker_resource()
+{
+	local docker_status=false
+	# check if docker service is running
+	systemctl is-active --quiet docker
+	if [ $? -eq 0 ]; then
+		docker_status=true
+		sudo systemctl stop docker
+	fi
+	# before removing stale docker dir, you should umount related resource
+	for stale_docker_mount_point in "${stale_docker_mount_point_union[@]}"; do
+		local mount_point_union=$(mount | grep "${stale_docker_mount_point}" | awk '{print $3}')
+		if [ -n "${mount_point_union}" ]; then
+			while IFS='$\n' read mount_point; do
+				sudo umount "${mount_point}"
+			done <<< "${mount_point_union}"
+		fi
+	done
+	# remove stale docker dir
+	for stale_docker_dir in "${stale_docker_dir_union[@]}"; do
+		if [ -d "${stale_docker_dir}" ]; then
+			sudo rm -rf "${stale_docker_dir}"
+		fi
+	done
+	[ "${docker_status}" = true ] && sudo systemctl restart docker
+}
+
+delete_stale_kata_resource()
+{
+	for stale_kata_dir in "${stale_kata_dir_union[@]}"; do
+		if [ -d "${stale_kata_dir}" ]; then
+			sudo rm -rf "${stale_kata_dir}"
+		fi
+	done
+}
+
+gen_clean_arch() {
+	# Set up some vars
+	stale_process_union=( "docker-containerd-shim" )
+	#docker supports different storage driver, such like overlay2, aufs, etc.
+	docker_storage_driver=$(docker info --format='{{.Driver}}')
+	stale_docker_mount_point_union=( "/var/lib/docker/containers" "/var/lib/docker/${docker_storage_driver}" )
+	stale_docker_dir_union=( "/var/lib/docker" )
+	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" )
+
+	info "kill stale process"
+	kill_stale_process
+	info "delete stale docker resource under ${stale_docker_dir_union[@]}"
+	delete_stale_docker_resource
+	info "delete stale kata resource under ${stale_kata_dir_union[@]}"
+	delete_stale_kata_resource
+}
+

--- a/.ci/x86_64/clean_up_x86_64.sh
+++ b/.ci/x86_64/clean_up_x86_64.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
 # Copyright (c) 2018 ARM Limited
+# Copyright (c) 2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
 
-tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 


### PR DESCRIPTION
Enable the bare metal slave machine cleanup scripts to be
called from any arch (lifting out the good work done for the
ARM slave cleanups).

Fixes: #888

Signed-off-by: Graham Whaley <graham.whaley@intel.com>