### PR TITLE
docker: Test to check cpu cgroups update fails on Power arch

### DIFF
--- a/integration/docker/cgroups_test.go
+++ b/integration/docker/cgroups_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -135,6 +136,9 @@ var _ = Describe("Checking CPU cgroups in the host", func() {
 				expectedPeriod = "100000"
 				expectedCpuset = "1"
 
+				if runtime.GOARCH == "ppc64le" {
+					expectedCpuset = "8"
+				}
 				_, _, exitCode = dockerUpdate("--cpus=2.5", "--cpu-shares", expectedShares, "--cpuset-cpus", expectedCpuset, id)
 				Expect(exitCode).To(BeZero())
 


### PR DESCRIPTION
On Power arch, if --cpuset-cpus are set to
offline host cpus, the test shall fail. Fix
it by testing execution on an online host
cpu.

Fixes: #1241

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com