### PR TITLE
test: Add K8s test for tcp liveness probe

### DIFF
--- a/integration/kubernetes/k8s-liveness-tcp-probes.bats
+++ b/integration/kubernetes/k8s-liveness-tcp-probes.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="tcptest"
+
+	if kubectl get runtimeclass | grep kata; then
+		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+	else
+		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+	fi
+}
+
+@test "Liveness tcp probe" {
+	sleep_liveness=10
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-tcp-liveness.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check liveness probe returns a success code
+	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
+
+	# Sleep necessary to check liveness probe returns a failure code
+	sleep "$sleep_liveness"
+	kubectl describe pod "$pod_name" | grep "Started container"
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -37,6 +37,7 @@ bats k8s-liveness-probes.bats
 bats k8s-attach-handlers.bats
 bats k8s-qos-pods.bats
 bats k8s-pod-quota.bats
+bats k8s-liveness-tcp-probes.bats
 bats k8s-volume.bats
 bats k8s-projected-volume.bats
 bats k8s-memory.bats

--- a/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tcptest
+  labels:
+    app: goproxy
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/integration/kubernetes/untrusted_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-tcp-liveness.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tcptest
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20


### PR DESCRIPTION
This will add a K8s test for tcp liveness probe.

Fixes #1180

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>