### PR TITLE
setup: add CI default value on setup.sh

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -15,6 +15,7 @@ source "${cidir}/lib.sh"
 
 arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_KATA="${INSTALL_KATA:-yes}"
+CI=${CI:-false}
 
 # values indicating whether related intergration tests have been supported
 CRIO="${CRIO:-yes}"


### PR DESCRIPTION
If CI envar is not found, the `setup.sh` script fails
because of an unbound variable.
Add default value of CI=false

Fixes #911.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>