### PR TITLE
metrics: docker memory: runc: Handle multiple sub-set PIDs

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -64,7 +64,7 @@ get_runc_pss_memory(){
         for shim in $shim_instances; do
                 child_pid="$(pgrep -P $shim)"
                 child_mem=$(sudo "$SMEM_BIN" -c "pid pss" | \
-                                grep "$child_pid" | awk '{print $2}')
+                                awk "/^$child_pid / {print \$2}")
 
 		# Getting all individual results
 		echo $child_mem >> $MEM_TMP_FILE


### PR DESCRIPTION
It looks like our use of 'smem | grep' would fail if one of the PIDs
in the list was a subset of another PID - as the grep would extract
both PIDs, which we did not want (the script would fail on the later
shell math).

Fix this by using the awk itself to do the PID line extraction from
the smem with an exact PID match, which also has the nice benefit of
dropping the grep.

Fixes: #1147

Signed-off-by: Graham Whaley <graham.whaley@intel.com>