### PR TITLE
kernel: add dev-kernel build process for CI environment on aarch64

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -40,7 +40,11 @@ download_repo() {
 }
 
 get_current_kernel_version() {
-	kernel_version=$(get_version "assets.kernel.version")
+	if [ "$DEV" == false ]; then
+		kernel_version=$(get_version "assets.kernel.version")
+	else
+		kernel_version=$(get_version "assets.kernel.dev.version")
+	fi
 	echo "${kernel_version/v/}"
 }
 
@@ -67,9 +71,15 @@ get_packaged_kernel_version() {
 build_and_install_kernel() {
 	info "Install kernel from sources"
 	pushd "${tmp_dir}" >> /dev/null
-	"${kernel_repo_dir}/kernel/build-kernel.sh" "setup"
-	"${kernel_repo_dir}/kernel/build-kernel.sh" "build"
-	sudo -E PATH="$PATH" "${kernel_repo_dir}/kernel/build-kernel.sh" "install"
+	if [ "$DEV" == false ]; then
+		"${kernel_repo_dir}/kernel/build-kernel.sh" "setup"
+		"${kernel_repo_dir}/kernel/build-kernel.sh" "build"
+		sudo -E PATH="$PATH" "${kernel_repo_dir}/kernel/build-kernel.sh" "install"
+	else
+		"${kernel_repo_dir}/kernel/build-kernel.sh" -d "setup"
+		"${kernel_repo_dir}/kernel/build-kernel.sh" -d "build"
+		sudo -E PATH="$PATH" "${kernel_repo_dir}/kernel/build-kernel.sh" -d "install"
+	fi
 	popd >> /dev/null
 }
 


### PR DESCRIPTION
when $DEV has been set as true, it means that the whole kata-ecosystem on aarch64 (mainly including kernel, qemu, etc) is built for development use, not stable. Here is about adding the dev-kernel(4.20-rc3+)
build process on aarch64.

Fixes: #959

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <Wei.Chen@arm.com>