### PR TITLE
CI: add filter scheme for CI tests on ppc64le

### DIFF
--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# for now, not all integration test suites are fully passed in ppc64le.
+# some need to be tested, and some need to be refined.
+# sequence of 'test' holds supported integration tests components.
+test:
+  - functional
+  - docker
+  - docker-compose
+
+# for now, not all test suites under docker integration are fully passed in aarch64.
+# some need to be tested, and some need to be refined.
+# ginkgo offers '-skip=REGEXP' flag to skip specific ones.
+# you can use infos from docker.Describe, docker.Context or docker.It to point to
+# specific test specs or whole container of specs.
+docker:
+  Describe:
+    - Update CPU set
+  Context:
+  It:
+    - should have the right number of vCPUs

--- a/.ci/ppc64le/filter_docker_ppc64le.sh
+++ b/.ci/ppc64le/filter_docker_ppc64le.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+GOPATH_LOCAL="${GOPATH%%:*}"
+kata_dir="${GOPATH_LOCAL}/src/github.com/kata-containers"
+test_dir="${kata_dir}/tests"
+ci_dir="${test_dir}/.ci"
+test_config_file="${ci_dir}/ppc64le/configuration_ppc64le.yaml"
+
+describe_skip_flag="docker.Describe"
+context_skip_flag="docker.Context"
+it_skip_flag="docker.It"
+
+# value for '-skip' in ginkgo
+_skip_options=()
+
+source "${ci_dir}/lib.sh"
+
+filter_and_build()
+{
+	local dependency="$1"
+	local array_docker=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${dependency}")
+	[ "${array_docker}" = "null" ] && return
+	mapfile -t _array_docker <<< "${array_docker}"
+	for entry in "${_array_docker[@]}"
+	do
+		_skip_options+=("${entry#- }|")
+	done
+}
+
+main()
+{
+	# install yq if not exist
+	[ -z "$(command -v yq)" ] && install_yq
+	# build skip option based on Describe block
+	filter_and_build "${describe_skip_flag}"
+
+	# build skip option based on context block
+	filter_and_build "${context_skip_flag}"
+
+	# build skip option based on it block
+	filter_and_build "${it_skip_flag}"
+
+	skip_options=$(IFS= ; echo "${_skip_options[*]}")
+
+	echo "${skip_options%|}"
+}
+
+main

--- a/.ci/ppc64le/filter_test_ppc64le.sh
+++ b/.ci/ppc64le/filter_test_ppc64le.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+GOPATH_LOCAL="${GOPATH%%:*}"
+kata_dir="${GOPATH_LOCAL}/src/github.com/kata-containers"
+test_dir="${kata_dir}/tests"
+ci_dir="${test_dir}/.ci"
+test_config_file="${ci_dir}/ppc64le/configuration_ppc64le.yaml"
+
+test_filter_flag="test"
+
+_test_union=()
+
+source "${ci_dir}/lib.sh"
+
+main()
+{
+	# install yq if not exist
+	[ -z "$(command -v yq)" ] && install_yq
+	local array_test=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${test_filter_flag}")
+	[ "${array_test}" = "null" ] && return
+	mapfile -t _array_test <<< "${array_test}"
+	for entry in "${_array_test[@]}"
+	do
+		_test_union+=("${entry#- }")
+	done
+	test_union=$(IFS=" "; echo "${_test_union[*]}")
+	echo "${test_union}"
+}
+
+main

--- a/arch/ppc64le-options.mk
+++ b/arch/ppc64le-options.mk
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# union for 'make test'
+UNION := $(shell bash -f .ci/ppc64le/filter_test_ppc64le.sh)
+
+# skiped test suites for docker integration tests
+SKIP := $(shell bash -f .ci/ppc64le/filter_docker_ppc64le.sh)


### PR DESCRIPTION
Not all tests are supported on ppc64le. Use
the filter scheme to filter out test cases
that are not meant for ppc64le.

Fixes: #1131

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com