### PR TITLE
Fix `manage_ctr_mgr.sh`

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -176,14 +176,15 @@ remove_docker(){
 	if [ -z "$pkg_name" ]; then
 		die "Docker not found in this system"
 	else
+		sudo systemctl stop docker
 		version=$(get_docker_version)
 		log_message "Removing package: $pkg_name version: $version"
 		if [ "$ID" == "ubuntu" ]; then
-			sudo apt -y purge "$pkg_name"
+			sudo apt -y purge ${pkg_name}
 		elif [ "$ID" == "fedora" ]; then
-			sudo dnf -y remove "$pkg_name"
+			sudo dnf -y remove ${pkg_name}
 		elif [ "$ID" == "centos" ]; then
-			sudo yum -y remove "$pkg_name"
+			sudo yum -y remove ${pkg_name}
 		else
 			die "This script doesn't support your Linux distribution"
 		fi

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -103,7 +103,7 @@ install_docker(){
 			curl -fsSL "${repo_url}/gpg" | sudo apt-key add -
 			sudo -E add-apt-repository "deb [arch=${arch}] ${repo_url} $(lsb_release -cs) stable"
 			sudo -E apt-get update
-			docker_version_full=$(apt-cache show $pkg_name | grep "^Version: $docker_version" | awk '{print $2}' | head -1)
+			docker_version_full=$(apt-cache madison $pkg_name | grep "$docker_version" | awk '{print $3}' | head -1)
 			sudo -E apt-get -y install "${pkg_name}=${docker_version_full}"
 		elif [ "$ID" == "fedora" ]; then
 			repo_url="https://download.docker.com/linux/fedora/docker-ce.repo"


### PR DESCRIPTION
use apt-cache madison to get docker version on ubuntu
- To get the proper docker version to install, we need to now use
`apt-cache madison` since `apt-cache show` is throwing an error.

- Stop the docker service before removing the
package.

- Do not quote `pkg_name` as it can contain more than
one package that we need to remove. e.g. `docker-ce` and
`docker-ce-cli`.

Fixes: #895