### PR TITLE
ci: baremetal cleanup: remove repo links and keys

### DIFF
--- a/.ci/aarch64/clean_up_aarch64.sh
+++ b/.ci/aarch64/clean_up_aarch64.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source "/etc/os-release" || source "/usr/lib/os-release"
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"

--- a/.ci/ppc64le/clean_up_ppc64le.sh
+++ b/.ci/ppc64le/clean_up_ppc64le.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source "/etc/os-release" || source "/usr/lib/os-release"
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"

--- a/.ci/s390x/clean_up_s390x.sh
+++ b/.ci/s390x/clean_up_s390x.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+source "/etc/os-release" || source "/usr/lib/os-release"
+
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 

--- a/.ci/x86_64/clean_up_x86_64.sh
+++ b/.ci/x86_64/clean_up_x86_64.sh
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source "/etc/os-release" || source "/usr/lib/os-release"
+
 lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 


### PR DESCRIPTION
When cleaning up our servers, we should also try to remove the kata
repo links and keys. In the past we have seen issues when keys/repos
change and the old ones already exist, and it has prevented the new
ones being injected/updated. It's also just good practice to try and
remove all the things we installed...

Fixes: #1225

Signed-off-by: Graham Whaley <graham.whaley@intel.com>