### PR TITLE
test: Add test for --cgroup-parent for specific paths

### DIFF
--- a/integration/docker/cgroups_test.go
+++ b/integration/docker/cgroups_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -203,4 +204,36 @@ var _ = Describe("Checking CPU cgroups in the host", func() {
 			})
 		})
 	})
+})
+
+var _ = Describe("Check cgroup paths", func() {
+	var (
+		args []string
+		id   string
+	)
+
+	BeforeEach(func() {
+		id = randomDockerName()
+		args = []string{"-d", "--name", id}
+	})
+
+	AfterEach(func() {
+		Expect(RemoveDockerContainer(id)).To(BeTrue())
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
+	})
+
+	DescribeTable("with a parent cgroup",
+		func(parentCgroup string) {
+			Skip("Issue: https://github.com/kata-containers/runtime/issues/1365")
+			args = append(args, "--cgroup-parent", parentCgroup, Image)
+			_, _, exitCode := dockerRun(args...)
+			Expect(exitCode).To(BeZero())
+		},
+		withParentCgroup("../"),
+		withParentCgroup("../../"),
+		withParentCgroup("../../../"),
+		withParentCgroup("../../../../"),
+		withParentCgroup("~"),
+		withParentCgroup("/../../../../hi"),
+	)
 })


### PR DESCRIPTION
This will run a container with --cgroup-parent for a specific path
in order to verify that we are able to run the container without issues.

Fixes #1299

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>