### PR TITLE
ci: Add installation scripts for debian.

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -59,7 +59,7 @@ get_packaged_agent_version() {
 
 install_packaged_image() {
 	rc=0
-	if [ "$ID"  == "ubuntu" ]; then
+	if [ "$ID"  == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		chronic sudo -E apt install -y "$PACKAGED_IMAGE" || rc=1
 	elif [ "$ID"  == "fedora" ]; then
 		chronic sudo -E dnf install -y "$PACKAGED_IMAGE" || rc=1

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -50,7 +50,7 @@ get_kata_config_version() {
 }
 
 get_packaged_kernel_version() {
-	if [ "$ID" == "ubuntu" ]; then
+	if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		kernel_version=$(sudo apt-cache madison $packaged_kernel | awk '{print $3}' | cut -d'-' -f1)
 	elif [ "$ID" == "fedora" ]; then
 		kernel_version=$(sudo dnf --showduplicate list ${packaged_kernel}.${kernel_arch} |
@@ -76,7 +76,7 @@ build_and_install_kernel() {
 install_packaged_kernel(){
 	info "Install packaged kernel version"
 	rc=0
-	if [ "$ID"  == "ubuntu" ]; then
+	if [ "$ID"  == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		chronic sudo apt install -y "$packaged_kernel" || rc=1
 	elif [ "$ID"  == "fedora" ]; then
 		chronic sudo dnf install -y "$packaged_kernel" || rc=1

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -16,7 +16,7 @@ PACKAGED_QEMU="qemu-lite"
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
 
 get_packaged_qemu_commit() {
-	if [ "$ID" == "ubuntu" ]; then
+	if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		qemu_commit=$(sudo apt-cache madison $PACKAGED_QEMU \
 			| awk '{print $3}' | cut -d'-' -f1 | cut -d'.' -f4)
 	elif [ "$ID" == "fedora" ]; then
@@ -34,7 +34,7 @@ install_packaged_qemu() {
 	rc=0
 	# Timeout to download packages from OBS
 	limit=180
-	if [ "$ID"  == "ubuntu" ]; then
+	if [ "$ID"  == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		chronic sudo apt remove -y "$PACKAGED_QEMU" || true
 		chronic sudo apt install -y "$PACKAGED_QEMU" || rc=1
 	elif [ "$ID"  == "fedora" ]; then
@@ -70,7 +70,7 @@ build_and_install_qemu() {
 	QEMU_PATCHES_PATH="${GOPATH}/src/${PACKAGING_REPO}/obs-packaging/qemu-lite/patches"
 	for patch in ${QEMU_PATCHES_PATH}/*.patch; do
 		echo "Applying patch: $patch"
-		git am -3 "$patch"
+		git apply "$patch"
 	done
 
 	echo "Build Qemu"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -31,6 +31,8 @@ setup_distro_env() {
 		bash -f "${cidir}/setup_env_fedora.sh"
 	elif [ "$ID" == ubuntu ]; then
 		bash -f "${cidir}/setup_env_ubuntu.sh"
+	elif [ "$ID" == debian ]; then
+		bash -f "${cidir}/setup_env_debian.sh"
 	else
 		die "ERROR: Unrecognised distribution: ${ID}."
 		exit 1

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "/etc/os-release" || source "/usr/lib/os-release"
+source "${cidir}/lib.sh"
+arch=$("${cidir}"/kata-arch.sh -d)
+export DEBIAN_FRONTEND=noninteractive
+
+echo "Install chronic"
+sudo -E apt install -y moreutils
+
+echo "Install curl"
+sudo -E apt install -y curl
+
+echo "Install git"
+sudo -E apt install -y git
+
+echo "Install kata containers dependencies"
+chronic sudo -E apt install -y libtool automake autotools-dev autoconf bc alien libpixman-1-dev coreutils
+
+echo "Install qemu dependencies"
+chronic sudo -E apt install -y libcap-dev libattr1-dev libcap-ng-dev librbd-dev
+
+echo "Install kernel dependencies"
+chronic sudo -E apt install -y libelf-dev
+
+echo "Install CRI-O dependencies for Debian"
+chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev \
+        libgpgme11-dev go-md2man thin-provisioning-tools
+
+echo "Install bison binary"
+chronic sudo -E apt install -y bison
+
+echo "Install libudev-dev"
+chronic sudo -E apt-get install -y libudev-dev
+
+echo "Install Build Tools"
+chronic sudo -E apt install -y build-essential python pkg-config zlib1g-dev
+
+echo -e "Install CRI-O dependencies available for Debian"
+chronic sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux
+
+chronic sudo -E apt install -y libostree-dev
+
+echo "Install YAML validator"
+chronic sudo -E apt install -y yamllint
+
+echo "Install tools for metrics tests"
+chronic sudo -E apt install -y smem jq
+
+echo "Enable librbd1 repository"
+sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/unstable.list
+deb http://deb.debian.org/debian unstable main contrib non-free
+deb-src http://deb.debian.org/debian unstable main contrib non-free
+EOF"
+
+echo "Lower priority than stable"
+sudo bash -c "cat <<EOF > /etc/apt/preferences.d/unstable
+Package: *
+Pin: release a=unstable
+Pin-Priority: 10
+EOF"
+
+echo "Install librbd1"
+chronic sudo -E apt update && sudo -E apt install -y -t unstable librbd1
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="http://download.opensuse.org/repositories/home:/katacontainers:/releases:/$arch:/master/Debian_$VERSION_ID.0"
+	sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
+	curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
+	chronic sudo -E apt-get update
+fi
+
+echo -e "Install cri-containerd dependencies"
+chronic sudo -E apt install -y libseccomp-dev libapparmor-dev btrfs-tools  make gcc pkg-config
+
+echo "Install crudini"
+chronic sudo -E apt install -y crudini
+
+echo "Install procenv"
+chronic sudo -E apt install -y procenv
+
+echo "Install haveged"
+chronic sudo -E apt install -y haveged


### PR DESCRIPTION
These set os scripts will installed system dependencies
as well all the components to run Kata Containers.

Fixes #964

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>