### PR TITLE
test: Remove -t flag from timeout as it is not longer supported

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -95,7 +95,7 @@ setup() {
 }
 
 @test "[display version] run a crate container" {
-	docker run --rm --runtime=$RUNTIME -i -e CRATE_HEAP_SIZE=1g crate timeout -t 10 crate -v
+	docker run --rm --runtime=$RUNTIME -i -e CRATE_HEAP_SIZE=1g crate timeout 10 crate -v
 }
 
 @test "[display nameserver] check the resolv.conf in a crux container" {


### PR DESCRIPTION
The timeout -t flag is not longer supported while we are running
a container with crate.

Fixes #1116

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>