### PR TITLE
ci: Modify Firecracker installation

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -85,3 +85,8 @@ check_vsock=$(sudo modprobe vhost_vsock)
 if [ $? != 0 ]; then
 	die "vsock is not supported on your host system"
 fi
+
+# FIXME - we need to create a symbolic link for kata-runtime
+# in order that kata-runtime kata-env works
+# https://github.com/kata-containers/runtime/issues/1144
+ln -s /opt/kata/bin/kata-runtime /usr/local/bin/

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -13,21 +13,14 @@ cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 
-KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
-
 echo "Install kata-containers image"
 "${cidir}/install_kata_image.sh"
 
 echo "Install Kata Containers Kernel"
 "${cidir}/install_kata_kernel.sh"
 
-if [ "$KATA_HYPERVISOR" == firecracker ]; then
-	echo "Install Firecracker"
-	"${cidir}/install_firecracker.sh"
-else
-	echo "Install Qemu"
-	"${cidir}/install_qemu.sh"
-fi
+echo "Install Qemu"
+"${cidir}/install_qemu.sh"
 
 echo "Install shim"
 "${cidir}/install_shim.sh"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -12,8 +12,6 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 
-KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
-
 # Modify the runtimes build-time defaults
 
 # enable verbose build
@@ -79,11 +77,7 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	fi
 fi
 
-if [ "$KATA_HYPERVISOR" == qemu ]; then
-	echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
-	docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
-	echo "Add kata-runtime as a new/default Docker runtime."
-	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
-else
-	echo "Kata runtime will not set as a default in Docker"
-fi
+echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
+docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
+echo "Add kata-runtime as a new/default Docker runtime."
+"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,6 +16,7 @@ source "${cidir}/lib.sh"
 arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_KATA="${INSTALL_KATA:-yes}"
 CI=${CI:-false}
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 # values indicating whether related intergration tests have been supported
 CRIO="${CRIO:-yes}"
@@ -83,6 +84,11 @@ install_kata() {
 	fi
 }
 
+install_firecracker() {
+	echo "Install Firecracker"
+	bash -f ${cidir}/install_firecracker.sh
+}
+
 install_extra_tools() {
 	echo "Install CNI plugins"
 	bash -f "${cidir}/install_cni_plugins.sh"
@@ -120,7 +126,11 @@ main() {
 	setup_distro_env
 	install_docker
 	enable_nested_virtualization
-	install_kata
+	if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+		install_firecracker
+	else
+		install_kata
+	fi
 	install_extra_tools
 	echo "Disable systemd-journald rate limit"
 	sudo crudini --set /etc/systemd/journald.conf Journal RateLimitInterval 0s


### PR DESCRIPTION
As we are installing from the tar, we are getting the static binaries for
runtime, shim, proxy, etc. With this change, we will avoid the duplication
of installing twice the kata elements.

Fixes #1075

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>