### PR TITLE
k8s: fix tests to be able to run them several times

### DIFF
--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -11,11 +11,11 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
+	job_name="jobtest"
+	names=( "test1" "test2" "test3" )
 }
 
 @test "Parallel jobs" {
-	job_name="jobtest"
-	declare -a names=( test1 test2 test3 )
 	# Create yaml files
 	for i in "${names[@]}"; do
 		sed "s/\$ITEM/$i/" ${pod_config_dir}/job-template.yaml > ${pod_config_dir}/job-$i.yaml

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -17,11 +17,12 @@ setup() {
 	get_pod_config_dir
 
 	tmp_file=$(mktemp -d /tmp/data.XXXX)
+	pod_yaml=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	msg="Hello from Kubernetes"
 	echo $msg > $tmp_file/index.html
 	pod_name="pv-pod"
 	# Define temporary file at yaml
-	sed -i "s|tmp_data|${tmp_file}|g" ${pod_config_dir}/pv-volume.yaml
+	sed -e "s|tmp_data|${tmp_file}|g" ${pod_config_dir}/pv-volume.yaml > "$pod_yaml"
 }
 
 @test "Create Persistent Volume" {
@@ -32,7 +33,7 @@ setup() {
 	volume_claim="pv-claim"
 
 	# Create the persistent volume
-	kubectl create -f "${pod_config_dir}/pv-volume.yaml"
+	kubectl create -f "$pod_yaml"
 
 	# Check the persistent volume
 	kubectl get pv $volume_name | grep Available
@@ -59,5 +60,6 @@ teardown() {
 	kubectl delete pod "$pod_name"
 	kubectl delete pvc "$volume_claim"
 	kubectl delete pv "$volume_name"
-	sudo rm -rf $tmp_file
+	rm -f "$pod_yaml"
+	rm -rf "$tmp_file"
 }


### PR DESCRIPTION
Do not overwrite on pod template. Instead create a
temporary file from the template with the needed changes.
This will let us run the tests several times without messing
up with the template files.

Also, remove `declare -a` from `name` array declaration on `k8s-parallel.bats`

For some reason, when using `declare -a` on the `name` array,
the values of the array cannot be retrieved on the `teardown()`
function. This was preventing the `teardown()` to correctly delete
some auto generated pod config files.
So lets remove the `declare -a` and move the declaration
of it to the `setup()`.