### PR TITLE
test: Add K8s test for empty dir

### DIFF
--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="sharevol-kata"
+	get_pod_config_dir
+}
+
+@test "Empty dir volumes" {
+	# Create the pod
+	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check volume mounts
+	cmd="mount | grep cache"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep "/host/cache type 9p"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep "/tmp/cache type tmpfs"
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -27,6 +27,7 @@ pushd "$kubernetes_dir"
 bats nginx.bats
 bats k8s-uts+ipc-ns.bats
 bats k8s-env.bats
+bats k8s-empty-dirs.bats
 bats k8s-limit-range.bats
 bats k8s-credentials-secrets.bats
 bats k8s-configmap.bats

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sharevol-kata
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: test
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]
+    volumeMounts:
+      - name: host-empty-vol
+        mountPath: "/host/cache"
+      - name: memory-empty-vol
+        mountPath: "/tmp/cache"
+  volumes:
+  - name: host-empty-vol
+    emptyDir: {}
+  - name: memory-empty-vol
+    emptyDir:
+      medium: Memory
+      sizeLimit: "50M"

--- a/integration/kubernetes/untrusted_workloads/pod-empty-dir.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-empty-dir.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sharevol-kata
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+  - name: test
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]
+    volumeMounts:
+      - name: host-empty-vol
+        mountPath: "/host/cache"
+      - name: memory-empty-vol
+        mountPath: "/tmp/cache"
+  volumes:
+  - name: host-empty-vol
+    emptyDir: {}
+  - name: memory-empty-vol
+    emptyDir:
+      medium: Memory
+      sizeLimit: "50M"


### PR DESCRIPTION
This will add a K8s test to verify empty dir volumes are handled correctly.

Fixes #1310

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>