### PR TITLE
Cri install then configure

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly runtime_path=$(which ${RUNTIME:-kata-runtime})
+
+sudo mkdir -p /etc/containerd/
+cat << EOT | sudo tee /etc/containerd/config.toml
+[plugins]
+    [plugins.cri.containerd]
+          [plugins.cri.containerd.untrusted_workload_runtime]
+	          runtime_type = "io.containerd.runtime.v1.linux"
+		          runtime_engine = "${runtime_path}"
+EOT

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+crio_config_file="/etc/crio/crio.conf"
+
+echo "Configure runtimes for trusted/untrusted annotations"
+sudo sed -i 's/^#* *runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
+sudo sed -i 's/^default_runtime/# default_runtime/' "$crio_config_file"
+sudo sed -i 's/^#*runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/kata-runtime"/' "$crio_config_file"
+sudo sed -i 's/#*default_workload_trust = ""/default_workload_trust = "trusted"/' "$crio_config_file"
+
+

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -11,7 +11,6 @@ set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cri_repository="github.com/containerd/cri"
-readonly runtime_path=$(which ${RUNTIME:-kata-runtime})
 
 # Flag to do tasks for CI
 CI=${CI:-""}
@@ -69,15 +68,6 @@ cat << EOF | sudo tee  /etc/systemd/system/kubelet.service.d/0-containerd.conf
 [Service]                                                 
 Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 EOF
-
-sudo mkdir -p /etc/containerd/
-cat << EOT | sudo tee /etc/containerd/config.toml
-[plugins]
-    [plugins.cri.containerd]
-          [plugins.cri.containerd.untrusted_workload_runtime]
-	          runtime_type = "io.containerd.runtime.v1.linux"
-		          runtime_engine = "${runtime_path}"
-EOT
 
 sudo systemctl daemon-reload
 

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -111,12 +111,6 @@ sudo sed -i 's/^#registries = \[/registries = \[ "docker.io" \] /' "$crio_config
 echo "Change stream_port where cri-o will listen"
 sudo sed -i 's/^stream_port.*/stream_port = "10020"/' "$crio_config_file"
 
-echo "Configure runtimes for trusted/untrusted annotations"
-sudo sed -i 's/^#* *runtime =.*/runtime = "\/usr\/local\/bin\/crio-runc"/' "$crio_config_file"
-sudo sed -i 's/^default_runtime/# default_runtime/' "$crio_config_file"
-sudo sed -i 's/^#*runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/usr\/local\/bin\/kata-runtime"/' "$crio_config_file"
-sudo sed -i 's/#*default_workload_trust = ""/default_workload_trust = "trusted"/' "$crio_config_file"
-
 service_path="/etc/systemd/system"
 crio_service_file="${cidir}/data/crio.service"
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -97,7 +97,8 @@ install_extra_tools() {
 
 	[ "${CRI_CONTAINERD}" = "yes" ] &&
 		echo "Install cri-containerd" &&
-		bash -f "${cidir}/install_cri_containerd.sh" ||
+		bash -f "${cidir}/install_cri_containerd.sh" &&
+		bash -f "${cidir}/configure_containerd_for_kata.sh" ||
 		echo "containerd not installed"
 
 	[ "${KUBERNETES}" = "yes" ] &&

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -92,7 +92,8 @@ install_extra_tools() {
 
 	[ "${CRIO}" = "yes" ] &&
 		echo "Install CRI-O" &&
-		bash -f "${cidir}/install_crio.sh" ||
+		bash -f "${cidir}/install_crio.sh" &&
+		bash -f "${cidir}/configure_crio_for_kata.sh" ||
 		echo "CRI-O not installed"
 
 	[ "${CRI_CONTAINERD}" = "yes" ] &&


### PR DESCRIPTION
This PR seperates installation and configuration of CRI shim + kubernetes from configuration of CRI shim to make use of kata containers.

This'll allow for better re-use when we want to just bring up a kubernetes node with crio/containerd (example, if you want to make use of kata-deploy). 