### PR TITLE
test: Change runtime name for Firecracker

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -67,7 +67,7 @@ else
 	cat <<-EOF | sudo tee "$docker_configuration_file"
 	{
 	 "runtimes": {
-	  "kata": {
+	  "kata-runtime": {
 	   "path": "${path}"
 	  }
 	 },


### PR DESCRIPTION
All our tests are looking for the kata-runtime name so we need to modify
the name of the runtime for Firecracker in order that the tests run correctly.

Fixes #1078

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>