### PR TITLE
ci: Add packaging repo for kata dependencies

### DIFF
--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -13,6 +13,7 @@ proxy_repo="${proxy_repo:-github.com/kata-containers/proxy}"
 runtime_repo="${runtime_repo:-github.com/kata-containers/runtime}"
 shim_repo="${shim_repo:-github.com/kata-containers/shim}"
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+packaging_repo="${tests_repo:-github.com/kata-containers/packaging}"
 
 apply_depends_on() {
 	# kata_repo variable is set by the jenkins_job_build.sh
@@ -58,7 +59,7 @@ apply_depends_on() {
 }
 
 clone_repos() {
-	local kata_repos=( "${agent_repo}" "${proxy_repo}" "${runtime_repo}" "${shim_repo}" "${tests_repo}" )
+	local kata_repos=( "${agent_repo}" "${proxy_repo}" "${runtime_repo}" "${shim_repo}" "${tests_repo}" "${packaging_repo}" )
 	for repo in "${kata_repos[@]}"
 	do
 		echo "Cloning ${repo}"


### PR DESCRIPTION
We need to add the packaging repo as a repository needed
for building the kata containers project.

Fixes #1024

Depends-on:github.com/kata-containers/packaging#295

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>