### PR TITLE
static-checks.sh: skip svg figures

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -360,6 +360,7 @@ check_license_headers()
 		--exclude="*.png" \
 		--exclude="*.pub" \
 		--exclude="*.service" \
+		--exclude="*.svg" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \
 		--exclude="*.yaml" \


### PR DESCRIPTION
Fixes: #1018
