### PR TITLE
ci: fix `.ci/lib.sh` to not require go installed

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -20,7 +20,12 @@ KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
 export KATA_DOCKER_TIMEOUT=30
 
 # Ensure GOPATH set
-export GOPATH=${GOPATH:-$(go env GOPATH)}
+if command -v go > /dev/null; then
+	export GOPATH=${GOPATH:-$(go env GOPATH)}
+else
+	# if go isn't installed, set default location for GOPATH
+	export GOPATH="${GOPATH:-$HOME/go}"
+fi
 
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"


### PR DESCRIPTION
`.ci/lib.sh` was using `go env` to get GOPATH value,
but this library is also used by the `install_go.sh`
script, which shouldn't require `go` to be installed.

Fix this issue, by adding a default value to GOPATH
if no `go` command is available.

Fixes: #1324.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>