### PR TITLE
rand: generate a new seed each time a new ID is required

### DIFF
--- a/rand.go
+++ b/rand.go
@@ -13,10 +13,9 @@ const letters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 const lettersMask = 63
 
-var randSrc = rand.NewSource(time.Now().UnixNano())
-
 // RandID returns a random string
 func RandID(n int) string {
+	randSrc := rand.NewSource(time.Now().UnixNano())
 	b := make([]byte, n)
 	for i := 0; i < n; {
 		if j := int(randSrc.Int63() & lettersMask); j < len(letters) {


### PR DESCRIPTION
To avoid generating the same container ID or name for two
different tests, the random seed should be generated when
the random string is required.

fixes #1304

Signed-off-by: Julio Montes <julio.montes@intel.com>