### PR TITLE
ci: bare cleanup: never fail the cleanup

### DIFF
--- a/.ci/aarch64/clean_up_aarch64.sh
+++ b/.ci/aarch64/clean_up_aarch64.sh
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 
-gen_clean_arch
+gen_clean_arch || info "Arch cleanup scripts failed"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -e
-
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"

--- a/.ci/x86_64/clean_up_x86_64.sh
+++ b/.ci/x86_64/clean_up_x86_64.sh
@@ -5,9 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 
-gen_clean_arch
+gen_clean_arch || info "Arch cleanup scripts failed"


### PR DESCRIPTION
We should probably never fail the cleanup script call, as we may be trying to clean
an unstable or part-cleaned system. Stop requiring `-e`, and add an `|| true` to the top
level call.