### PR TITLE
ci: metrics: pull checkmetrics configs from source tree

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -12,7 +12,10 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_DIR}/../metrics/lib/common.bash"
 RESULTS_DIR=${SCRIPT_DIR}/../metrics/results
 CHECKMETRICS_DIR=${SCRIPT_DIR}/../cmd/checkmetrics
-CHECKMETRICS_CONFIG_DIR="/etc/checkmetrics"
+# Where to look by default, if this machine is not a static CI machine with a fixed name.
+CHECKMETRICS_CONFIG_DEFDIR="/etc/checkmetrics"
+# Where to look if this machine is a static CI machine with a known fixed name.
+CHECKMETRICS_CONFIG_DIR="${CHECKMETRICS_DIR}/ci_slaves"
 CM_DEFAULT_DENSITY_CONFIG="${CHECKMETRICS_DIR}/baseline/density-CI.toml"
 
 # Set up the initial state
@@ -82,12 +85,12 @@ check() {
 		# we can expect the cloud image to have a default named file in the correct
 		# place.
 		if [ -n "${METRICS_CI_CLOUD}" ]; then
-			local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DIR}/checkmetrics-json.toml"
+			local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DEFDIR}/checkmetrics-json.toml"
 
 			# If we don't have a machine specific file in place, then copy
 			# over the default cloud density file.
 			if [ ! -f ${CM_BASE_FILE} ]; then
-				sudo mkdir -p ${CHECKMETRICS_CONFIG_DIR}
+				sudo mkdir -p ${CHECKMETRICS_CONFIG_DEFDIR}
 				sudo cp ${CM_DEFAULT_DENSITY_CONFIG} ${CM_BASE_FILE}
 			fi
 		else

--- a/cmd/checkmetrics/ci_slaves/README.md
+++ b/cmd/checkmetrics/ci_slaves/README.md
@@ -1,0 +1,19 @@
+# CI slaves reference files
+
+This directory contains the reference `checkmetrics` configuration files
+utilised by the CI system build machines to check CI metrics results.
+
+These files are actively downloaded by the CI system on a per-build basis.
+Thus, any changes to the files in this directory should apply automatically
+to all future CI build/runs.
+
+The files in this directory are named according to how the
+[metrics CI script](../../../.ci/run_metrics_PR_ci.sh) invokes `checkmetrics`,
+using the CI build machine hostname to locate the correct file:
+
+```bash
+local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DIR}/checkmetrics-json-$(uname -n).toml"
+```
+
+Thus, each CI metrics slave machine should be uniquely named, to allow for file
+differentiation in this directory.

--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -1,0 +1,48 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file contains baseline expectations
+# for checked results by checkmetrics tool.
+#
+# values set specifically for packet.com c1.small slave.
+
+[[metric]]
+name = "boot-times"
+type = "json"
+description = "measure container lifecycle timings"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
+checktype = "mean"
+midval = 0.85
+minpercent = 5.0
+maxpercent = 5.0
+
+[[metric]]
+name = "memory-footprint"
+type = "json"
+description = "measure container average footprint"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
+checktype = "mean"
+midval = 155950.0
+minpercent = 5.0
+maxpercent = 5.0
+
+[[metric]]
+name = "memory-footprint-ksm"
+type = "json"
+description = "measure container average footprint with KSM"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
+checktype = "mean"
+midval = 56192.0
+minpercent = 5.0
+maxpercent = 5.0
+


### PR DESCRIPTION
To allow easier management and quicker updates, make the metrics CI check the bounds against config files stored in the source tree.