### PR TITLE
shimv2: skip test on centos

### DIFF
--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -7,6 +7,7 @@
 # This test will perform several tests to validate kata containers with
 # shimv2 + containerd + cri
 
+source /etc/os-release || source /usr/lib/os-release
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 ${SCRIPT_PATH}/../../../.ci/install_cri_containerd.sh
@@ -18,5 +19,9 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
-${SCRIPT_PATH}/../cri/integration-tests.sh
-
+if [ "$ID" != "centos" ]; then
+	${SCRIPT_PATH}/../cri/integration-tests.sh
+else
+	issue="https://github.com/kata-containers/tests/issues/1047"
+	echo "Skip shimv2 on $ID, see: $issue"
+fi


### PR DESCRIPTION
shimv2 on centos have been randomly failing.
See: https://github.com/kata-containers/tests/issues/1047
Skip the test until issue gets solved.

Fixes: #1061.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>