### PR TITLE
integration/docker: increase quota and period

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -120,8 +120,8 @@ var _ = Describe("CPU constraints", func() {
 		args       []string
 		id         string
 		shares     int = 300
-		quota      int = 2000
-		period     int = 1500
+		quota      int = 20000
+		period     int = 15000
 		cpusetCpus int = 0
 		cpusetMems int = 0
 	)


### PR DESCRIPTION
cpu cgroups in the host is about to be supported and currently the values to
test quota and period are too small to run a hypervisor.

fixes #1152

Signed-off-by: Julio Montes <julio.montes@intel.com>