### PR TITLE
clean-up: fix 'target busy' error when umounting on aarch64

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -224,7 +224,7 @@ delete_stale_docker_resource()
 		local mount_point_union=$(mount | grep "${stale_docker_mount_point}" | awk '{print $3}')
 		if [ -n "${mount_point_union}" ]; then
 			while IFS='$\n' read mount_point; do
-				sudo umount "${mount_point}"
+				[ -n "$(grep "${mount_point}" "/proc/mounts")" ] && sudo umount -R "${mount_point}"
 			done <<< "${mount_point_union}"
 		fi
 	done


### PR DESCRIPTION
when umounting directory ../rootfs/ which has a few sub-directories mounted, we will face 'target busy' error. So we need to add '-R' flag to umount recursively.
I grab a snippet from ARM CI debug info and you can see the error `target is busy`:
` 23:30:15 umount: /run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs: target is busy.`
Logging into ARM CI and see the mount info:
```
root@testing-1:~# mount | grep "/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8" | awk '{print $3}' | sort -r
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev/shm
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev/pts
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev/mqueue
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev/mqueue
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev/hugepages
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs/dev
/run/kata-containers/shared/sandboxes/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/f302e1e4d4a1391bf43450e0c6abcc3178049328823659fb656b431e3b914fd8/rootfs

```
You can see that there existed a few sub-directories under `rootfs/`, which needed to be umounted firstly.

Fixes: #1190

Signed-off-by: Penny Zheng <penny.zheng@arm.com>