### PR TITLE
metrics: network: ab: specify RUNTIME for test

### DIFF
--- a/metrics/network/network-metrics-nginx-ab-benchmark.sh
+++ b/metrics/network/network-metrics-nginx-ab-benchmark.sh
@@ -72,7 +72,7 @@ EOF
 
 function nginx_ab_networking {
 	# Launch nginx container
-	docker run -d -p $port $nginx_image
+	docker run --runtime "$RUNTIME" -d -p $port $nginx_image
 	echo >&2 "WARNING: sleeping for $start_time seconds to let the container start correctly"
 	sleep "$start_time"
 	ab -s ${socket_time} -n ${requests} -r -c ${concurrency_value} http://${url}/ > $TMP_FILE


### PR DESCRIPTION
Ensure we specify which RUNTIME to use for the test, so we do not
just fall to using the default.
Especially relevant as we may switch the default from being Kata.

Fixes: #1287

Signed-off-by: Graham Whaley <graham.whaley@intel.com>