### PR TITLE
tests: Skip failing K8s tests on initrd

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -6,8 +6,12 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+TEST_INITRD="${TEST_INITRD:-no}"
+issue="https://github.com/kata-containers/runtime/issues/1127"
 
 setup() {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 	pod_name="memory-test"
 
@@ -19,6 +23,8 @@ setup() {
 }
 
 @test "Exceeding memory constraints" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	memory_limit_size="50Mi"
 	allocated_size="250M"
 	# Create test .yaml
@@ -35,6 +41,8 @@ setup() {
 }
 
 @test "Running within memory constraints" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	memory_limit_size="200Mi"
 	allocated_size="100M"
 	# Create test .yaml

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -6,8 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+TEST_INITRD="${TEST_INITRD:-no}"
+issue="https://github.com/kata-containers/runtime/issues/1127"
 
 setup() {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 
 	if sudo -E kubectl get runtimeclass | grep kata; then
@@ -18,6 +21,8 @@ setup() {
 }
 
 @test "Guaranteed QoS" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	pod_name="qos-test"
 
 	# Create pod
@@ -31,6 +36,8 @@ setup() {
 }
 
 @test "Burstable QoS" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	pod_name="burstable-test"
 
 	# Create pod
@@ -44,6 +51,7 @@ setup() {
 }
 
 @test "BestEffort QoS" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	pod_name="besteffort-test"
 
 	# Create pod
@@ -57,5 +65,6 @@ setup() {
 }
 
 teardown() {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	sudo -E kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -6,8 +6,12 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+TEST_INITRD="${TEST_INITRD:-no}"
+issue="https://github.com/kata-containers/runtime/issues/1127"
 
 setup() {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 
 	if sudo -E kubectl get runtimeclass | grep kata; then
@@ -25,6 +29,7 @@ setup() {
 }
 
 @test "Create Persistent Volume" {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	wait_time=10
 	sleep_time=2
 	volume_name="pv-volume"
@@ -54,6 +59,7 @@ setup() {
 }
 
 teardown() {
+	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	sudo -E kubectl delete pod "$pod_name"
 	sudo -E kubectl delete pvc "$volume_claim"
 	sudo -E kubectl delete pv "$volume_name"


### PR DESCRIPTION
Some K8s tests are failing with initrd (issue: kata-containers/runtime#1127)
so we want to skip them in order to unblock the CI.

Fixes #1057

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>