### PR TITLE
test: Skip docker kill for firecracker

### DIFF
--- a/.ci/hypervisors/firecracker/configuration_firecracker.yaml
+++ b/.ci/hypervisors/firecracker/configuration_firecracker.yaml
@@ -17,9 +17,11 @@ docker:
     - build with docker
     - inspect
     - docker top
+    - docker kill
     - users and groups
     - terminal with docker
     - docker commit
+    - CPU constraints
     - ulimits
     - docker cp with volume attached
     - load with docker


### PR DESCRIPTION
Docker kill integration test is failing randomly so we need to
disable it for Firecracker.

Fixes #1160

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>