### PR TITLE
CI: Fix static checker test with '--all'

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -540,7 +540,7 @@ check_files()
 
 	info "Checking files"
 
-	if [ "$specifc_branch" = "true" ]
+	if [ "$specific_branch" = "true" ]
 	then
 		info "Checking all files in $branch branch"
 


### PR DESCRIPTION
Fixed a typo in `check_files()` that was stopping the static analysis
script from working correctly when run with `--all`.

Fixes #998.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>