### PR TITLE
integration/docker: use random repo names

### DIFF
--- a/integration/docker/commit_test.go
+++ b/integration/docker/commit_test.go
@@ -14,12 +14,14 @@ var _ = Describe("docker commit", func() {
 		id       string
 		exitCode int
 		stdout   string
+		repoName string
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
 		_, _, exitCode = dockerRun("-td", "--name", id, Image, "sh")
 		Expect(exitCode).To(Equal(0))
+		repoName = randomDockerRepoName()
 	})
 
 	AfterEach(func() {
@@ -29,20 +31,19 @@ var _ = Describe("docker commit", func() {
 
 	Context("commit a container with new configurations", func() {
 		It("should have the new configurations", func() {
-			imageName := "test/container-test"
-			_, _, exitCode = dockerCommit("-m", "test_commit", id, imageName)
+			_, _, exitCode = dockerCommit("-m", "test_commit", id, repoName)
 			Expect(exitCode).To(Equal(0))
 
 			stdout, _, exitCode = dockerImages()
 			Expect(exitCode).To(Equal(0))
-			Expect(stdout).To(ContainSubstring(imageName))
+			Expect(stdout).To(ContainSubstring(repoName))
 
-			_, _, exitCode = dockerRmi(imageName)
+			_, _, exitCode = dockerRmi(repoName)
 			Expect(exitCode).To(Equal(0))
 
 			stdout, _, exitCode = dockerImages()
 			Expect(exitCode).To(Equal(0))
-			Expect(stdout).NotTo(ContainSubstring(imageName))
+			Expect(stdout).NotTo(ContainSubstring(repoName))
 		})
 	})
 })

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/kata-containers/tests"
+	ginkgoconf "github.com/onsi/ginkgo/config"
 )
 
 const (
@@ -365,6 +366,11 @@ func KillDockerContainer(name string) bool {
 	}
 
 	return true
+}
+
+// returns a random and valid repository name
+func randomDockerRepoName() string {
+	return strings.ToLower(tests.RandID(14)) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)
 }
 
 // dockerRm removes a container

--- a/integration/docker/load_test.go
+++ b/integration/docker/load_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (
@@ -10,19 +14,20 @@ import (
 
 var _ = Describe("load", func() {
 	var (
-		id        string
-		imageName string
-		exitCode  int
+		id       string
+		repoName string
+		exitCode int
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
 		_, _, exitCode = dockerRun("-td", "--name", id, Image)
 		Expect(exitCode).To(Equal(0))
+		repoName = randomDockerRepoName()
 	})
 
 	AfterEach(func() {
-		_, _, exitCode = dockerRmi(imageName)
+		_, _, exitCode = dockerRmi(repoName)
 		Expect(exitCode).To(Equal(0))
 		Expect(RemoveDockerContainer(id)).To(BeTrue())
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
@@ -37,13 +42,12 @@ var _ = Describe("load", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer os.Remove(file.Name())
 				Expect(file.Name()).To(BeAnExistingFile())
-				imageName = "test/container-test"
-				_, _, exitCode = dockerCommit(id, imageName)
+				_, _, exitCode = dockerCommit(id, repoName)
 				Expect(exitCode).To(Equal(0))
-				_, _, exitCode = dockerSave(imageName, "--output", file.Name())
+				_, _, exitCode = dockerSave(repoName, "--output", file.Name())
 				Expect(exitCode).To(Equal(0))
 				stdout, _, _ := dockerLoad("--input", file.Name())
-				Expect(stdout).To(ContainSubstring(imageName))
+				Expect(stdout).To(ContainSubstring(repoName))
 			})
 		})
 	})


### PR DESCRIPTION
Use random repositories names to avoid collisions between
parallel tests.

fixes #1332

Signed-off-by: Julio Montes <julio.montes@intel.com>