### PR TITLE
integration/cri-o: unskip ulimits test

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,5 +9,4 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
-'test "ulimits"'
 );


### PR DESCRIPTION
unskip crio ulimits test now that kata support rlimits

Depends-on: github.com/kata-containers/agent#431

fixes #907

Signed-off-by: Julio Montes <julio.montes@intel.com>