### PR TITLE
Kata manager improvements

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -422,23 +422,10 @@ parse_args()
 	while getopts "c:hnv" opt
 	do
 		case "$opt" in
-			c)
-				config_file="$OPTARG"
-				;;
-
-			h)
-				usage
-				exit 0
-				;;
-
-			n)
-				execute="no"
-				verbose="yes"
-				;;
-
-			v)
-				verbose="yes"
-				;;
+			c) config_file="$OPTARG" ;;
+			h) usage; exit 0 ;;
+			n) execute="no"; verbose="yes" ;;
+			v) verbose="yes" ;;
 		esac
 	done
 

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -358,25 +358,24 @@ cmd_remove_packages()
 	info "removing packages"
 
 	case "$distro" in
-		centos|fedora)
+		centos|fedora|opensuse|rhel|sles)
 			packages=$(rpm -qa|egrep "${packages_regex}" || true)
 			;;
 
-		ubuntu)
+		debian|ubuntu)
 			packages=$(dpkg-query -W -f='${Package}\n'|egrep "${packages_regex}" || true)
 			;;
 
-		*)
-			die "invalid distro: '$distro'"
-			;;
+		*) die "invalid distro: '$distro'" ;;
 	esac
 
 	[ -z "$packages" ] && die "packages not installed"
 
 	case "$distro" in
-		centos) sudo yum -y remove $packages ;;
+		centos|rhel) sudo yum -y remove $packages ;;
+		debian|ubuntu) sudo apt-get -y remove $packages ;;
 		fedora) sudo dnf -y remove $packages ;;
-		ubuntu) sudo apt-get -y remove $packages ;;
+		opensuse|sles) sudo zypper remove -y $packages ;;
 	esac
 }
 

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -470,4 +470,5 @@ main()
 	setup
 	parse_args "$@"
 }
+
 main "$@"


### PR DESCRIPTION
Add a `-f` option to forcibly remove packages that may be "held", "pinned" or locked.

Fixes #1143.

Support Debian, OpenSuSE, SLES and RHEL.

Fixes #1142.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>