### PR TITLE
test: Update allocated memory size value for K8s test

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -36,7 +36,7 @@ setup() {
 
 @test "Running within memory constraints" {
 	memory_limit_size="200Mi"
-	allocated_size="100M"
+	allocated_size="150M"
 	# Create test .yaml
         sed \
             -e "s/\${memory_size}/${memory_limit_size}/" \

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -33,12 +33,12 @@ bats k8s-pid-ns.bats
 bats k8s-cpu-ns.bats
 bats k8s-parallel.bats
 bats k8s-security-context.bats
-bats k8s-memory.bats
 bats k8s-liveness-probes.bats
 bats k8s-attach-handlers.bats
 bats k8s-qos-pods.bats
 bats k8s-pod-quota.bats
 bats k8s-volume.bats
 bats k8s-projected-volume.bats
+bats k8s-memory.bats
 ./cleanup_env.sh
 popd


### PR DESCRIPTION
Revert the memory value to the original value (https://github.com/kata-containers/tests/pull/534).
The main purpose of this is to fixed the bug (https://github.com/kata-containers/tests/issues/903)
where we could not allocated a memory size more than 100M.

Fixes #953

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>