### PR TITLE
k8s: do not use sudo when making calls to kubectl 

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -23,7 +23,7 @@ crio)
 	;;
 esac
 
-export KUBECONFIG=/etc/kubernetes/admin.conf
+export KUBECONFIG="$HOME/.kube/config"
 sudo -E kubeadm reset -f --cri-socket="${cri_runtime_socket}"
 
 sudo systemctl stop "${cri_runtime}"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -64,30 +64,30 @@ sudo cp "/etc/kubernetes/admin.conf" "$HOME/.kube/config"
 sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
 export KUBECONFIG="$HOME/.kube/config"
 
-sudo -E kubectl get nodes
-sudo -E kubectl get pods
+kubectl get nodes
+kubectl get pods
 
 # kube-flannel config file taken from k8s 1.12 documentation:
 flannel_config="https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml"
 
-sudo -E kubectl apply -f "$flannel_config"
+kubectl apply -f "$flannel_config"
 
 # The kube-dns pod usually takes around 120 seconds to get ready
 # This instruction will wait until it is up and running, so we can
 # start creating our containers.
 dns_wait_time=120
 sleep_time=5
-cmd="sudo -E kubectl get pods --all-namespaces | grep 'coredns.*1/1.*Running'"
+cmd="kubectl get pods --all-namespaces | grep 'coredns.*1/1.*Running'"
 waitForProcess "$dns_wait_time" "$sleep_time" "$cmd"
 
 if [ "${use_runtime_class}" == true ]; then
 	runtimeclass_files_path="${SCRIPT_PATH}/runtimeclass_workloads"
 	echo "Install RuntimeClass resource definition"
-	sudo -E kubectl apply -f \
+	kubectl apply -f \
 		"https://raw.githubusercontent.com/kubernetes/kubernetes/v${kubernetes_version/-*}/cluster/addons/runtimeclass/runtimeclass_crd.yaml"
 	echo "Create kata RuntimeClass resource"
-	sudo -E kubectl create -f "${runtimeclass_files_path}/kata-runtimeclass.yaml"
+	kubectl create -f "${runtimeclass_files_path}/kata-runtimeclass.yaml"
 fi
 
 # Enable the master node to be able to schedule pods.
-sudo -E kubectl taint nodes "$(hostname)" node-role.kubernetes.io/master:NoSchedule-
+kubectl taint nodes "$(hostname)" node-role.kubernetes.io/master:NoSchedule-

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -59,7 +59,10 @@ fi
 
 sudo -E kubeadm init --config "${kubeadm_config_file}"
 
-export KUBECONFIG=/etc/kubernetes/admin.conf
+mkdir -p "$HOME/.kube"
+sudo cp "/etc/kubernetes/admin.conf" "$HOME/.kube/config"
+sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
+export KUBECONFIG="$HOME/.kube/config"
 
 sudo -E kubectl get nodes
 sudo -E kubectl get pods

--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -8,10 +8,10 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="handlers"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -20,16 +20,16 @@ setup() {
 
 @test "Running with postStart and preStop handlers" {
 	# Create the pod with postStart and preStop handlers
-	sudo -E kubectl create -f "${pod_config_dir}/lifecycle-events.yaml"
+	kubectl create -f "${pod_config_dir}/lifecycle-events.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check postStart message
 	display_message="cat /usr/share/message"
-	check_postStart=$(sudo -E kubectl exec $pod_name -- sh -c "$display_message" | grep "Hello from the postStart handler")
+	check_postStart=$(kubectl exec $pod_name -- sh -c "$display_message" | grep "Hello from the postStart handler")
 }
 
 teardown(){
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -8,8 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep -q kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep -q kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -21,24 +21,24 @@ setup() {
 	pod_name="config-env-test-pod"
 
 	# Create ConfigMap
-	sudo -E kubectl create -f "${pod_config_dir}/configmap.yaml"
+	kubectl create -f "${pod_config_dir}/configmap.yaml"
 
 	# View the values of the keys
-	sudo -E kubectl get configmaps $config_name -o yaml | grep -q "data-"
+	kubectl get configmaps $config_name -o yaml | grep -q "data-"
 
 	# Create a pod that consumes the ConfigMap
-	sudo -E kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
+	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check env
 	cmd="env"
-	sudo -E kubectl exec $pod_name -- sh -c $cmd | grep "KUBE_CONFIG_1=value-1"
-	sudo -E kubectl exec $pod_name -- sh -c $cmd | grep "KUBE_CONFIG_2=value-2"
+	kubectl exec $pod_name -- sh -c $cmd | grep "KUBE_CONFIG_1=value-1"
+	kubectl exec $pod_name -- sh -c $cmd | grep "KUBE_CONFIG_2=value-2"
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$pod_name"
-	sudo -E kubectl delete configmap "$config_name"
+	kubectl delete pod "$pod_name"
+	kubectl delete configmap "$config_name"
 }

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -8,8 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -22,35 +22,35 @@ setup() {
 	second_pod_name="secret-envars-test-pod"
 
 	# Create the secret
-	sudo -E kubectl create -f "${pod_config_dir}/inject_secret.yaml"
+	kubectl create -f "${pod_config_dir}/inject_secret.yaml"
 
 	# View information about the secret
-	sudo -E kubectl get secret "${secret_name}" -o yaml | grep "type: Opaque"
+	kubectl get secret "${secret_name}" -o yaml | grep "type: Opaque"
 
 	# Create a pod that has access to the secret through a volume
-	sudo -E kubectl create -f "${pod_config_dir}/pod-secret.yaml"
+	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# List the files
 	cmd="ls /tmp/secret-volume"
-	sudo -E kubectl exec $pod_name -- sh -c "$cmd" | grep -w "password"
-	sudo -E kubectl exec $pod_name -- sh -c "$cmd" | grep -w "username"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep -w "password"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep -w "username"
 
 	# Create a pod that has access to the secret data through environment variables
-	sudo -E kubectl create -f "${pod_config_dir}/pod-secret-env.yaml"
+	kubectl create -f "${pod_config_dir}/pod-secret-env.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$second_pod_name"
+	kubectl wait --for=condition=Ready pod "$second_pod_name"
 
 	# Display environment variables
 	second_cmd="printenv"
-	sudo -E kubectl exec $second_pod_name -- sh -c "$second_cmd" | grep -w "SECRET_USERNAME"
-	sudo -E kubectl exec $second_pod_name -- sh -c "$second_cmd" | grep -w "SECRET_PASSWORD"
+	kubectl exec $second_pod_name -- sh -c "$second_cmd" | grep -w "SECRET_USERNAME"
+	kubectl exec $second_pod_name -- sh -c "$second_cmd" | grep -w "SECRET_PASSWORD"
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$pod_name" "$second_pod_name"
-	sudo -E kubectl delete secret "$secret_name"
+	kubectl delete pod "$pod_name" "$second_pod_name"
+	kubectl delete secret "$secret_name"
 }

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -8,10 +8,10 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -20,16 +20,16 @@ setup() {
 
 @test "Environment variables" {
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-env.yaml"
+	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"
-	sudo -E kubectl exec $pod_name -- sh -c $cmd | grep "MY_POD_NAME=$pod_name"
+	kubectl exec $pod_name -- sh -c $cmd | grep "MY_POD_NAME=$pod_name"
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -8,10 +8,10 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="liveness-exec"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -22,19 +22,19 @@ setup() {
 	sleep_liveness=10
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
+	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check liveness probe returns a success code
-	sudo -E kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
+	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
 
 	# Sleep necessary to check liveness probe returns a failure code
 	sleep "$sleep_liveness"
-	sudo -E kubectl describe pod "$pod_name" | grep "Liveness probe failed"
+	kubectl describe pod "$pod_name" | grep "Liveness probe failed"
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -12,10 +12,10 @@ issue="https://github.com/kata-containers/runtime/issues/1127"
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="memory-test"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -34,7 +34,7 @@ setup() {
             "${pod_config_dir}/pod-memory-limit.yaml" > "${pod_config_dir}/test_exceed_memory.yaml"
 
 	# Create the pod exceeding memory constraints
-	run sudo -E kubectl create -f "${pod_config_dir}/test_exceed_memory.yaml"
+	run kubectl create -f "${pod_config_dir}/test_exceed_memory.yaml"
 	[ "$status" -ne 0 ]
 
 	rm -f "${pod_config_dir}/test_exceed_memory.yaml"
@@ -52,11 +52,11 @@ setup() {
             "${pod_config_dir}/pod-memory-limit.yaml" > "${pod_config_dir}/test_within_memory.yaml"
 
 	# Create the pod within memory constraints
-	sudo -E kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
+	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	rm -f "${pod_config_dir}/test_within_memory.yaml"
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -8,8 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep -q kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep -q kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -26,24 +26,24 @@ setup() {
 
 	# Create the jobs
 	for i in "${names[@]}"; do
-		sudo -E kubectl create -f "${pod_config_dir}/job-$i.yaml"
+		kubectl create -f "${pod_config_dir}/job-$i.yaml"
 	done
 
 	# Check the jobs
-	sudo -E kubectl get jobs -l jobgroup=${job_name}
+	kubectl get jobs -l jobgroup=${job_name}
 
 	# Check the pods
-	sudo -E kubectl wait --for=condition=Ready pod -l jobgroup=${job_name}
+	kubectl wait --for=condition=Ready pod -l jobgroup=${job_name}
 
 	# Check output of the jobs
-	for i in $(sudo -E kubectl get pods -l jobgroup=${job_name} -o name); do
-		sudo -E kubectl logs ${i}
+	for i in $(kubectl get pods -l jobgroup=${job_name} -o name); do
+		kubectl logs ${i}
 	done
 }
 
 teardown() {
 	# Delete jobs
-	sudo -E kubectl delete jobs -l jobgroup=${job_name}
+	kubectl delete jobs -l jobgroup=${job_name}
 
 	# Remove generated yaml files
 	for i in "${names[@]}"; do

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -9,12 +9,12 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
 	skip "This is not working (https://github.com/kata-containers/agent/issues/261)"
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="busybox"
 	first_container_name="first-test-container"
 	second_container_name="second-test-container"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -27,26 +27,26 @@ setup() {
 	sleep_time=5
 
 	# Create the pod
-	sudo -E kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
+	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
 	# Check pod creation
-	pod_status_cmd="sudo -E kubectl get pods -a | grep $pod_name | grep Running"
+	pod_status_cmd="kubectl get pods -a | grep $pod_name | grep Running"
 	waitForProcess "$wait_time" "$sleep_time" "$pod_status_cmd"
 
 	# Check PID from first container
-	first_pid_container=$(sudo -E kubectl exec $pod_name -c $first_container_name ps | grep "/pause")
+	first_pid_container=$(kubectl exec $pod_name -c $first_container_name ps | grep "/pause")
 
 	# Check PID from second container
-	second_pid_container=$(sudo -E kubectl exec $pod_name -c $second_container_name ps | grep "/pause")
+	second_pid_container=$(kubectl exec $pod_name -c $second_container_name ps | grep "/pause")
 
 	[ "$first_pid_container" == "$second_pid_container" ]
 }
 
 teardown() {
 	skip "This is not working (https://github.com/kata-containers/agent/issues/261)"
-	sudo -E kubectl delete deployment "$pod_name"
+	kubectl delete deployment "$pod_name"
 	# Wait for the pods to be deleted
-	cmd="sudo -E kubectl get pods | grep found."
+	cmd="kubectl get pods | grep found."
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
-	sudo -E kubectl get pods
+	kubectl get pods
 }

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -7,8 +7,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -22,20 +22,20 @@ setup() {
 	sleep_time=2
 
 	# Create the resourcequota
-	sudo -E kubectl create -f "${pod_config_dir}/resource-quota.yaml"
+	kubectl create -f "${pod_config_dir}/resource-quota.yaml"
 
 	# View information about resourcequota
-	sudo -E kubectl get resourcequota "$resource_name" --output=yaml | grep 'pods: "2"'
+	kubectl get resourcequota "$resource_name" --output=yaml | grep 'pods: "2"'
 
 	# Create deployment
-	sudo -E kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
+	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
 
 	# View information about the deployment
-	cmd="sudo -E kubectl get deployment \"$deployment_name\" --output=yaml | grep -q 'forbidden: exceeded quota'"
+	cmd="kubectl get deployment \"$deployment_name\" --output=yaml | grep -q 'forbidden: exceeded quota'"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 }
 
 teardown() {
-	sudo -E kubectl delete resourcequota "$resource_name"
-	sudo -E kubectl delete deployment "$deployment_name"
+	kubectl delete resourcequota "$resource_name"
+	kubectl delete deployment "$deployment_name"
 }

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -8,8 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep -q kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep -q kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -29,30 +29,30 @@ setup() {
 	echo "$password" > $SECOND_TMP_FILE
 
 	# Package these files into secrets
-	sudo -E kubectl create secret generic user --from-file=$TMP_FILE
-	sudo -E kubectl create secret generic pass --from-file=$SECOND_TMP_FILE
+	kubectl create secret generic user --from-file=$TMP_FILE
+	kubectl create secret generic pass --from-file=$SECOND_TMP_FILE
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
+	kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check that the projected sources exists
 	cmd="ls /projected-volume | grep username"
-	sudo -E kubectl exec $pod_name -- sh -c "$cmd"
+	kubectl exec $pod_name -- sh -c "$cmd"
 	sec_cmd="ls /projected-volume | grep password"
-	sudo -E kubectl exec $pod_name -- sh -c "$sec_cmd"
+	kubectl exec $pod_name -- sh -c "$sec_cmd"
 
 	# Check content of the projected sources
 	check_cmd="cat /projected-volume/username*"
-	sudo -E kubectl exec $pod_name -- sh -c "$check_cmd" | grep "$username"
+	kubectl exec $pod_name -- sh -c "$check_cmd" | grep "$username"
 	sec_check_cmd="cat /projected-volume/password*"
-	sudo -E kubectl exec $pod_name -- sh -c "$sec_check_cmd" | grep "$password"
+	kubectl exec $pod_name -- sh -c "$sec_check_cmd" | grep "$password"
 }
 
 teardown() {
 	rm -f $TMP_FILE $SECOND_TMP_FILE
-	sudo -E kubectl delete pod "$pod_name"
-	sudo -E kubectl delete secret pass user
+	kubectl delete pod "$pod_name"
+	kubectl delete secret pass user
 }

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -11,9 +11,9 @@ issue="https://github.com/kata-containers/runtime/issues/1127"
 
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -26,13 +26,13 @@ setup() {
 	pod_name="qos-test"
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
+	kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
-	sudo -E kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Guaranteed"
+	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Guaranteed"
 }
 
 @test "Burstable QoS" {
@@ -41,13 +41,13 @@ setup() {
 	pod_name="burstable-test"
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-burstable.yam"l
+	kubectl create -f "${pod_config_dir}/pod-burstable.yam"l
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
-	sudo -E kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Burstable"
+	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Burstable"
 }
 
 @test "BestEffort QoS" {
@@ -55,16 +55,16 @@ setup() {
 	pod_name="besteffort-test"
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-besteffort.yam"l
+	kubectl create -f "${pod_config_dir}/pod-besteffort.yam"l
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
-	sudo -E kubectl get pod "$pod_name" --output=yaml | grep "qosClass: BestEffort"
+	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: BestEffort"
 }
 
 teardown() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -8,8 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
-	export KUBECONFIG=/etc/kubernetes/admin.conf
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	export KUBECONFIG="$HOME/.kube/config"
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -20,17 +20,17 @@ setup() {
 	pod_name="security-context-test"
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
+	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check user
 	cmd="ps --user 1000 -f"
 	process="tail -f /dev/null"
-	sudo -E kubectl exec $pod_name -- sh -c $cmd | grep "$process"
+	kubectl exec $pod_name -- sh -c $cmd | grep "$process"
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$pod_name"
+	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -9,13 +9,13 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
 	busybox_image="busybox"
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	first_pod_name="first-test"
 	second_pod_name="second-test"
 	# Pull the images before launching workload.
 	sudo -E crictl pull "$busybox_image"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -30,19 +30,19 @@ setup() {
 	first_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$first_pod_config"
 	sed -i "s/NAME/${first_pod_name}/" "$first_pod_config"
-	sudo -E kubectl create -f "$first_pod_config"
-	sudo -E kubectl wait --for=condition=Ready pod "$first_pod_name"
-	first_pod_uts_ns=$(sudo -E kubectl exec "$first_pod_name" -- sh -c "$uts_cmd" | grep uts | cut -d ':' -f3)
-	first_pod_ipc_ns=$(sudo -E kubectl exec "$first_pod_name" -- sh -c "$ipc_cmd" | grep ipc | cut -d ':' -f3)
+	kubectl create -f "$first_pod_config"
+	kubectl wait --for=condition=Ready pod "$first_pod_name"
+	first_pod_uts_ns=$(kubectl exec "$first_pod_name" -- sh -c "$uts_cmd" | grep uts | cut -d ':' -f3)
+	first_pod_ipc_ns=$(kubectl exec "$first_pod_name" -- sh -c "$ipc_cmd" | grep ipc | cut -d ':' -f3)
 
 	# Run the second pod
 	second_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$second_pod_config"
 	sed -i "s/NAME/${second_pod_name}/" "$second_pod_config"
-	sudo -E kubectl create -f "$second_pod_config"
-	sudo -E kubectl wait --for=condition=Ready pod "$second_pod_name"
-	second_pod_uts_ns=$(sudo -E kubectl exec "$second_pod_name" -- sh -c "$uts_cmd" | grep uts | cut -d ':' -f3)
-	second_pod_ipc_ns=$(sudo -E kubectl exec "$second_pod_name" -- sh -c "$ipc_cmd" | grep ipc | cut -d ':' -f3)
+	kubectl create -f "$second_pod_config"
+	kubectl wait --for=condition=Ready pod "$second_pod_name"
+	second_pod_uts_ns=$(kubectl exec "$second_pod_name" -- sh -c "$uts_cmd" | grep uts | cut -d ':' -f3)
+	second_pod_ipc_ns=$(kubectl exec "$second_pod_name" -- sh -c "$ipc_cmd" | grep ipc | cut -d ':' -f3)
 
 	# Check UTS and IPC namespaces
 	[ "$first_pod_uts_ns" == "$second_pod_uts_ns" ]
@@ -50,6 +50,6 @@ setup() {
 }
 
 teardown() {
-	sudo -E kubectl delete pod "$first_pod_name"
-	sudo -E kubectl delete pod "$second_pod_name"
+	kubectl delete pod "$first_pod_name"
+	kubectl delete pod "$second_pod_name"
 }

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -12,9 +12,9 @@ issue="https://github.com/kata-containers/runtime/issues/1127"
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -36,32 +36,32 @@ setup() {
 	volume_claim="pv-claim"
 
 	# Create the persistent volume
-	sudo -E kubectl create -f "${pod_config_dir}/pv-volume.yaml"
+	kubectl create -f "${pod_config_dir}/pv-volume.yaml"
 
 	# Check the persistent volume
-	sudo -E kubectl get pv $volume_name | grep Available
+	kubectl get pv $volume_name | grep Available
 
 	# Create the persistent volume claim
-	sudo -E kubectl create -f "${pod_config_dir}/volume-claim.yaml"
+	kubectl create -f "${pod_config_dir}/volume-claim.yaml"
 
 	# Check the persistent volume claim
-	cmd="sudo -E kubectl get pvc $volume_claim | grep Bound"
+	cmd="kubectl get pvc $volume_claim | grep Bound"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Create pod
-	sudo -E kubectl create -f "${pod_config_dir}/pv-pod.yaml"
+	kubectl create -f "${pod_config_dir}/pv-pod.yaml"
 
 	# Check pod creation
-	sudo -E kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	cmd="cat /mnt/index.html"
-	sudo -E kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"
 }
 
 teardown() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
-	sudo -E kubectl delete pod "$pod_name"
-	sudo -E kubectl delete pvc "$volume_claim"
-	sudo -E kubectl delete pv "$volume_name"
+	kubectl delete pod "$pod_name"
+	kubectl delete pvc "$volume_claim"
+	kubectl delete pv "$volume_name"
 	sudo rm -rf $tmp_file
 }

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -13,12 +13,12 @@ setup() {
 	nginx_image="nginx:$nginx_version"
 	busybox_image="busybox"
 	deployment="nginx-deployment"
-	export KUBECONFIG=/etc/kubernetes/admin.conf
+	export KUBECONFIG="$HOME/.kube/config"
 	# Pull the images before launching workload.
 	sudo -E crictl pull "$busybox_image"
 	sudo -E crictl pull "$nginx_image"
 
-	if sudo -E kubectl get runtimeclass | grep kata; then
+	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
@@ -28,21 +28,21 @@ setup() {
 @test "Verify nginx connectivity between pods" {
 	wait_time=30
 	sleep_time=3
-	sudo -E kubectl create -f "${pod_config_dir}/${deployment}.yaml"
-	sudo -E kubectl wait --for=condition=Available deployment/${deployment}
-	sudo -E kubectl expose deployment/${deployment}
+	kubectl create -f "${pod_config_dir}/${deployment}.yaml"
+	kubectl wait --for=condition=Available deployment/${deployment}
+	kubectl expose deployment/${deployment}
 
 	busybox_pod="test-nginx"
-	sudo -E kubectl run $busybox_pod --restart=Never --image="$busybox_image" \
+	kubectl run $busybox_pod --restart=Never --image="$busybox_image" \
 		-- wget --timeout=5 "$deployment"
-	cmd="sudo -E kubectl get pods -a | grep $busybox_pod | grep Completed"
+	cmd="kubectl get pods -a | grep $busybox_pod | grep Completed"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
-	sudo -E kubectl logs "$busybox_pod" | grep "index.html"
-	sudo -E kubectl describe pod "$busybox_pod"
+	kubectl logs "$busybox_pod" | grep "index.html"
+	kubectl describe pod "$busybox_pod"
 }
 
 teardown() {
-	sudo -E kubectl delete deployment "$deployment"
-	sudo -E kubectl delete service "$deployment"
-	sudo -E kubectl delete pod "$busybox_pod"
+	kubectl delete deployment "$deployment"
+	kubectl delete service "$deployment"
+	kubectl delete pod "$busybox_pod"
 }


### PR DESCRIPTION
Instead of using `/etc/kubernetes/admin.conf`, copy it to the
`$HOME/.kube/` of the non-root user to be able to make calls
to the kubernetes cluster without being root.
Also remove sudo from `kubectl` calls.

Fixes: #1154.