### PR TITLE
CI: allow CPU hotplug tests on s390x

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -11,9 +11,6 @@ test:
 docker:
   Describe:
     - CPUs and CPU set
-    - Update number of CPUs
-    - Hot plug CPUs
-    - Update CPU constraints
     - Hotplug memory
     - update memory constraints
   Context:


### PR DESCRIPTION
packaging/pull/340 allows these tests to work.
"CPUs and CPU set" test suite still does not work yet because it
requires CPU hot-unplug feature.

Fixes #1203

Signed-off-by: Tuan Hoang <tmhoang@linux.vnet.ibm.com>