### PR TITLE
integration/docker: unskip docer cp test

### DIFF
--- a/integration/docker/cp_test.go
+++ b/integration/docker/cp_test.go
@@ -123,7 +123,6 @@ var _ = Describe("docker cp with volume", func() {
 
 	Context("check mount points", func() {
 		It("should be removed", func() {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/794")
 			file, err := ioutil.TempFile(os.TempDir(), "file")
 			Expect(err).ToNot(HaveOccurred())
 			err = file.Close()


### PR DESCRIPTION
Unskip docker cp test to check mount points are not left
after running docker cp.

Depends-on: github.com/kata-containers/runtime#980

fixes #970

Signed-off-by: Julio Montes <julio.montes@intel.com>