### PR TITLE
test: Filter docker integration tests for Firecracker

### DIFF
--- a/.ci/hypervisors/firecracker/configuration_firecracker.yaml
+++ b/.ci/hypervisors/firecracker/configuration_firecracker.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# We need to skip some docker integration tests as they are not
+# running correctly using Firecracker. We will skip them using
+# the ginkgo flag 'skip=REGEXP'.
+test:
+  - docker
+docker:
+  Describe:
+    - restart
+    - docker exec
+    - capabilities
+    - package manager update test
+    - build with docker
+    - inspect
+    - docker top
+    - users and groups
+    - terminal with docker
+    - docker commit
+    - ulimits
+    - docker cp with volume attached
+    - load with docker
+    - docker volume
+    - docker env
+    - CPUs and CPU set
+    - docker exit code
+    - run container with docker
+    - run hot plug block devices
+    - pause with docker
+    - Update number of CPUs
+    - docker cp
+    - docker privileges
+    - diff
+    - Hot plug CPUs
+    - Update CPU constraints
+    - memory constraints
+    - Hotplug memory when create containers
+    - run container and update its memory constraints
+  Context:
+    - remove bind-mount source before container exits
+  It:

--- a/.ci/hypervisors/firecracker/filter_docker_firecracker.sh
+++ b/.ci/hypervisors/firecracker/filter_docker_firecracker.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/../../lib.sh"
+
+test_config_file="${cidir}/configuration_firecracker.yaml"
+
+describe_skip_flag="docker.Describe"
+context_skip_flag="docker.Context"
+it_skip_flag="docker.It"
+
+# value for '-skip' in ginkgo
+_skip_options=()
+
+filter_and_build() {
+	local dependency="$1"
+	local array_docker=$("${GOPATH}/bin/yq" read "${test_config_file}" "${dependency}")
+	[ "${array_docker}" = "null" ] && return
+	mapfile -t _array_docker <<< "${array_docker}"
+	for entry in "${_array_docker[@]}"
+	do
+		_skip_options+=("${entry#- }|")
+	done
+}
+
+main() {
+	# Check GOPATH is set
+	check_gopath
+
+	# Check if yq is installed
+	[ -z "$(command -v yq)" ] && install_yq
+
+	# Build skip option based on Describe block
+	filter_and_build "${describe_skip_flag}"
+
+	# Build skip option based on context block
+	filter_and_build "${context_skip_flag}"
+
+	# Build skip option based on it block
+	filter_and_build "${it_skip_flag}"
+
+	skip_options=$(IFS= ; echo "${_skip_options[*]}")
+
+	echo "${skip_options%|}"
+}
+
+main

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -25,6 +25,8 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
 	"FIRECRACKER")
+		echo "INFO: Running docker integration tests"
+		sudo -E PATH="$PATH" bash -c "make docker"
 		echo "INFO: Running soak test"
 		sudo -E PATH="$PATH" bash -c "make docker-stability"
 		echo "INFO: Running oci call test"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TIMEOUT := 60
 UNION := functional docker crio docker-compose network netmon docker-stability oci openshift kubernetes swarm vm-factory entropy ramdisk shimv2
 
 # skipped test suites for docker integration tests
-SKIP :=
+SKIP := $(shell bash -f .ci/hypervisors/$(KATA_HYPERVISOR)/filter_docker_$(KATA_HYPERVISOR).sh)
 
 # get arch
 ARCH := $(shell bash -c '.ci/kata-arch.sh -d')


### PR DESCRIPTION
Currently not all the docker integration tests are running
with Firecracker so with this change we filter the tests.

Fixes #1104

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>