### PR TITLE
docker: Run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
+# Number of processor units available
+NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
+# Number of `go test` processes that ginkgo will spawn.
+GINKGO_NODES := $(shell echo $(NPROCS)\-2 | bc)
+
 # Load architecture-dependent settings
 ifneq ($(wildcard $(ARCH_FILE)),)
 include $(ARCH_FILE)
@@ -49,8 +54,21 @@ endif
 docker: ginkgo
 ifeq ($(RUNTIME),)
 	$(error RUNTIME is not set)
+endif
+
+ifeq ($(KATA_HYPERVISOR),firecracker)
+	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+else ifeq ($(ARCH),aarch64)
+	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" ./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	# Run tests in parallel, skip tests that need to be run serialized
+	./ginkgo -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	# Now run serialized tests
+	./ginkgo -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif
 

--- a/integration/docker/cp_test.go
+++ b/integration/docker/cp_test.go
@@ -52,7 +52,7 @@ var _ = Describe("docker cp", func() {
 	})
 })
 
-var _ = Describe("docker cp with volume attached", func() {
+var _ = Describe("[Serial Test] docker cp with volume attached", func() {
 	var (
 		id          string
 		exitCode    int
@@ -102,7 +102,7 @@ var _ = Describe("docker cp with volume attached", func() {
 	})
 })
 
-var _ = Describe("docker cp with volume", func() {
+var _ = Describe("[Serial Test] docker cp with volume", func() {
 	var (
 		id            string
 		exitCode      int

--- a/integration/docker/volume_test.go
+++ b/integration/docker/volume_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("docker volume", func() {
+var _ = Describe("[Serial Test] docker volume", func() {
 	var (
 		args          []string
 		id            string = randomDockerName()


### PR DESCRIPTION
Most of our docker tests can be executed in parallel.
Use the `ginkgo -p` option to achieve this.
The ones that cannot be run in parallel are now tagged in
the test name as [Serial Test] to run them after we run
the tests that can be run in parallel.
This should reduce at least 10 minutes of CI time.

Fixes: #1256.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>