### PR TITLE
tests: Add K8s test to check postStart handlers

### DIFF
--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+	pod_name="handlers"
+	pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+}
+
+@test "Running with postStart and preStop handlers" {
+	# Create the pod with postStart and preStop handlers
+	sudo -E kubectl create -f "${pod_config_dir}/lifecycle-events.yaml"
+
+	# Check pod creation
+	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check postStart message
+	display_message="cat /usr/share/message"
+	check_postStart=$(sudo -E kubectl exec $pod_name -- sh -c "$display_message" | grep "Hello from the postStart handler")
+}
+
+teardown(){
+	sudo -E kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -37,5 +37,6 @@ bats k8s-pid-ns.bats
 bats k8s-cpu-ns.bats
 bats k8s-memory.bats
 bats k8s-liveness-probes.bats
+bats k8s-attach-handlers.bats
 ./cleanup_env.sh
 popd

--- a/integration/kubernetes/untrusted_workloads/lifecycle-events.yaml
+++ b/integration/kubernetes/untrusted_workloads/lifecycle-events.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: handlers
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+  - name: handlers-container
+    image: nginx
+    lifecycle:
+      postStart:
+        exec:
+          command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+      preStop:
+        exec:
+          command: ["/usr/sbin/nginx","-s","quit"]


### PR DESCRIPTION
We create a Pod that has one container. The container has handlers for
postStart and preStop events and then we verify the message for the
postStart event.

Fixes #904

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>