### PR TITLE
ci: don't checkout to different branch on packaging repo

### DIFF
--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -90,8 +90,13 @@ clone_repos() {
 			echo "... and rebasing with origin/${branch}"
 			git rebase "origin/${branch}"
 		else
-			echo "Checking out to ${branch}"
-			git fetch origin && git checkout "$branch"
+			# Packaging repo only has master branch, so we
+			# cannot checkout to a different branch.
+			if  [ "${repo}" != "${packaging_repo}" ]
+			then
+				echo "Checking out to ${branch}"
+				git fetch origin && git checkout "$branch"
+			fi
 		fi
 		popd
 	done


### PR DESCRIPTION
Packaging repo only has the master branch, so we cannot
checkout to a different branch when running tests for
stable branches.

Fixes: #1034.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>