### PR TITLE
ci: cleanup: fix process kill for multiple processes

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -203,9 +203,9 @@ kill_stale_process()
 	extract_kata_env
 	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do
-		local pids=$(pgrep -f "${stale_process}")
+		local pids=$(pgrep -d ' ' -f "${stale_process}")
 		if [ -n "$pids" ]; then
-			sudo kill -9 "${pids}" || true
+			sudo kill -9 ${pids} || true
 		fi
 	done
 }


### PR DESCRIPTION
When trying to kill off stale processes with a combination of
pgrep and kill, a mix of line separator and quotations meant the
kill only worked if we found a single process.

Fix by using a separator of ' '(space) for the pgrep and
don't quote the pid expansion - a pid list is just a plain
list of numbers with spaces between them.

Fixes: #974

Signed-off-by: Graham Whaley <graham.whaley@intel.com>