### PR TITLE
integration/cri-o: skip crio test 'ctr list filtering'

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -10,4 +10,5 @@
 declare -a skipCRIOTests=(
 'test "ctr oom"'
 'test "ulimits"'
+'test "ctr list filtering"'
 );


### PR DESCRIPTION
Skip crio test 'ctr list filtering' to allow
kata-containers/runtime#847 lands

fixes #945

Signed-off-by: Julio Montes <julio.montes@intel.com>