### PR TITLE
metrics: launch times: update end check for new kernel dmesg

### DIFF
--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -82,12 +82,12 @@ run_workload() {
 		# Grab the last kernel dmesg time
 		# In our case, we need to find the last real kernel line before
 		# the systemd lines begin. The last:
-		# 'Freeing unused kernel memory' line is a reasonable
+		# 'Freeing unused kernel' line is a reasonable
 		# 'last in kernel line' to look for.
 		# We make a presumption here that as we are in a cold-boot VM
 		# kernel, the first dmesg is at '0 seconds', so the timestamp
 		# of that last line is the length of time in the kernel.
-		kernel_last_line=$( (fgrep "Freeing unused kernel memory" <<- EOF
+		kernel_last_line=$( (fgrep "Freeing unused kernel" <<- EOF
 				${workload_result[@]}
 			EOF
 			) | tail -1 )


### PR DESCRIPTION
The kernel dmesg output has changed around the 'Freeing kernel memory',
which we search for to try and identify the 'end of kernel' boot time.
Update the search expression we use to find the last instance of these
lines - which was as easy as trimming the 'memory' word from the end
of the expression, which now works for both older and newer kernel
demsg outputs.

As an example of how the outputs changed, here is a grep of two logs
(taken from bare metal hosts btw, not Kata Container boots):

$ grep "Freeing unused kernel" *log
newlog:[    2.243048] Freeing unused kernel image memory: 2180K
newlog:[    2.248191] Freeing unused kernel image memory: 2012K
newlog:[    2.248337] Freeing unused kernel image memory: 120K
oldlog:[    2.462519] Freeing unused kernel memory: 1528K
oldlog:[    2.483732] Freeing unused kernel memory: 1664K
oldlog:[    2.484299] Freeing unused kernel memory: 92K

Fixes: #1036

Signed-off-by: Graham Whaley <graham.whaley@intel.com>