### PR TITLE
centos: fix cri-o issues

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -13,6 +13,17 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 
+echo "Install go-md2man"
+go_md2man_url=$(get_test_version "externals.go-md2man.url")
+go_md2man_version=$(get_test_version "externals.go-md2man.version")
+go_md2man_repo=${go_md2man_url/https:\/\/}
+go get -d "${go_md2man_repo}"
+pushd "$GOPATH/src/${go_md2man_repo}"
+git checkout "${go_md2man_version}"
+go build
+go install
+popd
+
 echo "Get CRI-O sources"
 kubernetes_sigs_org="github.com/kubernetes-sigs"
 ghprbGhRepository="${ghprbGhRepository:-}"
@@ -36,17 +47,6 @@ then
 
 	git fetch
 	git checkout "${crio_version}"
-fi
-
-# Add link of go-md2man to $GOPATH/bin
-GOBIN="$GOPATH/bin"
-if [ ! -d "$GOBIN" ]
-then
-        mkdir -p "$GOBIN"
-fi
-
-if [ ! -e "${GOBIN}/go-md2man" ]; then
-	ln -sf $(command -v go-md2man) "$GOBIN"
 fi
 
 echo "Get CRI Tools"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -18,6 +18,9 @@ else
   centos_version=$(grep VERSION_ID /usr/lib/os-release | cut -d '"' -f2)
 fi
 
+# Send error when a package is not available in the repositories
+echo "skip_missing_names_on_install=0" | sudo tee -a /etc/yum.conf
+
 # Check EPEL repository is enabled on CentOS
 if [ -z $(yum repolist | grep "Extra Packages") ]; then
 	echo >&2 "ERROR: EPEL repository is not enabled on CentOS."

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -47,8 +47,9 @@ echo "Install kernel dependencies"
 chronic sudo -E yum -y install elfutils-libelf-devel
 
 echo "Install CRI-O dependencies for CentOS"
-chronic sudo -E yum install -y glibc-static libglib2.0-devel libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs \
-	 btrfs-progs-devel util-linux gpgme-devel
+chronic sudo -E yum install -y glibc-static libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs \
+	 btrfs-progs-devel util-linux gpgme-devel glib2-devel glibc-devel libselinux-devel ostree-devel \
+	 pkgconfig
 
 echo "Install bison binary"
 chronic sudo -E yum install -y bison
@@ -77,7 +78,7 @@ if [ "$(arch)" == "x86_64" ]; then
 fi
 
 echo "Install cri-containerd dependencies"
-chronic sudo -E yum install -y libseccomp-devel btrfs-progs-devel libseccomp-static
+chronic sudo -E yum install -y libseccomp-devel btrfs-progs-devel
 
 echo "Install crudini"
 chronic sudo -E yum install -y crudini

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -44,7 +44,7 @@ echo "Install kernel dependencies"
 chronic sudo -E yum -y install elfutils-libelf-devel
 
 echo "Install CRI-O dependencies for CentOS"
-chronic sudo -E yum install -y glibc-static libglib2.0-devel libseccomp-devel libassuan-devel libgpg-error-devel go-md2man device-mapper-libs \
+chronic sudo -E yum install -y glibc-static libglib2.0-devel libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs \
 	 btrfs-progs-devel util-linux gpgme-devel
 
 echo "Install bison binary"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -35,7 +35,7 @@ echo "Install CRI-O dependencies"
 chronic sudo -E dnf -y install btrfs-progs-devel device-mapper-devel      \
 	glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel  \
 	libgpg-error-devel libseccomp-devel libselinux-devel ostree-devel \
-	pkgconfig go-md2man util-linux
+	pkgconfig util-linux
 
 echo "Install bison binary"
 chronic sudo -E dnf -y install bison

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -28,7 +28,7 @@ chronic sudo -E apt install -y libelf-dev
 
 echo "Install CRI-O dependencies for all Ubuntu versions"
 chronic sudo -E apt install -y libglib2.0-dev libseccomp-dev libapparmor-dev \
-	libgpgme11-dev go-md2man thin-provisioning-tools
+	libgpgme11-dev thin-provisioning-tools
 
 echo "Install bison binary"
 chronic sudo -E apt install -y bison

--- a/versions.yaml
+++ b/versions.yaml
@@ -43,3 +43,8 @@ externals:
       Tool used by the CI to check URLs in documents and code comments.
     url: "https://mvdan.cc/xurls/cmd/xurls"
     version: "70405f5eab516c9f7b626d803b043415809499a6"
+
+  go-md2man:
+    description: "cri-o dependency used for building documentation"
+    url: "https://github.com/cpuguy83/go-md2man"
+    version: "v1.0.8"


### PR DESCRIPTION
the centos image that is used in the vexxhost cloud was updated to 7.6, which is good, but the go-md2man package is no longer available, this is why the cri-o tests started to fail.
Instead of getting the go-md2man from the centos repositories, build and install it from sources.
Also, add yum configuration to fail when a package is not available.