### PR TITLE
s390x: run docker test in serial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 ifeq ($(KATA_HYPERVISOR),firecracker)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-else ifeq ($(ARCH),aarch64)
+else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x))
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else ifneq (${FOCUS},)


### PR DESCRIPTION
Ginkgo doesn't skip the tests in `SKIP` when they're run in parallel.

Fixes: #1330

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>