### PR TITLE
ci: Skip running kata-runtime kata-env for firecracker

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -9,6 +9,8 @@ set -e
 
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
 # Signify to all scripts that they are running in a CI environment
 [ -z "${KATA_DEV_MODE}" ] && export CI=true
 
@@ -114,11 +116,13 @@ fi
 
 # Now we have all the components installed, log that info before we
 # run the tests.
-if command -v kata-runtime; then
-	echo "Logging kata-env information:"
-	kata-runtime kata-env
-else
-	echo "WARN: Kata runtime is not installed"
+if [ "$KATA_HYPERVISOR" == "qemu" ]; then
+	if command -v kata-runtime; then
+		echo "Logging kata-env information:"
+		kata-runtime kata-env
+	else
+		echo "WARN: Kata runtime is not installed"
+	fi
 fi
 
 if [ -z "${METRICS_CI}" ]


### PR DESCRIPTION
kata-runtime kata-env does not work with firecracker so we need to skip
running it.

Fixes #1063

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>