### PR TITLE
CI: bare metal: do not fail on bare metal cleanup

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -54,7 +54,7 @@ mkdir -p $(dirname "${kata_repo_dir}")
 if [ "${BAREMETAL}" == true ]; then
 	arch=$("${tests_repo_dir}/.ci/kata-arch.sh")
 	echo "Looking for baremetal cleanup script for arch ${arch}"
-	clean_up_script="${tests_repo_dir}/.ci/${arch}/clean_up_${arch}.sh"
+	clean_up_script=("${tests_repo_dir}/.ci/${arch}/clean_up_${arch}.sh") || true
 	if [ -f "${clean_up_script}" ]; then
 		echo "Running baremetal cleanup script for arch ${arch}"
 		tests_repo="${tests_repo}" "${clean_up_script}"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -16,12 +16,38 @@ die(){
 	exit 1
 }
 
+info() {
+        echo -e "INFO: $*"
+}
+
 # Gets versions and paths of all the components
 # list in kata-env
 extract_kata_env(){
 	local toml
 
-	toml="$(kata-runtime kata-env)"
+	# If we cannot find the runtime, or it fails to run for some reason, do not die
+	# on the error, but set some sane defaults
+	toml="$(set +e; kata-runtime kata-env)"
+	if [ $? != 0 ]; then
+		# We could be more diligent here and search for each individual component,
+		# but if the runtime cannot tell us the exact details it is configured for then
+		# we would be guessing anyway - so, set some defaults that may be true and give
+		# strong hints that we 'made them up'.
+		info "Runtime environment not found - setting defaults"
+		RUNTIME_CONFIG_PATH="/usr/share/defaults/kata-containers/configuration.toml"
+		RUNTIME_VERSION="0.0.0"
+		RUNTIME_COMMIT="unknown"
+		RUNTIME_PATH="/usr/local/bin/kata-runtime"
+		SHIM_PATH="/usr/libexec/kata-containers/kata-shim"
+		SHIM_VERSION="0.0.0"
+		PROXY_PATH="/usr/libexec/kata-containers/kata-proxy"
+		PROXY_VERSION="0.0.0"
+		HYPERVISOR_PATH="/usr/bin/qemu-system-x86_64"
+		HYPERVISOR_VERSION="0.0.0"
+		INITRD_PATH=""
+		NETMON_PATH="/usr/libexec/kata-containers/kata-netmon"
+		return 0
+	fi
 
 	# The runtime path itself, for kata-runtime, will be contained in the `kata-env`
 	# section. For other runtimes we do not know where the runtime Docker is using lives.


### PR DESCRIPTION
We should probably never fail on bare metal cleanup, as it is trying to potentially
clean up a corrupt system, and may hit things it does not expect.
Instead, try our hardest, and use some defaults if we cannot find the actual
runtime defaults.