### PR TITLE
integration/docker: fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ else ifneq (${FOCUS},)
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
 	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ functional: ginkgo
 ifeq (${RUNTIME},)
 	$(error RUNTIME is not set)
 else
-	./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	./ginkgo -failFast -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif
 
@@ -59,17 +59,17 @@ ifeq ($(RUNTIME),)
 endif
 
 ifeq ($(KATA_HYPERVISOR),firecracker)
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else ifeq ($(ARCH),aarch64)
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
-	./ginkgo -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 # The time limit in seconds for each test
-TIMEOUT := 60
+TIMEOUT := 120
 
 # union for 'make test'
 UNION := functional docker crio docker-compose network netmon \

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,6 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
-# Number of processor units available
-NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
-# Number of `go test` processes that ginkgo will spawn.
-GINKGO_NODES := $(shell echo $(NPROCS)\-2 | bc)
-
 # Load architecture-dependent settings
 ifneq ($(wildcard $(ARCH_FILE)),)
 include $(ARCH_FILE)
@@ -69,7 +64,7 @@ else ifneq (${FOCUS},)
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -p -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
 	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,15 @@ ifeq ($(KATA_HYPERVISOR),firecracker)
 else ifeq ($(ARCH),aarch64)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+else ifneq (${FOCUS},)
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
-	./ginkgo -failFast -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -7,7 +7,6 @@ package docker
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/kata-containers/tests"
 )
@@ -51,6 +52,8 @@ var cidDirectory string
 
 // AlpineImage is the alpine image
 var AlpineImage string
+
+var images []string
 
 // versionDockerImage is the definition in the yaml for the Alpine image
 type versionDockerImage struct {
@@ -96,6 +99,16 @@ func init() {
 
 	// Define Alpine image with its proper version
 	AlpineImage = "alpine:" + versions.Docker.Alpine.Version
+
+	images = []string{
+		Image,
+		AlpineImage,
+		PostgresImage,
+		DebianImage,
+		FedoraImage,
+		CentosImage,
+		StressImage,
+	}
 }
 
 func cidFilePath(containerName string) string {

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	. "github.com/kata-containers/tests"
@@ -24,44 +25,50 @@ func randomDockerName() string {
 	return RandID(30)
 }
 
-func TestIntegration(t *testing.T) {
+var _ = SynchronizedBeforeSuite(func() []byte {
 	// before start we have to download the docker images
-	images := []string{
-		Image,
-		AlpineImage,
-		PostgresImage,
-		DebianImage,
-		FedoraImage,
-		CentosImage,
-		StressImage,
-	}
-
 	for _, i := range images {
 		// vish/stress is single-arch image only for amd64
 		if i == StressImage && runtime.GOARCH != "amd64" {
 			//check if vish/stress has already been built
 			argsImage := []string{"--format", "'{{.Repository}}:{{.Tag}}'", StressImage}
 			imagesStdout, _, imagesExitcode := dockerImages(argsImage...)
-			if imagesExitcode != 0 {
-				t.Fatalf("failed to docker images --format '{{.Repository}}:{{.Tag}}' %s\n", StressImage)
-			}
+			Expect(imagesExitcode).To(BeZero())
 			if imagesStdout == "" {
 				gopath := os.Getenv("GOPATH")
 				entirePath := filepath.Join(gopath, StressDockerFile)
 				argsBuild := []string{"-t", StressImage, entirePath}
 				_, _, buildExitCode := dockerBuild(argsBuild...)
-				if buildExitCode != 0 {
-					t.Fatalf("failed to build stress image in %s\n", runtime.GOARCH)
-				}
+				Expect(buildExitCode).To(BeZero())
 			}
 		} else {
 			_, _, exitCode := dockerPull(i)
-			if exitCode != 0 {
-				t.Fatalf("failed to pull docker image: %s\n", i)
-			}
+			Expect(exitCode).To(BeZero())
 		}
 	}
 
+	return nil
+}, func(data []byte) {
+	// check whether all images were downloaded
+	stdout, _, exitCode := dockerImages("--format", "{{.Repository}}")
+	Expect(exitCode).To(BeZero())
+
+	dockerImages := strings.Split(stdout, "\n")
+	for _, i := range images {
+		found := false
+		// remove tag
+		i = strings.Split(i, ":")[0]
+		for _, dockerImage := range dockerImages {
+			if i == dockerImage {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+	}
+})
+
+func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Suite")
 }

--- a/rand.go
+++ b/rand.go
@@ -13,10 +13,9 @@ const letters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 const lettersMask = 63
 
-var randSrc = rand.NewSource(time.Now().UnixNano())
-
 // RandID returns a random string
 func RandID(n int) string {
+	randSrc := rand.NewSource(time.Now().UnixNano())
 	b := make([]byte, n)
 	for i := 0; i < n; {
 		if j := int(randSrc.Int63() & lettersMask); j < len(letters) {


### PR DESCRIPTION
SynchronizedBeforeSuite is used to synchronize parallel test.
Use SynchronizedBeforeSuite to pull all docker images before running any test.
When a test fails, the CI fails. To improve CI time and allow other jobs
run, integration and functional test should fail and stop running the tests
after a failure occurs.
To avoid generating the same container ID or name for two
different tests, the random seed should be generated when
the random string is required.
Run sequentially only the tests that match with FOCUS.
The FOCUS environment variable is used to debug and put attention on
certain tests.

fixes #1306
fixes #1304 
fixes #1302
fixes #1308

Signed-off-by: Julio Montes <julio.montes@intel.com>