### PR TITLE
functional: add cgroup path

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -122,6 +122,7 @@
 				}
 			]
 		},
+		"cgroupsPath": "kata",
 		"namespaces": [
 			{
 				"type": "pid"


### PR DESCRIPTION
add cgroupsPath to test cgroup path creation in functional tests

fixes #1140

Signed-off-by: Julio Montes <julio.montes@intel.com>