### PR TITLE
ci: Test install kata-runtime in "No GO command or GOPATH not set" mode

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -34,7 +34,7 @@ runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
-build_and_install "github.com/kata-containers/runtime"
+build_and_install "github.com/kata-containers/runtime" "" "true"
 
 # Check system supports running Kata Containers
 kata_runtime_path=$(command -v kata-runtime)

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -85,8 +85,15 @@ function build() {
 function build_and_install() {
 	github_project="$1"
 	make_target="$2"
+	test_not_gopath_set="$3"
+
 	build "${github_project}" "${make_target}"
 	pushd "${GOPATH}/src/${github_project}"
+	if [ "$test_not_gopath_set" = "true" ]; then
+		info "Installing ${github_project} in No GO command or GOPATH not set mode"
+		sudo -E KATA_RUNTIME="${KATA_RUNTIME}" make install
+		[ $? -ne 0 ] && die "Fail to install ${github_project} in No GO command or GOPATH not set mode"
+	fi
 	info "Installing ${github_project}"
 	sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
 	popd


### PR DESCRIPTION
Add a test to install kata-runtime in "No GO command or GOPATH not set" mode.

Fixes: #1233

Signed-off-by: Hui Zhu <teawater@hyper.sh>