### PR TITLE
cri-o: skip test 'ctr execsync std{out,err}'

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -8,5 +8,6 @@
 # Currently these are the CRI-O tests that are not working
 
 declare -a skipCRIOTests=(
+'test "ctr execsync std{out,err}"'
 'test "ctr oom"'
 );


### PR DESCRIPTION
This test has been failing randomly. See:
https://github.com/kata-containers/tests/issues/1042
for more details
Let's skip it until we find the root cause.

Fixes: #1045.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>