### PR TITLE
k8s: mute message when runtimeclass is not configured

### DIFF
--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -6,16 +6,13 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="handlers"
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Running with postStart and preStop handlers" {

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -6,14 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep -q kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "ConfigMap for a pod" {

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
@@ -18,11 +19,7 @@ setup() {
 	total_requests=512
 	total_cpu_container=1
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Check CPU constraints" {

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -6,14 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Credentials using secrets" {

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -6,16 +6,12 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
-
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Environment variables" {

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -6,16 +6,13 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
 	sleep_liveness=20
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Liveness probe" {

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
 
@@ -14,12 +15,7 @@ setup() {
 
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="memory-test"
-
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Exceeding memory constraints" {

--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -6,14 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep -q kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Parallel jobs" {

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	skip "This is not working (https://github.com/kata-containers/agent/issues/261)"
@@ -14,11 +15,7 @@ setup() {
 	first_container_name="first-test-container"
 	second_container_name="second-test-container"
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Check PID namespaces" {

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -5,14 +5,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Pod quota" {

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -6,14 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep -q kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Projected volume" {

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -6,18 +6,14 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
 
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
-
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Guaranteed QoS" {

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -6,14 +6,11 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Security context" {

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	busybox_image="busybox"
@@ -15,11 +16,7 @@ setup() {
 	# Pull the images before launching workload.
 	sudo -E crictl pull "$busybox_image"
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 
 	uts_cmd="ls -la /proc/self/ns/uts"
 	ipc_cmd="ls -la /proc/self/ns/ipc"

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
 
@@ -13,12 +14,7 @@ setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 
 	export KUBECONFIG="$HOME/.kube/config"
-
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 
 	tmp_file=$(mktemp -d /tmp/data.XXXX)
 	msg="Hello from Kubernetes"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 
 setup() {
 	versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
@@ -18,11 +19,7 @@ setup() {
 	sudo -E crictl pull "$busybox_image"
 	sudo -E crictl pull "$nginx_image"
 
-	if kubectl get runtimeclass | grep kata; then
-		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	else
-		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
-	fi
+	get_pod_config_dir
 }
 
 @test "Verify nginx connectivity between pods" {

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -138,7 +138,9 @@ clean_env()
 get_pod_config_dir() {
 	if kubectl get runtimeclass 2> /dev/null | grep -q "kata"; then
 		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+		info "k8s configured to use runtimeclass"
 	else
 		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+		info "k8s configured to use trusted and untrusted annotations"
 	fi
 }

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -134,3 +134,11 @@ clean_env()
 		sudo timeout ${KATA_DOCKER_TIMEOUT} docker rm -f $(docker ps -qa)
 	fi
 }
+
+get_pod_config_dir() {
+	if kubectl get runtimeclass 2> /dev/null | grep -q "kata"; then
+		pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+	else
+		pod_config_dir="${BATS_TEST_DIRNAME}/untrusted_workloads"
+	fi
+}


### PR DESCRIPTION
k8s: mute message when runtimeclass is not configured

When runtimeclass is not configured on a test environment,
it is normal that we get this message:
```
error: the server doesn't have a resource type "runtimeclass"
```

This message is not the cause of a test failure, since we
use old trusted and untrusted tags when runtimeclass is not
configured.
To avoid confusion, lets send the message to /dev/null.

Also,  add information so that we know if we are running the
tests using runtimeclass or trusted/untrusted annotations.

Fixes: #1196.