### PR TITLE
test: Add K8s test using a security context

### DIFF
--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+	if sudo -E kubectl get runtimeclass | grep kata; then
+		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+	else
+		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+	fi
+}
+
+@test "Security context" {
+	pod_name="security-context-test"
+
+	# Create pod
+	sudo -E kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
+
+	# Check pod creation
+	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check user
+	cmd="ps --user 1000 -f"
+	process="tail -f /dev/null"
+	sudo -E kubectl exec $pod_name -- sh -c $cmd | grep "$process"
+}
+
+teardown() {
+	sudo -E kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -31,6 +31,7 @@ bats k8s-credentials-secrets.bats
 bats k8s-pid-ns.bats
 bats k8s-cpu-ns.bats
 bats k8s-parallel.bats
+bats k8s-security-context.bats
 bats k8s-memory.bats
 bats k8s-liveness-probes.bats
 bats k8s-attach-handlers.bats

--- a/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-test
+spec:
+  runtimeClassName: kata
+  securityContext:
+    runAsUser: 1000
+  containers:
+  - name: sec-text
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/untrusted_workloads/pod-security-context.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-security-context.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-test
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  securityContext:
+    runAsUser: 1000
+  containers:
+  - name: sec-text
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
This test sets a security context for a pod.

Fixes #1008

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>