### PR TITLE
ci: install kata-agent as init

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -84,7 +84,8 @@ update_agent() {
 	"${IMG_MOUNT_DIR}/usr/bin/kata-agent" --version
 
 	echo "Install new agent"
-	sudo -E PATH="$PATH" bash -c "make install DESTDIR=$IMG_MOUNT_DIR"
+	sudo -E PATH="$PATH" bash -c "make install INIT=yes DESTDIR=$IMG_MOUNT_DIR"
+	sudo -E PATH="$PATH" bash -c "ln -sf kata-agent $IMG_MOUNT_DIR/sbin/init"
 	installed_version=$("${IMG_MOUNT_DIR}/usr/bin/kata-agent" --version)
 	echo "New agent version: $installed_version"
 


### PR DESCRIPTION
install kata-agent as init to rid of systemd

fixes #947

Signed-off-by: Julio Montes <julio.montes@intel.com>