### PR TITLE
functional: Add test checking for container state

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -60,6 +60,9 @@ func NewBundle(workload []string) (*Bundle, error) {
 		return nil, err
 	}
 
+	// By default, let's not create a terminal
+	config.Process.Terminal = false
+
 	config.Process.Args = workload
 
 	bundle := &Bundle{

--- a/container.go
+++ b/container.go
@@ -185,6 +185,22 @@ func (c *Container) Exec(process Process) (string, string, int) {
 	return cmd.Run()
 }
 
+// State returns the state of the container
+// calls into state command returning its stdout, stderr and exit code
+func (c *Container) State() (string, string, int) {
+	args := []string{}
+
+	args = append(args, "state")
+
+	if c.ID != nil {
+		args = append(args, *c.ID)
+	}
+
+	cmd := NewCommand(Runtime, args...)
+
+	return cmd.Run()
+}
+
 // List the containers
 // calls to list command returning its stdout, stderr and exit code
 func (c *Container) List(format string, quiet bool, all bool) (string, string, int) {

--- a/functional/state_test.go
+++ b/functional/state_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package functional
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/kata-containers/tests"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	stateWorkload = []string{"true"}
+)
+
+const (
+	stateStopped  = "stopped"
+	stateWaitTime = 5
+)
+
+var _ = Describe("state", func() {
+	var (
+		container *Container
+		err       error
+	)
+
+	BeforeEach(func() {
+		container, err = NewContainer(stateWorkload, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container).NotTo(BeNil())
+	})
+
+	AfterEach(func() {
+		Expect(container.Teardown()).To(Succeed())
+	})
+
+	DescribeTable("container",
+		func(status string, waitTime int) {
+			_, stderr, exitCode := container.Run()
+			Expect(exitCode).To(Equal(0))
+			Expect(stderr).To(BeEmpty())
+
+			time.Sleep(time.Second * time.Duration(waitTime))
+
+			stdout, stderr, exitCode := container.State()
+			Expect(exitCode).To(Equal(0))
+			Expect(stderr).To(BeEmpty())
+			subString := fmt.Sprintf("\"status\": \"%s\"", status)
+			Expect(stdout).To(ContainSubstring(subString))
+		},
+		Entry(fmt.Sprintf("with workload %s, timeWait %d", stateWorkload, stateWaitTime), stateStopped, stateWaitTime),
+	)
+})


### PR DESCRIPTION
Following an issue that we found with the kata-runtime regarding
a wrong state being reported after the container workload terminated,
this patch introduces a test that runs a simple container workload
and validate that the value obtained after a few seconds is "stopped".

Previously, this test would have failed as we would have retrieved
"running", which is a wrong value in this case.

Fixes #956

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>