### PR TITLE
test: Add K8s test for http and tcp liveness probes

### DIFF
--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -9,7 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	pod_name="liveness-exec"
+	sleep_liveness=20
 
 	if kubectl get runtimeclass | grep kata; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
@@ -19,7 +19,7 @@ setup() {
 }
 
 @test "Liveness probe" {
-	sleep_liveness=10
+	pod_name="liveness-exec"
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
@@ -33,6 +33,41 @@ setup() {
 	# Sleep necessary to check liveness probe returns a failure code
 	sleep "$sleep_liveness"
 	kubectl describe pod "$pod_name" | grep "Liveness probe failed"
+}
+
+@test "Liveness http probe" {
+	pod_name="liveness-http"
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-http-liveness.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check liveness probe returns a success code
+	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
+
+	# Sleep necessary to check liveness probe returns a failure code
+	sleep "$sleep_liveness"
+	kubectl describe pod "$pod_name" | grep "Started container"
+}
+
+
+@test "Liveness tcp probe" {
+	pod_name="tcptest"
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-tcp-liveness.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check liveness probe returns a success code
+	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
+
+	# Sleep necessary to check liveness probe returns a failure code
+	sleep "$sleep_liveness"
+	kubectl describe pod "$pod_name" | grep "Started container"
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness-test
+  name: liveness-http
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: liveness
+    image: k8s.gcr.io/liveness
+    args:
+    - /server
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3

--- a/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tcptest
+  labels:
+    app: goproxy
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/integration/kubernetes/untrusted_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-http-liveness.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness-test
+  name: liveness-http
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+  - name: liveness
+    image: k8s.gcr.io/liveness
+    args:
+    - /server
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3

--- a/integration/kubernetes/untrusted_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-tcp-liveness.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tcptest
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20


### PR DESCRIPTION
Add K8s test for http and tcp liveness probes.

Fixes #1178

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>