### PR TITLE
test: Enable K8s CPU test for containerd.

### DIFF
--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -20,8 +20,6 @@ setup() {
 }
 
 @test "Check CPU constraints" {
-	issue="https://github.com/kata-containers/tests/issues/794"
-	[ "${CRI_RUNTIME}" == "containerd" ] && skip "test not working with ${CRI_RUNTIME} see: ${issue}"
 	wait_time=120
 	sleep_time=5
 


### PR DESCRIPTION
Now that https://github.com/kata-containers/tests/pull/892 has been
merged, we can enable K8s CPU test for containerd.

Fixes #794

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>