### PR TITLE
tests: Add kata-ksm-throttler to Debian

### DIFF
--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -14,6 +14,7 @@
 
 cidir=$(dirname "$0")
 source "${cidir}/../../metrics/lib/common.bash"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 # How many times will we run the test loop...
 ITERATIONS="${ITERATIONS:-5}"
@@ -37,6 +38,15 @@ VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
 # let's cap the test. If you want to run until you hit the memory limit
 # then just set this to a very large number
 MAX_CONTAINERS="${MAX_CONTAINERS:-110}"
+
+install_kata_ksm_throttler() {
+	if [ "$ID" == debian ]; then
+		echo "Install kata-ksm-throttler"
+		sudo -E apt install -y kata-ksm-throttler
+		echo "Start kata-ksm-throttler"
+		systemctl start kata-ksm-throttler
+	fi
+}
 
 check_vsock_active() {
 	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
@@ -198,6 +208,9 @@ check_mounts() {
 
 init() {
 	kill_all_containers
+
+	# Install kata-ksm-throttler (Debian)
+	install_kata_ksm_throttler
 
 	# Enable netmon
 	enable_netmon

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -10,6 +10,7 @@ RESULT_DIR="${LIB_DIR}/../results"
 
 source ${LIB_DIR}/../../lib/common.bash
 source ${LIB_DIR}/json.bash
+source /etc/os-release || source /usr/lib/os-release
 
 # Set variables to reasonable defaults if unset or empty
 DOCKER_EXE="${DOCKER_EXE:-docker}"
@@ -195,7 +196,11 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	if [ "$ID" == debian ]; then
+		local processes="kata-proxy kata-shim kata-runtime qemu"
+	else
+		local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	fi
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
The process of ksm-throttler is verified by the soak test. However,
for Debian 9 we need to install kata-ksm-throttler package and
then start the service.

Fixes #1037

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>