### PR TITLE
tests: run k8s tests in parallel

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -328,3 +328,20 @@ gen_clean_arch() {
 	[ -d "$GOCACHE" ] && sudo rm -rf ${GOCACHE}/*
 }
 
+build_install_parallel() {
+	gnu_parallel_url=$(get_test_version "externals.parallel.url")
+	gnu_parallel_version=$(get_test_version "externals.parallel.version")
+	gnu_parallel_tar_pkg="parallel-${gnu_parallel_version}.tar.bz2"
+	gnu_parallel_dir="./${gnu_parallel_tar_pkg//.*}"
+
+	chronic curl -sLO "${gnu_parallel_url}/${gnu_parallel_tar_pkg}"
+	tar -xf "${gnu_parallel_tar_pkg}"
+
+	pushd "${gnu_parallel_dir}"
+	chronic ./configure
+	chronic make
+	chronic sudo make install
+	popd
+
+	rm -rf "$gnu_parallel_dir" "$gnu_parallel_tar_pkg"
+}

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -92,6 +92,11 @@ chronic sudo -E yum install -y procenv
 echo "Install haveged"
 chronic sudo -E yum install -y haveged
 
+echo "Install GNU parallel"
+# GNU parallel not available in Centos repos, so build it instead.
+chronic sudo -E yum -y install perl bzip2 make
+build_install_parallel
+
 if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 	echo "Install ${KATA_KSM_THROTTLER_JOB}"
 	chronic sudo -E yum install ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -90,6 +90,9 @@ chronic sudo -E apt install -y procenv
 echo "Install haveged"
 chronic sudo -E apt install -y haveged
 
+echo "Install GNU parallel"
+chronic sudo -E apt install -y parallel
+
 if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 	echo "Install ${KATA_KSM_THROTTLER_JOB}"
 	chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -67,6 +67,9 @@ chronic sudo -E dnf -y install procenv
 echo "Install haveged"
 chronic sudo -E dnf -y install haveged
 
+echo "Install GNU parallel"
+chronic sudo -E dnf -y install parallel
+
 if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 	echo "Install ${KATA_KSM_THROTTLER_JOB}"
 	chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -60,3 +60,6 @@ chronic sudo -E zypper -n install crudini
 
 echo "Install haveged"
 chronic sudo -E zypper -n install haveged
+
+echo "Install GNU parallel"
+chronic sudo -E zypper -n install gnu_parallel

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -79,6 +79,9 @@ chronic sudo -E apt install -y procenv
 echo "Install haveged"
 chronic sudo -E apt install -y haveged
 
+echo "Install GNU parallel"
+chronic sudo -E apt install -y parallel
+
 if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 	echo "Install ${KATA_KSM_THROTTLER_JOB}"
 	chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ docker-stability:
 
 kubernetes:
 	bash -f .ci/install_bats.sh
-	bash -f integration/kubernetes/run_kubernetes_tests.sh
+	NODES=${GINKGO_NODES} bash integration/kubernetes/run_kubernetes_tests.sh
 
 swarm:
 	systemctl is-active --quiet docker || sudo systemctl start docker

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -10,6 +10,9 @@ set -e
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_dir=$(dirname $0)
 
+# If NODES is not already defined, default it to 1.
+NODES="${NODES:-1}"
+
 # Currently, Kubernetes tests only work on Ubuntu.
 # We should delete this condition, when it works for other Distros.
 if [ "$ID" != ubuntu  ]; then
@@ -24,26 +27,8 @@ systemctl is-active --quiet docker || sudo systemctl start docker
 
 pushd "$kubernetes_dir"
 ./init.sh
-bats nginx.bats
-bats k8s-uts+ipc-ns.bats
-bats k8s-env.bats
-bats k8s-empty-dirs.bats
-bats k8s-limit-range.bats
-bats k8s-credentials-secrets.bats
-bats k8s-configmap.bats
-bats k8s-custom-dns.bats
-bats k8s-pid-ns.bats
-bats k8s-cpu-ns.bats
-bats k8s-parallel.bats
-bats k8s-security-context.bats
-bats k8s-liveness-probes.bats
-bats k8s-attach-handlers.bats
-bats k8s-qos-pods.bats
-bats k8s-pod-quota.bats
-bats k8s-sysctls.bats
-bats k8s-volume.bats
-bats k8s-projected-volume.bats
-bats k8s-memory.bats
-bats k8s-block-volume.bats
+
+bats -j "$NODES" *.bats
+
 ./cleanup_env.sh
 popd

--- a/versions.yaml
+++ b/versions.yaml
@@ -60,3 +60,8 @@ externals:
     # https://github.com/kata-containers/tests/issues/1329
     # https://github.com/kata-containers/tests/issues/1345
     version: "d278457390d8c314192c08a7024e4648c40883af"
+
+  parallel:
+    description: "GNU parallel tool"
+    url: "https://ftp.gnu.org/gnu/parallel"
+    version: "20190222"


### PR DESCRIPTION
- install GNU parallel, which is a `bats` requirement for running
tests in parallel.
- use `bats -j` to run the k8s in parallel. 
