### PR TITLE
CI: logs: reduce the log output upon error

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -236,22 +236,11 @@ check_log_files()
 
 		# Display *all* errors caused by runtime exceptions and fatal
 		# signals.
-		for pattern in "fatal error" "fatal signal"
+		for pattern in "fatal error" "fatal signal" "segfault at [0-9]"
 		do
 			# Search for pattern and print all subsequent lines with specified log
 			# level.
-			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true | grep "level=\"*error\"*")
-			if [ -n "$results" ]
-			then
-				errors=1
-				echo >&2 -e "ERROR: detected ${pattern} in '${log}'\n${results}"
-			fi
-		done
-
-		for pattern in "segfault at [0-9]"
-		do
-			results=$(sed -ne "/\<${pattern}\>/,\$ p" "$log" || true)
-
+			results=$(grep "${pattern}" "$log" || true )
 			if [ -n "$results" ]
 			then
 				errors=1


### PR DESCRIPTION
Rather than dump the error line found and all its 'freinds',
which can result in massive log dumps, let's just dump the log
line we found.

If somebody does need to look at the complete log, the CI keeps
them as artifact attachments to the build run anyway.

Fixes: #1000

Signed-off-by: Graham Whaley <graham.whaley@intel.com>