### PR TITLE
test: Add CRI-O dependencies for SLES setup

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -42,6 +42,10 @@ chronic sudo -E zypper -n install libcap-devel libattr1 libcap-ng-devel librbd-d
 echo "Install kernel dependencies"
 chronic sudo -E zypper -n install libelf-devel flex
 
+echo "Install CRI-O dependencies"
+chronic sudo -E zypper -n install libglib-2_0-0 libseccomp-devel libapparmor-devel libgpg-error-devel \
+	glibc-devel-static libgpgme-devel libassuan-devel glib2-devel glibc-devel util-linux
+
 echo "Install bison binary"
 chronic sudo -E zypper -n install bison
 


### PR DESCRIPTION
This will add CRI-O dependencies for SLES installation setup.

Fixes #1264

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>