### PR TITLE
k8s: skip Quality of Service tests

### DIFF
--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -9,15 +9,16 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
+memory_issue="https://github.com/kata-containers/runtime/issues/1249"
 
 setup() {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Guaranteed QoS" {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 
 	pod_name="qos-test"
 
@@ -32,7 +33,7 @@ setup() {
 }
 
 @test "Burstable QoS" {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 
 	pod_name="burstable-test"
 
@@ -47,7 +48,7 @@ setup() {
 }
 
 @test "BestEffort QoS" {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 	pod_name="besteffort-test"
 
 	# Create pod
@@ -61,6 +62,6 @@ setup() {
 }
 
 teardown() {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
These tests have been failing because a cgroup gets out of
memory.
For details, see:
https://github.com/kata-containers/runtime/issues/1249
Skip them until we figure out what to do with this issue.

Fixes: #1239.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>