### PR TITLE
docker: logs test fix

### DIFF
--- a/integration/docker/logs_test.go
+++ b/integration/docker/logs_test.go
@@ -14,7 +14,7 @@ var _ = Describe("logs", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		_, _, exitCode := dockerRun("-td", "--name", id, Image, "sh", "-c", "'echo hello'")
+		_, _, exitCode := dockerRun("-t", "--name", id, Image, "/bin/echo", "hello")
 		Expect(exitCode).To(Equal(0))
 	})
 


### PR DESCRIPTION
The '-d' option could lead to a race condition.
The option sh -c 'echo hello' cause an issue on s390x.

Fixes: #1293

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>