### PR TITLE
kata-manager: Remove directory if git clone fails.

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -270,7 +270,7 @@ get_git_repo()
 	fi
 
 	info "getting repo $1 using git"
-	git clone "$repo_url" "$local_dest"
+	git clone "$repo_url" "$local_dest" || (rm -fr "$local_dest" && exit 1)
 }
 
 exec_document()


### PR DESCRIPTION
Remove directory if git clone fails, otherwise the following installation
fails.

Signed-off-by: Yang Bo <bo@hyper.sh>