### PR TITLE
test: Skip shimv2 on openSUSE Leap

### DIFF
--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -10,7 +10,14 @@
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
 extract_kata_env
+
+if [[ "$ID" =~ ^opensuse.*$ ]]; then
+	issue="https://github.com/kata-containers/tests/issues/1251"
+	echo "Skip shimv2 on $ID, see: $issue"
+	exit
+fi
 
 if [ -z $INITRD_PATH ]; then
 	echo "Skipping vm templating test as initrd is not set"

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -19,6 +19,12 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
+if [[ "$ID" =~ ^opensuse.*$ ]]; then
+	issue="https://github.com/kata-containers/tests/issues/1251"
+	echo "Skip shimv2 on $ID, see: $issue"
+	exit
+fi
+
 if [ "$ID" != "centos" ]; then
 	${SCRIPT_PATH}/../cri/integration-tests.sh
 else


### PR DESCRIPTION
Currently shimv2 tests are not working on openSUSE Leap
(https://github.com/kata-containers/tests/issues/1251).

Fixes #1252

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>