### PR TITLE
test: Add K8s test for http liveness probe

### DIFF
--- a/integration/kubernetes/k8s-liveness-http-probes.bats
+++ b/integration/kubernetes/k8s-liveness-http-probes.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="liveness-http"
+
+	if kubectl get runtimeclass | grep kata; then
+		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+	else
+		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+	fi
+}
+
+@test "Liveness http probe" {
+	sleep_liveness=10
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-http-liveness.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check liveness probe returns a success code
+	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
+
+	# Sleep necessary to check liveness probe returns a failure code
+	sleep "$sleep_liveness"
+	kubectl describe pod "$pod_name" | grep "Started container"
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -40,5 +40,6 @@ bats k8s-pod-quota.bats
 bats k8s-volume.bats
 bats k8s-projected-volume.bats
 bats k8s-memory.bats
+bats k8s-liveness-http-probes.bats
 ./cleanup_env.sh
 popd

--- a/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness-test
+  name: liveness-http
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: liveness
+    image: k8s.gcr.io/liveness
+    args:
+    - /server
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3

--- a/integration/kubernetes/untrusted_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-http-liveness.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness-test
+  name: liveness-http
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+  - name: liveness
+    image: k8s.gcr.io/liveness
+    args:
+    - /server
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3


### PR DESCRIPTION
This will add a K8s test that define a liveness HTTP request.
This is related with request https://github.com/kata-containers/tests/issues/1127.

Fixes #1178

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>