### PR TITLE
metrics: Fix tittle for percentiles

### DIFF
--- a/metrics/report/report_dockerfile/fio-reads.R
+++ b/metrics/report/report_dockerfile/fio-reads.R
@@ -177,7 +177,7 @@ read_clat_box_plot <- ggplot() +
 	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
 	stat_summary( data=all_ldata, aes(blocksize, percentile, group=runtime, color=runtime), fun.y=mean, geom="line") +
 	ylim(0, NA) +
-	ggtitle("Random Read completion latency", subtitle="95&98 percentiles, boxplot over jobs") +
+	ggtitle("Random Read completion latency", subtitle="95&99 percentiles, boxplot over jobs") +
 	xlab("Blocksize") +
 	ylab("Latency (ms)") +
 	theme(axis.text.x=element_text(angle=90)) +

--- a/metrics/report/report_dockerfile/fio-writes.R
+++ b/metrics/report/report_dockerfile/fio-writes.R
@@ -177,7 +177,7 @@ write_clat_box_plot <- ggplot() +
 	geom_boxplot( data=all_ldata, aes(blocksize, percentile, color=runtime)) +
 	stat_summary( data=all_ldata, aes(blocksize, percentile, group=runtime, color=runtime), fun.y=mean, geom="line") +
 	ylim(0, NA) +
-	ggtitle("Random Write completion latency", subtitle="95&98 Percentiles, boxplot across jobs") +
+	ggtitle("Random Write completion latency", subtitle="95&99 Percentiles, boxplot across jobs") +
 	xlab("Blocksize") +
 	ylab("Latency (ms)") +
 	theme(axis.text.x=element_text(angle=90)) +


### PR DESCRIPTION
The report is printing 98 for percentiles but it should be 99 for the fio
write and fio reads operations.

Fixes #1089

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>