### PR TITLE
integration/docker: include number of parallel node in the container's name

### DIFF
--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 
 	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -22,7 +24,7 @@ const (
 )
 
 func randomDockerName() string {
-	return RandID(30)
+	return RandID(29) + fmt.Sprintf("%d", GinkgoConfig.ParallelNode)
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {


### PR DESCRIPTION
Each parallel test has its own node number, to avoid two or more test using
the same container name at the same time, parallel node should be included in
the container's name.

fixes #1304

Signed-off-by: Julio Montes <julio.montes@intel.com>