### PR TITLE
makefile: honor FOCUS environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,15 @@ ifeq ($(KATA_HYPERVISOR),firecracker)
 else ifeq ($(ARCH),aarch64)
 	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+else ifneq (${FOCUS},)
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -nodes=${GINKGO_NODES} -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
-	./ginkgo -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+	./ginkgo -v -focus "\[Serial Test\]" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif


### PR DESCRIPTION
Run sequentially only the tests that match with `FOCUS`.
The `FOCUS` environment variable is used to debug and put attention on
certain tests.

fixes #1306

Signed-off-by: Julio Montes <julio.montes@intel.com>