### PR TITLE
CI: Run clean-up script for bare metal ppc64le environment

### DIFF
--- a/.ci/ppc64le/clean_up_ppc64le.sh
+++ b/.ci/ppc64le/clean_up_ppc64le.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
+source "${lib_script}"
+
+gen_clean_arch || info "Arch cleanup scripts failed"


### PR DESCRIPTION
Run clean-up script as we should provide clean environment
for each CI build.

Fixes: #1138

Signed-off-by: niteshkonkar@in.ibm.com