### PR TITLE
CI: correct memory test suite name on s390x

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -15,7 +15,7 @@ docker:
     - Hot plug CPUs
     - Update CPU constraints
     - Hotplug memory
-    - update memory constraints
+    - memory constraints
   Context:
     - remove bind-mount source before container exits
     - run container exceeding memory constraints


### PR DESCRIPTION
The correct name should be 'memory constraints'.

Fixes #1205

Signed-off-by: Tuan Hoang <tmhoang@linux.vnet.ibm.com>