### PR TITLE
ci: Modify Firecracker to install from repository

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -12,6 +12,7 @@ set -o pipefail
 cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 echo "Install kata-containers image"
 "${cidir}/install_kata_image.sh"
@@ -19,8 +20,13 @@ echo "Install kata-containers image"
 echo "Install Kata Containers Kernel"
 "${cidir}/install_kata_kernel.sh"
 
-echo "Install Qemu"
-"${cidir}/install_qemu.sh"
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	echo "Install Firecracker"
+	"${cidir}/install_firecracker.sh"
+else
+	echo "Install Qemu"
+	"${cidir}/install_qemu.sh"
+fi
 
 echo "Install shim"
 "${cidir}/install_shim.sh"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -11,6 +11,7 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 # Modify the runtimes build-time defaults
 
@@ -77,7 +78,17 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	fi
 fi
 
-echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
-docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
-echo "Add kata-runtime as a new/default Docker runtime."
-"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
+if [ "$KATA_HYPERVISOR" == "qemu" ]; then
+	echo "Add runtime as a new/default Docker runtime. Docker version \"$(docker --version)\" could change according to updates."
+	docker_options="-D --add-runtime kata-runtime=/usr/local/bin/kata-runtime"
+	echo "Add kata-runtime as a new/default Docker runtime."
+	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
+else
+	echo "Kata runtime will not set as a default in Docker"
+fi
+
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	echo "Enable firecracker configuration.toml"
+	path="/usr/share/defaults/kata-containers"
+	sudo mv ${path}/configuration-fc.toml ${path}/configuration.toml
+fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,7 +16,6 @@ source "${cidir}/lib.sh"
 arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_KATA="${INSTALL_KATA:-yes}"
 CI=${CI:-false}
-KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 # values indicating whether related intergration tests have been supported
 CRIO="${CRIO:-yes}"
@@ -84,11 +83,6 @@ install_kata() {
 	fi
 }
 
-install_firecracker() {
-	echo "Install Firecracker"
-	bash -f ${cidir}/install_firecracker.sh
-}
-
 install_extra_tools() {
 	echo "Install CNI plugins"
 	bash -f "${cidir}/install_cni_plugins.sh"
@@ -126,11 +120,7 @@ main() {
 	setup_distro_env
 	install_docker
 	enable_nested_virtualization
-	if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-		install_firecracker
-	else
-		install_kata
-	fi
+	install_kata
 	install_extra_tools
 	echo "Disable systemd-journald rate limit"
 	sudo crudini --set /etc/systemd/journald.conf Journal RateLimitInterval 0s


### PR DESCRIPTION
Instead of installing firecracker, runtime, and all the other Kata
components from the tar, this will change to install from the sources.

Fixes #1091

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>