### PR TITLE
tests: Add K8s tests for persistent volumes

### DIFF
--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+	pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+	tmp_file=$(mktemp -d /tmp/data.XXXX)
+	msg="Hello from Kubernetes"
+	echo $msg > $tmp_file/index.html
+	pod_name="pv-pod"
+	# Define temporary file at yaml
+	sed -i "s|tmp_data|${tmp_file}|g" ${pod_config_dir}/pv-volume.yaml
+}
+
+@test "Create Persistent Volume" {
+	volume_name="pv-volume"
+	volume_claim="pv-claim"
+
+	# Create the persistent volume
+	sudo -E kubectl create -f "${pod_config_dir}/pv-volume.yaml"
+
+	# Check the persistent volume
+	sudo -E kubectl get pv $volume_name | grep Available
+
+	# Create the persistent volume claim
+	sudo -E kubectl create -f "${pod_config_dir}/volume-claim.yaml"
+
+	# Check the persistent volume claim
+	sudo -E kubectl get pvc $volume_claim | grep Bound
+
+	# Create pod
+	sudo -E kubectl create -f "${pod_config_dir}/pv-pod.yaml"
+
+	# Check pod creation
+	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+
+	cmd="cat /mnt/index.html"
+	sudo -E kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"
+}
+
+teardown() {
+	sudo -E kubectl delete pod "$pod_name"
+	sudo rm -rf $tmp_file
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -31,5 +31,6 @@ bats k8s-cpu-ns.bats
 bats k8s-memory.bats
 bats k8s-liveness-probes.bats
 bats k8s-attach-handlers.bats
+bats k8s-volume.bats
 ./cleanup_env.sh
 popd

--- a/integration/kubernetes/untrusted_workloads/pv-pod.yaml
+++ b/integration/kubernetes/untrusted_workloads/pv-pod.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pv-pod
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  volumes:
+    - name: pv-storage
+      persistentVolumeClaim:
+       claimName: pv-claim
+  containers:
+    - name: pv-container
+      image: busybox
+      ports:
+      command:
+        - sleep
+        - "120"
+      volumeMounts:
+        - mountPath: "/mnt/"
+          name: pv-storage

--- a/integration/kubernetes/untrusted_workloads/pv-volume.yaml
+++ b/integration/kubernetes/untrusted_workloads/pv-volume.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "tmp_data"

--- a/integration/kubernetes/untrusted_workloads/volume-claim.yaml
+++ b/integration/kubernetes/untrusted_workloads/volume-claim.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi


### PR DESCRIPTION
This test will create a persistent volume that is backed
by physical storage and then we will create a persistent
volume claim which will automatically bound to the persistent
volume and finally we will create a pod that uses a persistent
volume claim as a storage.

Fixes #921

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>