### PR TITLE
ci: Add perf package to run PnP metrics

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -54,7 +54,7 @@ echo "Install YAML validator"
 chronic sudo -E apt install -y yamllint
 
 echo "Install tools for metrics tests"
-chronic sudo -E apt install -y smem jq
+chronic sudo -E apt install -y smem jq linux-tools-common linux-tools-`uname -r`
 
 if [ "$(arch)" == "x86_64" ]; then
 	echo "Install Kata Containers OBS repository"


### PR DESCRIPTION
While running the jenkins-metrics-ubuntu job, we have an error message saying
that PERF command is missing and with that some tests are not running. With
this change we are installing the packages that we need to have perf.

Fixes #763

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>