### PR TITLE
test: Enable oci_call test for Debian

### DIFF
--- a/integration/oci_calls/oci_call_test.sh
+++ b/integration/oci_calls/oci_call_test.sh
@@ -21,11 +21,6 @@ IMAGE="busybox"
 PAYLOAD="tail -f /dev/null"
 NAME="testoci"
 
-if [ "$ID" == "debian" ]; then
-	echo "Skip oci_call_test on $ID (see: https://github.com/kata-containers/tests/issues/1065)"
-	exit
-fi
-
 function remove_tmp_file {
 	rm -rf $TMP_FILE
 }


### PR DESCRIPTION
Enable this test as it is not failing on the current Jenkins systems
(4 vcpus).

Fixes #1065

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>