### PR TITLE
test: fix the shimv2 case random failed

### DIFF
--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -25,9 +25,4 @@ if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ] || [ "$ID" == rhel ]; then
 	exit
 fi
 
-if [ "$ID" != "centos" ]; then
-	${SCRIPT_PATH}/../cri/integration-tests.sh
-else
-	issue="https://github.com/kata-containers/tests/issues/1047"
-	echo "Skip shimv2 on $ID, see: $issue"
-fi
+${SCRIPT_PATH}/../cri/integration-tests.sh


### PR DESCRIPTION
Test if there is some legacy containerd process running,
kill them before try to run another test case, otherwise
it will be failed to relaunch another containerd daemon
which used by following testcase.

Fixes:#1047

Signed-off-by: Fupan Li <lifupan@gmail.com>