### PR TITLE
Integration: reopen a test suit under docker for arm64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -25,5 +25,4 @@ docker:
     - Hotplug memory when create containers
     - run container and update its memory constraints
   Context:
-    - remove bind-mount source before container exits
   It:


### PR DESCRIPTION
"remove bind-mount source before container exit" test suit has passed on aarch64, so delete it in
"configuration_aarch64.yaml"

Fixes: #1182

Signed-off-by: Jianyong Wu  <jianyong.wu@arm.com>
@grahamwhaley @jodh-intel @devimc @Pennyzct 