### PR TITLE
ci: Exclude *.service.in files from license static check

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -360,6 +360,7 @@ check_license_headers()
 		--exclude="*.png" \
 		--exclude="*.pub" \
 		--exclude="*.service" \
+		--exclude="*.service.in" \
 		--exclude="*.svg" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \


### PR DESCRIPTION
In order to prevent CI failures when systemd service template
files are modified, this commit excludes *.service.in files from
the license static check script.

Fixes #1100

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>