### PR TITLE
test: Increase time to get correct logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 TIMEOUT := 60
 
 # union for 'make test'
-UNION := functional docker crio docker-compose network netmon docker-stability oci openshift kubernetes swarm vm-factory entropy ramdisk shimv2
+UNION := oci
 
 # skipped test suites for docker integration tests
 FILTER_FILE = .ci/hypervisors/$(KATA_HYPERVISOR)/filter_docker_$(KATA_HYPERVISOR).sh

--- a/integration/oci_calls/oci_call_test.sh
+++ b/integration/oci_calls/oci_call_test.sh
@@ -76,13 +76,12 @@ function setup() {
 function run_oci_call() {
 	local -a oci_call=( "create" "start" "state" )
 
-	# This sleep is necessary to gather the correct logs
-	sleep 10
-
 	get_time
 
 	# Start a container
 	docker run -d --runtime=${RUNTIME} --name=${NAME} ${IMAGE} ${PAYLOAD}
+
+	sleep 10
 
 	get_debug_logs
 
@@ -94,13 +93,12 @@ function run_oci_call() {
 function stop_oci_call() {
 	local -a oci_call=( "kill" "delete" "state" )
 
-	# This sleep is necessary to gather the correct logs
-	sleep 10
-
 	get_time
 
 	# Stop a container
 	docker stop ${NAME}
+
+	sleep 10
 
 	get_debug_logs
 
@@ -121,13 +119,12 @@ function run_oci_call_true() {
 		local -a oci_call=( "create" "start" "kill" "delete" "state" )
 	fi
 
-	# This sleep is necessary to gather the correct logs
-	sleep 10
-
 	get_time
 
 	# Run a container with true
 	docker run --rm --runtime=${RUNTIME} ${IMAGE} true
+
+	sleep 10
 
 	get_debug_logs
 


### PR DESCRIPTION
Increase the time to get the correct logs for the oci call test.

Fixes #1192

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>