### PR TITLE
test: Modify soak test for Debian

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -10,6 +10,7 @@ RESULT_DIR="${LIB_DIR}/../results"
 
 source ${LIB_DIR}/../../lib/common.bash
 source ${LIB_DIR}/json.bash
+source /etc/os-release || source /usr/lib/os-release
 
 # Set variables to reasonable defaults if unset or empty
 DOCKER_EXE="${DOCKER_EXE:-docker}"
@@ -195,12 +196,22 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	if [ "$ID" == debian ]; then
+		local processes="kata-proxy kata-shim kata-runtime qemu"
+	else
+		local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
+	fi
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"
 		pgrep -a ${p}
 	done
+
+	# Verify kata-ksm-throttler on Debian
+	debian_process="kata-ksm-throttler"
+	debian_process_path=$(whereis ${debian_process} | tr -d '[:space:]'| cut -d ':' -f2)
+	echo " --pgrep ${debian_process}--"
+	pgrep -f ${debian_process_path} > /dev/null
 }
 
 common_init(){


### PR DESCRIPTION
In order to enable a Jenkins job, we need to install kata-ksm-throttler
and start it on Debian. We also need to disable the soak test for Debian,
as presently it detects some incomplete containers with incorrect status
(see: https://github.com/kata-containers/runtime/issues/1132).

Fixes #1054

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>