### PR TITLE
.ci: Fix the indention for current_branch variable.

### DIFF
--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -73,7 +73,7 @@ clone_repos() {
 		# are already in the PR branch, before trying to fetch the same branch.
 		if [ ${repo} == ${tests_repo} ] && [ "${repo}" == "${kata_repo}" ]
 		then
-		current_branch=$(git rev-parse --abbrev-ref HEAD)
+			current_branch=$(git rev-parse --abbrev-ref HEAD)
 			if [ "${current_branch}" == "${pr_branch}" ]
 			then
 				echo "Already on branch ${current_branch}"


### PR DESCRIPTION
One more tab should be placed for the current_branch variable to fix
broken syntax.

Fixes #876

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>