### PR TITLE
test: Add docker integration test for sysctls

### DIFF
--- a/integration/docker/sysctls_test.go
+++ b/integration/docker/sysctls_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sysctls", func() {
+	var (
+		args     []string
+		id       string
+		stdout   string
+		exitCode int
+	)
+
+	BeforeEach(func() {
+		id = randomDockerName()
+	})
+
+	AfterEach(func() {
+		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
+	})
+
+	Context("sysctls for fs", func() {
+		It("should be applied", func() {
+			fsValue := "512"
+			args = []string{"--name", id, "--rm", "--sysctl", "fs.mqueue.queues_max=" + fsValue, Image, "cat", "/proc/sys/fs/mqueue/queues_max"}
+			stdout, _, exitCode = dockerRun(args...)
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring(fsValue))
+		})
+	})
+})


### PR DESCRIPTION
This will add a docker integration test for sysctls.

Fixes #1312

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>