### PR TITLE
ci: show merge log after rebase

### DIFF
--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -52,6 +52,8 @@ apply_depends_on() {
 		git fetch origin "pull/${pr_id}/head:${dependency_branch}" && \
 			git checkout "${dependency_branch}" && \
 			git rebase "origin/${branch}"
+			# And show what we rebased on top of to aid debugging
+			git log --oneline master~1..HEAD
 		popd
 	done
 
@@ -89,6 +91,8 @@ clone_repos() {
 			git checkout "${pr_branch}"
 			echo "... and rebasing with origin/${branch}"
 			git rebase "origin/${branch}"
+			# And show what we rebased on top of to aid debugging
+			git log --oneline master~1..HEAD
 		else
 			# Packaging repo only has master branch, so we
 			# cannot checkout to a different branch.


### PR DESCRIPTION
To aid in debugging failed CI runs, output the git log after we
have done a rebase to show what we rebased on top of.

Fixes: #1294

Signed-off-by: Graham Whaley <graham.whaley@intel.com>