### PR TITLE
metrics: Remove exit after using die function

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -52,7 +52,6 @@ check_cmds()
 	for cmd in "${req_cmds[@]}"; do
 		if ! command -v "$cmd" > /dev/null 2>&1; then
 			die "command $cmd not available"
-			exit 1;
 		fi
 		echo "command: $cmd: yes"
 	done
@@ -75,7 +74,6 @@ check_images()
 		echo "docker pull'ing: $img"
 		if ! docker pull "$img"; then
 			die "Failed to docker pull image $img"
-			exit 1;
 		fi
 		echo "docker pull'd: $img"
 	done


### PR DESCRIPTION
Die function performs an exit 1 already so with this PR we will remove
the duplicated exits.

Fixes #1027

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>