### PR TITLE
ci: metrics: adjust kata2 slave settings

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 155950.0
+midval = 132550.0
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 56192.0
+midval = 55850.0
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
Adjust bounds values for metric-kata2 packet slave to take
into account recent changes.

Data based on last 5 days runs for runtime and tests repos.
Critical change here is the non-ksm memory footprint one.

Fixes: #1320

Signed-off-by: Graham Whaley <graham.whaley@intel.com>