### PR TITLE
ci: build and install qemu behind a proxy

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -63,8 +63,8 @@ build_and_install_qemu() {
 	pushd "${GOPATH}/src/${QEMU_REPO}"
 	git fetch
 	git checkout "$CURRENT_QEMU_COMMIT"
-	[ -d "capstone" ] || git clone https://github.com/qemu/capstone.git capstone
-	[ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
+	[ -n "$(ls -A capstone)" ] || git clone https://github.com/qemu/capstone.git capstone
+	[ -n "$(ls -A ui/keycodemapdb)" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 
 	# Apply required patches
 	QEMU_PATCHES_PATH="${GOPATH}/src/${PACKAGING_REPO}/obs-packaging/qemu-lite/patches"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -11,6 +11,7 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 
+CURRENT_QEMU_BRANCH=$(get_version "assets.hypervisor.qemu-lite.branch")
 CURRENT_QEMU_COMMIT=$(get_version "assets.hypervisor.qemu-lite.commit")
 PACKAGED_QEMU="qemu-lite"
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
@@ -51,13 +52,14 @@ install_packaged_qemu() {
 }
 
 build_and_install_qemu() {
-	QEMU_REPO=$(get_version "assets.hypervisor.qemu-lite.url")
+	QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu-lite.url")
 	# Remove 'https://' from the repo url to be able to clone the repo using 'go get'
-	QEMU_REPO=${QEMU_REPO/https:\/\//}
+	QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 	PACKAGING_REPO="github.com/kata-containers/packaging"
 	QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
 
-	go get -d "${QEMU_REPO}" || true
+	mkdir -p "${GOPATH}/src"
+	git clone --branch "$CURRENT_QEMU_BRANCH" --single-branch "${QEMU_REPO_URL}" "${GOPATH}/src/${QEMU_REPO}"
 	go get -d "$PACKAGING_REPO" || true
 
 	pushd "${GOPATH}/src/${QEMU_REPO}"


### PR DESCRIPTION
Use `git` instead of `go get` to clone qemu and its repositories since `go get`
downloads the repo and its modules hence it's too slow, this behaviour can fail
in systems that run behind a proxy.

fixes #1119