### PR TITLE
kubeadm: don't hardcode k8s version on config file

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -50,6 +50,7 @@ kubeadm_config_template="${SCRIPT_PATH}/kubeadm/config.yaml"
 kubeadm_config_file="$(mktemp --tmpdir kubeadm_config.XXXXXX.yaml)"
 
 sed -e "s|CRI_RUNTIME_SOCKET|${cri_runtime_socket}|" "${kubeadm_config_template}" > "${kubeadm_config_file}"
+sed -i "s|KUBERNETES_VERSION|v${kubernetes_version/-*}|" "${kubeadm_config_file}"
 
 if [ "${use_runtime_class}"  == true ]; then
 	echo "Add RuntimeClass feature for apiserver in kubeadm config file"

--- a/integration/kubernetes/kubeadm/config.yaml
+++ b/integration/kubernetes/kubeadm/config.yaml
@@ -5,7 +5,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
-kubernetesVersion: v1.12.0
+kubernetesVersion: KUBERNETES_VERSION
 networking:
   dnsDomain: cluster.local
   podSubnet: 10.244.0.0/16


### PR DESCRIPTION
Instead of hardcoding the k8s version that we are going to
use in the kubeadm config file, lets get it from the
`versions.yaml` file.

Fixes: #1171.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>