### PR TITLE
integration: cri-o: Skip 'ctr stats'

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,4 +9,5 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
+'test "ctr stats"'
 );


### PR DESCRIPTION
Based on recent fix of the CRI-O bats 'ctr stats' from this following
PR https://github.com/kubernetes-sigs/cri-o/pull/2054, this test is
failing for Kata since Kata v1 does not support proper stats.

This is something that needs to be fixed once the CI for Kata v2 will
be in place.

For now, let's simply skip this test.

Fixes #1311

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>