### PR TITLE
metrics: fix tests to work with static kata (including fc)

### DIFF
--- a/integration/ramdisk/ramdisk.sh
+++ b/integration/ramdisk/ramdisk.sh
@@ -29,6 +29,7 @@ remove_tmp_file() {
 trap remove_tmp_file EXIT
 
 setup() {
+	extract_kata_env
 	clean_env
 
 	# Stop docker
@@ -36,7 +37,6 @@ setup() {
 }
 
 test_ramdisk() {
-	extract_kata_env
 
 	# Grab the time (filter journalctl)
 	grab_time=$(date +"%H:%M:%S")

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -22,6 +22,24 @@ info() {
         echo -e "INFO: $*"
 }
 
+# Check if the $1 argument is the name of a 'known'
+# Kata runtime. Of course, the end user can choose any name they
+# want in reality, but this function knows the names of the default
+# and recommended Kata docker runtime install names.
+is_a_kata_runtime(){
+	case "$1" in
+	"kata-runtime") ;&	# fallthrough
+	"kata-qemu") ;&		# fallthrough
+	"kata-fc")
+		echo "1"
+		return
+		;;
+	esac
+
+	echo "0"
+}
+
+
 # Gets versions and paths of all the components
 # list in kata-env
 extract_kata_env(){

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -42,7 +42,7 @@ is_a_kata_runtime(){
 
 # Try to find the real runtime path for the docker runtime passed in $1
 get_docker_kata_path(){
-	local jpaths=$(docker info --format "{{json .Runtimes}}")
+	local jpaths=$(docker info --format "{{json .Runtimes}}" || true)
 	local rpath=$(jq .\"$1\".path <<< "$jpaths")
 	# Now we have to de-quote it..
 	rpath="${rpath%\"}"
@@ -99,7 +99,13 @@ extract_kata_env(){
 	RUNTIME_CONFIG_PATH="/usr/share/defaults/kata-containers/configuration.toml"
 	RUNTIME_VERSION="0.0.0"
 	RUNTIME_COMMIT="unknown"
-	RUNTIME_PATH="$rpath"
+	# If docker is broken, disabled or not installed then we may not get a runtime
+	# path from it...
+	if [ -z "$RUNTIME_PATH" ]; then
+		RUNTIME_PATH="/usr/bin/kata-runtime"
+	else
+		RUNTIME_PATH="$rpath"
+	fi
 	SHIM_PATH="/usr/libexec/kata-containers/kata-shim"
 	SHIM_VERSION="0.0.0"
 	PROXY_PATH="/usr/libexec/kata-containers/kata-proxy"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -56,53 +56,64 @@ extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
 
-	# If we cannot find the runtime, or it fails to run for some reason, do not die
-	# on the error, but set some sane defaults
-	toml="$(set +e; $rpath kata-env)"
-	if [ $? != 0 ]; then
-		# We could be more diligent here and search for each individual component,
-		# but if the runtime cannot tell us the exact details it is configured for then
-		# we would be guessing anyway - so, set some defaults that may be true and give
-		# strong hints that we 'made them up'.
-		info "Runtime environment not found - setting defaults"
-		RUNTIME_CONFIG_PATH="/usr/share/defaults/kata-containers/configuration.toml"
-		RUNTIME_VERSION="0.0.0"
-		RUNTIME_COMMIT="unknown"
-		RUNTIME_PATH="/usr/local/bin/kata-runtime"
-		SHIM_PATH="/usr/libexec/kata-containers/kata-shim"
-		SHIM_VERSION="0.0.0"
-		PROXY_PATH="/usr/libexec/kata-containers/kata-proxy"
-		PROXY_VERSION="0.0.0"
-		if [ "$KATA_HYPERVISOR" == firecracker ]; then
-			HYPERVISOR_PATH="/usr/bin/firecracker"
-		 else
-			HYPERVISOR_PATH="/usr/bin/qemu-system-x86_64"
+	# If we can execute the path handed back to us
+	if [ -x "$rpath" ]; then
+		# and if the kata-env command does not error out. Bash hack so we can get $? even
+		# when the sub-command fails, but does not invoke the errexit in this parent shell.
+		local is_valid=$( $rpath kata-env >/dev/null 2>&1 && echo $? || echo $? )
+
+		if [ "$is_valid" == "0" ]; then
+			# then we can parse out the data we want
+			local toml="$($rpath kata-env)"
+
+			# The runtime path itself, for kata-runtime, will be contained in the `kata-env`
+			# section. For other runtimes we do not know where the runtime Docker is using lives.
+			RUNTIME_CONFIG_PATH=$(awk '/^  \[Runtime.Config\]$/ {foundit=1} /^    Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			RUNTIME_VERSION=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Semver =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			RUNTIME_COMMIT=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Commit =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			RUNTIME_PATH=$(awk '/^\[Runtime\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+			SHIM_PATH=$(awk '/^\[Shim\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			SHIM_VERSION=$(awk '/^\[Shim\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+			PROXY_PATH=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			PROXY_VERSION=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {print $5; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+			HYPERVISOR_PATH=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			HYPERVISOR_VERSION=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+			INITRD_PATH=$(awk '/^\[Initrd\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+
+			NETMON_PATH=$(awk '/^\[Netmon\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			return 0
 		fi
-		HYPERVISOR_VERSION="0.0.0"
-		INITRD_PATH=""
-		NETMON_PATH="/usr/libexec/kata-containers/kata-netmon"
-		return 0
 	fi
 
-	# The runtime path itself, for kata-runtime, will be contained in the `kata-env`
-	# section. For other runtimes we do not know where the runtime Docker is using lives.
-	RUNTIME_CONFIG_PATH=$(awk '/^  \[Runtime.Config\]$/ {foundit=1} /^    Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	RUNTIME_VERSION=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Semver =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	RUNTIME_COMMIT=$(awk '/^  \[Runtime.Version\]$/ {foundit=1} /^    Commit =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	RUNTIME_PATH=$(awk '/^\[Runtime\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-
-	SHIM_PATH=$(awk '/^\[Shim\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	SHIM_VERSION=$(awk '/^\[Shim\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-
-	PROXY_PATH=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	PROXY_VERSION=$(awk '/^\[Proxy\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {print $5; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-
-	HYPERVISOR_PATH=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-	HYPERVISOR_VERSION=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-
-	INITRD_PATH=$(awk '/^\[Initrd\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
-
-	NETMON_PATH=$(awk '/^\[Netmon\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+	# We have not found a command with a 'kata-env' option we can run. Set up some
+	# default values.
+	# We could be more diligent here and search for each individual component,
+	# but if the runtime cannot tell us the exact details it is configured for then
+	# we would be guessing anyway - so, set some defaults that may be true and give
+	# strong hints that we 'made them up'.
+	info "Runtime environment not found - setting defaults"
+	RUNTIME_CONFIG_PATH="/usr/share/defaults/kata-containers/configuration.toml"
+	RUNTIME_VERSION="0.0.0"
+	RUNTIME_COMMIT="unknown"
+	RUNTIME_PATH="$rpath"
+	SHIM_PATH="/usr/libexec/kata-containers/kata-shim"
+	SHIM_VERSION="0.0.0"
+	PROXY_PATH="/usr/libexec/kata-containers/kata-proxy"
+	PROXY_VERSION="0.0.0"
+	if [ "$KATA_HYPERVISOR" == firecracker ]; then
+		HYPERVISOR_PATH="/usr/bin/firecracker"
+	else
+		# We would use $(${cidir}/kata-arch.sh -d) here but we don't know
+		# that the callee has set up ${cidir} for us.
+		HYPERVISOR_PATH="/usr/bin/qemu-system-$(uname -m)"
+	fi
+	HYPERVISOR_VERSION="0.0.0"
+	INITRD_PATH=""
+	NETMON_PATH="/usr/libexec/kata-containers/kata-netmon"
 }
 
 # Checks that processes are not running

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -40,14 +40,25 @@ is_a_kata_runtime(){
 }
 
 
+# Try to find the real runtime path for the docker runtime passed in $1
+get_docker_kata_path(){
+	local jpaths=$(docker info --format "{{json .Runtimes}}")
+	local rpath=$(jq .\"$1\".path <<< "$jpaths")
+	# Now we have to de-quote it..
+	rpath="${rpath%\"}"
+	rpath="${rpath#\"}"
+	echo "$rpath"
+}
+
 # Gets versions and paths of all the components
 # list in kata-env
 extract_kata_env(){
 	local toml
+	local rpath=$(get_docker_kata_path "$RUNTIME")
 
 	# If we cannot find the runtime, or it fails to run for some reason, do not die
 	# on the error, but set some sane defaults
-	toml="$(set +e; kata-runtime kata-env)"
+	toml="$(set +e; $rpath kata-env)"
 	if [ $? != 0 ]; then
 		# We could be more diligent here and search for each individual component,
 		# but if the runtime cannot tell us the exact details it is configured for then

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -19,7 +19,7 @@ die(){
 }
 
 info() {
-        echo -e "INFO: $*"
+	echo -e "INFO: $*"
 }
 
 # Check if the $1 argument is the name of a 'known'

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -119,8 +119,15 @@ extract_kata_env(){
 # Checks that processes are not running
 check_processes() {
 	extract_kata_env
-	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
-	vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')
+
+	# Only check the kata-env if we have managed to find the kata executable...
+	if [ -x "$RUNTIME_PATH" ]; then
+		local vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
+		local vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')
+	else
+		local vsock_configured="false"
+		local vsock_supported="false"
+	fi
 	if [ "$vsock_configured" == true ] && [ "$vsock_supported" == true ]; then
 		general_processes=( ${HYPERVISOR_PATH} ${SHIM_PATH} )
 	else

--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -236,7 +236,7 @@ get_docker_memory_usage(){
 EOF
 )"
 
-	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ]; then
+	elif [ "$RUNTIME" == "kata-qemu" ] || [ "$RUNTIME" == "kata-fc" ] || [ "$RUNTIME" == "kata-runtime" ]; then
 		# Get PSS memory of VM runtime components.
 		# And check that the smem search has found the process - we get a "0"
 		#  back if that procedure fails (such as if a process has changed its name
@@ -256,9 +256,14 @@ EOF
 			die "Failed to find PSS for $SHIM_PATH"
 		fi
 
-		proxy_mem="$(get_pss_memory "$PROXY_PATH")"
-		if [ "$proxy_mem" == "0" ]; then
-			die "Failed to find PSS for $PROXY_PATH"
+		# Some runtimes do not have a proxy, so just set it to 0 space...
+		if [ "$PROXY_PATH" != "" ]; then
+			proxy_mem="$(get_pss_memory "$PROXY_PATH")"
+			if [ "$proxy_mem" == "0" ]; then
+				die "Failed to find PSS for $PROXY_PATH"
+			fi
+		else
+			proxy_mem=0
 		fi
 
 		proxy_mem="$(bc -l <<< "scale=2; $proxy_mem / $NUM_CONTAINERS")"

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -217,14 +217,19 @@ show_system_state() {
 }
 
 common_init(){
-	case "$RUNTIME" in
-		kata-runtime)
-			extract_kata_env
-			;;
-		*)
+
+	# If we are running a kata runtime, go extract its environment
+	# for later use.
+	local iskata=$(is_a_kata_runtime "$RUNTIME")
+
+	if [ "$iskata" == "1" ]; then
+		extract_kata_env
+	else
+		# We know we have nothing to do for runc
+		if [ "$RUNTIME" != "runc" ]; then
 			warning "Unrecognised runtime ${RUNTIME}"
-			;;
-	esac
+		fi
+	fi
 }
 
 

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -162,7 +162,10 @@ init () {
 	echo "Executing test: ${TEST_NAME} ${TEST_ARGS}"
 	check_cmds "${REQUIRED_CMDS[@]}"
 
-	if [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ] ; then
+	# Only try to grab a dmesg boot time if we are pretty sure we are running a
+	# Kata runtime
+	local iskata=$(is_a_kata_runtime "$RUNTIME")
+	if [ "$iskata" == "1" ]; then
 		CALCULATE_KERNEL=1
 		DMESGCMD="; dmesg"
 	else


### PR DESCRIPTION
Some of our metrics tests code presumed that kata was called `kata-runtime`, and that `kata-runtime` was always installed. That is not now the case with the advent of the static builds and `kata-fc`.
Update the scripts to handle the new runtimes and build types.