### PR TITLE
kata-webhook: Support fetching request context

### DIFF
--- a/kata-webhook/README.md
+++ b/kata-webhook/README.md
@@ -30,27 +30,10 @@ and sample admission controller we created by running
 ```bash
 $ kubectl apply -f deploy/
 ```
-The admission webhook (deploy/webhook-registration.yaml)
-is setup to exclude certian namespaces from being run with Kata using filters on namespace labels.
 
-```yaml
-    namespaceSelector:
-      matchExpressions:
-        -  {key: "kata", operator: NotIn, values: ["false"]}
-```
-The rook operators for example are marked as such.
+The webhook mutates pods to use the kata runtime class for all pods except
+those with 
 
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: rook-ceph-system
-  labels:
-    kata: "false"
-```
-
-Pods not explicitly excluded by the namespace filter are dynamically tagged to run with Kata with some exceptions.
-
-* `hostNetwork: true`
-* `rook-ceph` and `rook-ceph-system` namespaces
+* `hostNetwork: true` 
+* namespace: `rook-ceph` and `rook-ceph-system`
 

--- a/kata-webhook/deploy/webhook-registration.yaml.tpl
+++ b/kata-webhook/deploy/webhook-registration.yaml.tpl
@@ -22,6 +22,3 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-    namespaceSelector:
-      matchExpressions:
-        -  {key: "kata", operator: NotIn, values: ["false"]}

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -22,6 +22,7 @@ spec:
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-key-file=/etc/webhook/certs/key.pem
+            - -exclude-namespaces=rook-ceph-system,rook-ceph
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs


### PR DESCRIPTION
Not all information about the admission request is available in
the object. Some properties like Namespace is only available in
the request context.

Modify the webhook to allow accessing the full context. This will
allow for richer processing and policies.

This also eliminates removes the need for explict namespace filters
in the webhook configuration. This means user yaml files can now
remain unmodified.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>