### PR TITLE
test: Modify run.sh for Firecracker tests

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -89,4 +89,4 @@ fi
 # FIXME - we need to create a symbolic link for kata-runtime
 # in order that kata-runtime kata-env works
 # https://github.com/kata-containers/runtime/issues/1144
-ln -s /opt/kata/bin/kata-runtime /usr/local/bin/
+sudo ln -s /opt/kata/bin/kata-runtime /usr/local/bin/

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -24,6 +24,12 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
+	"FIRECRACKER")
+		echo "INFO: Running soak test"
+		sudo -E PATH="$PATH" bash -c "make docker-stability"
+		echo "INFO: Running oci call test"
+		sudo -E PATH="$PATH" bash -c "make oci"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"


### PR DESCRIPTION
This will modify the run.sh in order to run the soak and the oci call
test for Firecracker.

Fixes #1087

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>