### PR TITLE
CI: Set GOPATH once

### DIFF
--- a/.ci/hypervisors/firecracker/filter_docker_firecracker.sh
+++ b/.ci/hypervisors/firecracker/filter_docker_firecracker.sh
@@ -30,9 +30,6 @@ filter_and_build() {
 }
 
 main() {
-	# Check GOPATH is set
-	check_gopath
-
 	# Check if yq is installed
 	[ -z "$(command -v yq)" ] && install_yq
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -15,6 +15,9 @@ export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 # more formats).
 export KATA_DOCKER_TIMEOUT=30
 
+# Ensure GOPATH set
+export GOPATH=${GOPATH:-$(go env GOPATH)}
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"
@@ -86,7 +89,6 @@ function build_and_install() {
 }
 
 function install_yq() {
-	GOPATH=${GOPATH:-${HOME}/go}
 	local yq_path="${GOPATH}/bin/yq"
 	local yq_pkg="github.com/mikefarah/yq"
 	[ -x  "${GOPATH}/bin/yq" ] && return
@@ -153,7 +155,6 @@ function get_dep_from_yaml_db(){
 
 function get_version(){
 	dependency="$1"
-	GOPATH=${GOPATH:-${HOME}/go}
 	runtime_repo="github.com/kata-containers/runtime"
 	runtime_repo_dir="$GOPATH/src/${runtime_repo}"
 	versions_file="${runtime_repo_dir}/versions.yaml"
@@ -175,13 +176,6 @@ function get_test_version(){
 	db="${cidir}/../versions.yaml"
 
 	get_dep_from_yaml_db "${db}" "${dependency}"
-}
-
-function check_gopath() {
-	# Verify GOPATH is set
-	if [ -z "$GOPATH" ]; then
-		export GOPATH=$(go env GOPATH)
-	fi
 }
 
 function waitForProcess(){

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -12,8 +12,6 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-check_gopath
-
 export RUNTIME="kata-runtime"
 
 export CI_JOB="${CI_JOB:-default}"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -116,7 +116,6 @@ install_extra_tools() {
 }
 
 main() {
-	check_gopath
 	setup_distro_env
 	install_docker
 	enable_nested_virtualization


### PR DESCRIPTION
The `.ci/lib.sh` script was setting `GOPATH` *three times*. Set it once in
the correct manner so that all scripts which source `.ci/lib.sh` will
have `GOPATH` set.

By setting `GOPATH` at the top of the script, this also resolves the
current CI error we're seeing where `GOPATH` is being referenced before
it's being set:

```sh
/home/centos/tests/.ci/lib.sh: line 19: GOPATH: unbound variable
```

Fixes #1133.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>