### PR TITLE
cri-o: fix name of skipped test

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,5 +9,5 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
-'test "ctr stats"'
+'test "ctr stats output"'
 );


### PR DESCRIPTION
The name of the test is 'ctr stats output'.
Add the complete name of the test in the list instead
of only part of it.

Fixes: #1311.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>