### PR TITLE
test: Skip memory constraints K8s test

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -9,9 +9,10 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
+memory_issue="https://github.com/kata-containers/runtime/issues/1249"
 
 setup() {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="memory-test"
@@ -19,7 +20,7 @@ setup() {
 }
 
 @test "Exceeding memory constraints" {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 
 	memory_limit_size="50Mi"
 	allocated_size="250M"
@@ -37,7 +38,7 @@ setup() {
 }
 
 @test "Running within memory constraints" {
-	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	skip "test not working see: ${issue}, ${memory_issue}"
 
 	memory_limit_size="200Mi"
 	allocated_size="150M"


### PR DESCRIPTION
Currently the issue https://github.com/kata-containers/runtime/issues/1249
is blocking to run properly the memory constraints test.

Fixes #1244

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>