### PR TITLE
tests: Do not check ksm-throttler process in Debian

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -10,6 +10,7 @@ RESULT_DIR="${LIB_DIR}/../results"
 
 source ${LIB_DIR}/../../lib/common.bash
 source ${LIB_DIR}/json.bash
+source /etc/os-release || source /usr/lib/os-release
 
 # Set variables to reasonable defaults if unset or empty
 DOCKER_EXE="${DOCKER_EXE:-docker}"
@@ -195,7 +196,11 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	if [ "$ID" == debian ]; then
+		local processes="kata-proxy kata-shim kata-runtime qemu"
+	else
+		local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	fi
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
In order to run the soak test we will not check ksm-throttler process
in Debian as it is not setup by default.

Fixes #1029

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>