### PR TITLE
cleanup: don't use killall, replace with kill

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -196,8 +196,9 @@ kill_stale_process()
 	extract_kata_env
 	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do
-		if pgrep -f "${stale_process}"; then
-			sudo killall -9 "${stale_process}" || true
+		local pids=$(pgrep -f "${stale_process}")
+		if [ -n "$pids" ]; then
+			sudo kill -9 "${pids}" || true
 		fi
 	done
 }


### PR DESCRIPTION
killall will only kill processes using the specified (exact)
binary. It will not kill off any processess running off a previously
unlinked binary (of the same name/path).
Replace the killall with a kill to clean up all processess of the
specified name.

Fixes: #92

Signed-off-by: Graham Whaley <graham.whaley@intel.com>