### PR TITLE
ci: cleanup: add timeouts to docker on cleanups

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -8,6 +8,13 @@
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 
+# How long do we wait for docker to perform a task before we
+# timeout with the presumption it has hung.
+# Docker itself has a 10s timeout, so make our timeout longer
+# than that. Measured in seconds by default (see timeout(1) for
+# more formats).
+export KATA_DOCKER_TIMEOUT=30
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"
@@ -243,7 +250,7 @@ gen_clean_arch() {
 	# Set up some vars
 	stale_process_union=( "docker-containerd-shim" )
 	#docker supports different storage driver, such like overlay2, aufs, etc.
-	docker_storage_driver=$(docker info --format='{{.Driver}}')
+	docker_storage_driver=$(timeout ${KATA_DOCKER_TIMEOUT} docker info --format='{{.Driver}}')
 	stale_docker_mount_point_union=( "/var/lib/docker/containers" "/var/lib/docker/${docker_storage_driver}" )
 	stale_docker_dir_union=( "/var/lib/docker" )
 	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" )

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -80,15 +80,19 @@ check_runtimes() {
 # stopped/running containers.
 clean_env()
 {
-	containers_running=$(docker ps -q)
+	# If the timeout has not been set, default it to 30s
+	# Docker has a built in 10s default timeout, so make ours
+	# longer than that.
+	KATA_DOCKER_TIMEOUT=${KATA_DOCKER_TIMEOUT:-30}
+	containers_running=$(timeout ${KATA_DOCKER_TIMEOUT} docker ps -q)
 
 	if [ ! -z "$containers_running" ]; then
 		# First stop all containers that are running
 		# Use kill, as the containers are generally benign, and most
 		# of the time our 'stop' request ends up doing a `kill` anyway
-		sudo docker kill $containers_running
+		sudo timeout ${KATA_DOCKER_TIMEOUT} docker kill $containers_running
 
 		# Remove all containers
-		sudo docker rm -f $(docker ps -qa)
+		sudo timeout ${KATA_DOCKER_TIMEOUT} docker rm -f $(docker ps -qa)
 	fi
 }


### PR DESCRIPTION
When cleaning up a system, it is possible for docker (and/or the
runtime) to have 'hung up', and that ends up with us calling docker
which stalls and then the CI times out.

Add timeouts to the calls to docker in the cleanup paths to try
and avoid the CI timeouts.

Fixes: #935

Signed-off-by: Graham Whaley <graham.whaley@intel.com>