### PR TITLE
tests: update bats repository

### DIFF
--- a/.ci/install_bats.sh
+++ b/.ci/install_bats.sh
@@ -9,8 +9,10 @@ set -e
 
 which bats && exit
 
+BATS_REPO="github.com/bats-core/bats-core"
+
 echo "Install BATS from sources"
-go get -d github.com/sstephenson/bats || true
-pushd $GOPATH/src/github.com/sstephenson/bats
+go get -d "${BATS_REPO}" || true
+pushd "${GOPATH}/src/${BATS_REPO}"
 sudo -E PATH=$PATH sh -c "./install.sh /usr"
 popd


### PR DESCRIPTION
Update bats repository.
Old bats repository is no longer active and moved to
new https://github.com/bats-core/bats-core which has an
active community.
Stability fixes and new features like running tests in parallel
have been added to bats in this new repo.

Fixes: #1276.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>