### PR TITLE
CI: quieten build output when under a CI

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -14,19 +14,19 @@ source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
 echo "Install kata-containers image"
-"${cidir}/install_kata_image.sh"
+ci_chronic "${cidir}/install_kata_image.sh"
 
 echo "Install Kata Containers Kernel"
-"${cidir}/install_kata_kernel.sh"
+ci_chronic "${cidir}/install_kata_kernel.sh"
 
 echo "Install Qemu"
-"${cidir}/install_qemu.sh"
+ci_chronic "${cidir}/install_qemu.sh"
 
 echo "Install shim"
-"${cidir}/install_shim.sh"
+ci_chronic "${cidir}/install_shim.sh"
 
 echo "Install proxy"
-"${cidir}/install_proxy.sh"
+ci_chronic "${cidir}/install_proxy.sh"
 
 echo "Install runtime"
-"${cidir}/install_runtime.sh"
+ci_chronic "${cidir}/install_runtime.sh"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -138,7 +138,7 @@ function install_yq() {
 	GOPATH=${GOPATH:-${HOME}/go}
 	local yq_path="${GOPATH}/bin/yq"
 	local yq_pkg="github.com/mikefarah/yq"
-	[ -x  "${GOPATH}/bin/yq" ] && return
+	[ -x "${GOPATH}/bin/yq" ] && return
 
 	read -r -a sysInfo <<< "$(uname -sm)"
 
@@ -207,7 +207,7 @@ function get_version(){
 	runtime_repo_dir="$GOPATH/src/${runtime_repo}"
 	versions_file="${runtime_repo_dir}/versions.yaml"
 	mkdir -p "$(dirname ${runtime_repo_dir})"
-	[ -d "${runtime_repo_dir}" ] ||  git clone --quiet https://${runtime_repo}.git "${runtime_repo_dir}"
+	[ -d "${runtime_repo_dir}" ] || git clone --quiet https://${runtime_repo}.git "${runtime_repo_dir}"
 
 	get_dep_from_yaml_db "${versions_file}" "${dependency}"
 }
@@ -234,18 +234,18 @@ function check_gopath() {
 }
 
 function waitForProcess(){
-        wait_time="$1"
-        sleep_time="$2"
-        cmd="$3"
-        while [ "$wait_time" -gt 0 ]; do
-                if eval "$cmd"; then
-                        return 0
-                else
-                        sleep "$sleep_time"
-                        wait_time=$((wait_time-sleep_time))
-                fi
-        done
-        return 1
+	wait_time="$1"
+	sleep_time="$2"
+	cmd="$3"
+	while [ "$wait_time" -gt 0 ]; do
+		if eval "$cmd"; then
+			return 0
+		else
+			sleep "$sleep_time"
+			wait_time=$((wait_time-sleep_time))
+		fi
+	done
+	return 1
 }
 
 kill_stale_process()

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -138,7 +138,7 @@ function install_yq() {
 	GOPATH=${GOPATH:-${HOME}/go}
 	local yq_path="${GOPATH}/bin/yq"
 	local yq_pkg="github.com/mikefarah/yq"
-	[ -x "${GOPATH}/bin/yq" ] && return
+	[ -x "${yq_path}" ] && return
 
 	read -r -a sysInfo <<< "$(uname -sm)"
 


### PR DESCRIPTION
When running under a CI, a lot of the console log output
comes from installing and building kata components, such
as the linux kernel.

When under the CI, `chronic` those commands to reduce the
log size.

Fixes: #993

Signed-off-by: Graham Whaley <graham.whaley@intel.com>