### PR TITLE
ci: cleanup: pass tests_repo to cleanup scripts

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -57,7 +57,7 @@ if [ "${BAREMETAL}" == true ]; then
 	clean_up_script="${tests_repo_dir}/.ci/${arch}/clean_up_${arch}.sh"
 	if [ -f "${clean_up_script}" ]; then
 		echo "Running baremetal cleanup script for arch ${arch}"
-		"${clean_up_script}"
+		tests_repo="${tests_repo}" "${clean_up_script}"
 	else
 		echo "No baremetal cleanup script for arch ${arch}"
 	fi


### PR DESCRIPTION
The baremetal cleanup scripts use `tests_repo` to find the funcs
to call, but that is not currently propagated from the caller.
Rather than export or source, let's pass it on the commandline
when calling the sub-scripts.

Fixes: #897

Signed-off-by: Graham Whaley <graham.whaley@intel.com>