### PR TITLE
ci: don't check license of C files distributed under the GPL license

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -365,6 +365,7 @@ check_license_headers()
 		--exclude="*.txt" \
 		--exclude="*.yaml" \
 		--exclude="*.pb.go" \
+		--exclude="*.gpl.c" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
Sometimes we need to include C files distributed under the GPL license, to
avoid issues with the tool that checks file headers, files with the suffix
`.gpl.c` are skipped.

fixes #1279

Signed-off-by: Julio Montes <julio.montes@intel.com>