### PR TITLE
CI: Fix new URL check logic in static check script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -473,7 +473,7 @@ check_docs()
 		if [ "$specific_branch" != "true" ]
 		then
 			# If the URL is new on this PR, it cannot be checked.
-			echo "$new_urls" | grep -q "\<${url}\>" && \
+			echo "$new_urls" | egrep -q "\<${url}\>" && \
 				info "ignoring new (but correct) URL: $url" && continue
 		fi
 


### PR DESCRIPTION
Fix a big in the static check script `check_docs()` function where regex
anchoring was being used with `grep`. That command doesn't understand
anchors so it needs to be `egrep` instead.

Fixes #1085.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>