### PR TITLE
ci: ensure cleanup/install of packages

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -35,10 +35,13 @@ install_packaged_qemu() {
 	# Timeout to download packages from OBS
 	limit=180
 	if [ "$ID"  == "ubuntu" ]; then
+		chronic sudo apt remove -y "$PACKAGED_QEMU" || true
 		chronic sudo apt install -y "$PACKAGED_QEMU" || rc=1
 	elif [ "$ID"  == "fedora" ]; then
+		chronic sudo dnf remove -y "$PACKAGED_QEMU" || true
 		chronic sudo dnf install -y "$PACKAGED_QEMU" || rc=1
 	elif [ "$ID"  == "centos" ]; then
+		chronic sudo yum remove -y "$PACKAGED_QEMU" || true
 		chronic sudo yum install -y "$PACKAGED_QEMU" || rc=1
 	else
 		die "Unrecognized distro"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -253,5 +253,7 @@ gen_clean_arch() {
 	delete_stale_docker_resource
 	info "delete stale kata resource under ${stale_kata_dir_union[@]}"
 	delete_stale_kata_resource
+	info "Remove installed kata packages"
+	${GOPATH}/src/${tests_repo}/cmd/kata-manager/kata-manager.sh remove-packages
 }
 


### PR DESCRIPTION
We have a glitch where installing qemu from packages could silently fail under some circumstances.
This has been seen on a bare metal CI machine.
Improve the situation by:
- making the package install more robust
- removing the packages in the bare metal cleanup scripts.