### PR TITLE
ci: Build memory-tested vish/stress image if arch arm64/ppc64le

### DIFF
--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -38,7 +38,7 @@ func TestIntegration(t *testing.T) {
 
 	for _, i := range images {
 		// vish/stress is single-arch image only for amd64
-		if i == StressImage && runtime.GOARCH == "arm64" {
+		if i == StressImage && runtime.GOARCH != "amd64" {
 			//check if vish/stress has already been built
 			argsImage := []string{"--format", "'{{.Repository}}:{{.Tag}}'", StressImage}
 			imagesStdout, _, imagesExitcode := dockerImages(argsImage...)


### PR DESCRIPTION
Since vish/stress is a single-arch image for amd64, we need
to build it for other architectures like arm64/ppc64le.

Fixes: #1113

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com