### PR TITLE
ci: allow downgrades to install kubernetes

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -26,5 +26,4 @@ deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 chronic sudo -E apt update
-chronic sudo -E apt install -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
-
+chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"


### PR DESCRIPTION
ci scripts fail when the system has a new version of kubernetes,
to fix this problem --allow-downgrades must be used.

fixes #927

Signed-off-by: Julio Montes <julio.montes@intel.com>