### PR TITLE
ci: metrics: do not enable debug for metrics CIs

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -47,9 +47,13 @@ if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	runtime_config_path="${NEW_RUNTIME_CONFIG}"
 fi
 
-echo "Enabling all debug options in file ${runtime_config_path}"
-sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
-sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${runtime_config_path}"
+if [ -z "${METRICS_CI}" ]; then
+	echo "Enabling all debug options in file ${runtime_config_path}"
+	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
+	sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${runtime_config_path}"
+else
+	echo "Metrics run - do not enable all debug options in file ${runtime_config_path}"
+fi
 
 if [ x"${TEST_INITRD}" == x"yes" ]; then
 	echo "Set to test initrd image"


### PR DESCRIPTION
We enable full debug in the CI install scripts, but that
costs us about 0.25s in boot time. Do not enable the debug
if we are doing a METRICS_CI build/run.

Fixes: #923

Signed-off-by: Graham Whaley <graham.whaley@intel.com>