### PR TITLE
ci: Kata-ksm-throttler for all the distros

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -7,6 +7,10 @@
 #
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
+export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
+
+# Name of systemd service for the throttler
+KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
 
 # How long do we wait for docker to perform a task before we
 # timeout with the presumption it has hung.

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -88,3 +88,8 @@ chronic sudo -E yum install -y procenv
 
 echo "Install haveged"
 chronic sudo -E yum install -y haveged
+
+if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+	echo "Install ${KATA_KSM_THROTTLER_JOB}"
+	chronic sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
+fi

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -89,3 +89,8 @@ chronic sudo -E apt install -y procenv
 
 echo "Install haveged"
 chronic sudo -E apt install -y haveged
+
+if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+	echo "Install ${KATA_KSM_THROTTLER_JOB}"
+	chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
+fi

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -63,3 +63,8 @@ chronic sudo -E dnf -y install procenv
 
 echo "Install haveged"
 chronic sudo -E dnf -y install haveged
+
+if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+	echo "Install ${KATA_KSM_THROTTLER_JOB}"
+	chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
+fi

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -75,3 +75,8 @@ chronic sudo -E apt install -y procenv
 
 echo "Install haveged"
 chronic sudo -E apt install -y haveged
+
+if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+	echo "Install ${KATA_KSM_THROTTLER_JOB}"
+	chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
+fi

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -46,16 +46,6 @@ if [ "$ID" == "debian" ]; then
 	exit
 fi
 
-install_kata_ksm_throttler() {
-	if [ "$ID" == "debian" ]; then
-		package="kata-ksm-throttler"
-		echo "Install ${package}"
-		sudo -E apt install -y ${package}
-		echo "Start ${package}"
-		systemctl start ${package}
-        fi
-}
-
 check_vsock_active() {
 	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
 	vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')
@@ -220,8 +210,6 @@ check_mounts() {
 
 init() {
 	kill_all_containers
-
-	install_kata_ksm_throttler
 
 	# Enable netmon
 	enable_netmon

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -11,6 +11,7 @@ RESULT_DIR="${LIB_DIR}/../results"
 source ${LIB_DIR}/../../lib/common.bash
 source ${LIB_DIR}/json.bash
 source /etc/os-release || source /usr/lib/os-release
+KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-no}"
 
 # Set variables to reasonable defaults if unset or empty
 DOCKER_EXE="${DOCKER_EXE:-docker}"
@@ -196,23 +197,19 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	if [ "$ID" == debian ]; then
-		local processes="kata-proxy kata-shim kata-runtime qemu"
-	else
-		local processes="kata-proxy kata-shim kata-runtime qemu ksm-throttler"
-	fi
+	local processes="kata-proxy kata-shim kata-runtime qemu"
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"
 		pgrep -a ${p}
 	done
 
-	# Verify kata-ksm-throttler on Debian
-	if [ "$ID" == "debian" ]; then
-		debian_process="kata-ksm-throttler"
-		debian_process_path=$(whereis ${debian_process} | tr -d '[:space:]'| cut -d ':' -f2)
-		echo " --pgrep ${debian_process}--"
-		pgrep -f ${debian_process_path} > /dev/null
+	# Verify kata-ksm-throttler
+	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+		process="kata-ksm-throttler"
+		process_path=$(whereis ${process} | tr -d '[:space:]'| cut -d ':' -f2)
+		echo " --pgrep ${process}--"
+		pgrep -f ${process_path} > /dev/null
 	fi
 }
 


### PR DESCRIPTION
With this we will install kata-ksm-throttler and when it is installed
we will verify that this process is running. The main purpose is to
enable a Jenkins job for kata-ksm-throttler.

Fixes #1121

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>