### PR TITLE
travis: add retry for bash install on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash; fi
 
 script:
   - bash .ci/static-checks.sh github.com/kata-containers/tests


### PR DESCRIPTION
For an unknown reason travis started failing when
installing bash on osx, but this is fixed when a
second attempt is run.

Fixes: #1041.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>