### PR TITLE
integration/docker: Don't use RandID directly

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Hot plug CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		waitTime = 5
 		maxTries = 5
 		args = []string{"--rm", "--name", id}
@@ -127,7 +127,7 @@ var _ = Describe("CPU constraints", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "--name", id}
 	})
 
@@ -195,7 +195,7 @@ var _ = Describe("Hot plug CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "--name", id}
 		cpus = 2
 	})
@@ -240,7 +240,7 @@ var _ = Describe("Update number of CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		waitTime = 5
 		maxTries = 5
 
@@ -332,7 +332,7 @@ var _ = Describe("Update CPU constraints", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 
 		updateArgs = []string{}
 		execArgs = []string{}
@@ -424,7 +424,7 @@ var _ = Describe("CPUs and CPU set", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "-dt", "--name", id, Image, "sh"}
 		cpuTests = []cpuTest{
 			{"1", "0-1", "2"},

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -368,6 +368,10 @@ func KillDockerContainer(name string) bool {
 	return true
 }
 
+func randomDockerName() string {
+	return tests.RandID(29) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)
+}
+
 // returns a random and valid repository name
 func randomDockerRepoName() string {
 	return strings.ToLower(tests.RandID(14)) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -5,16 +5,13 @@
 package docker
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
-	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -22,10 +19,6 @@ const (
 	shouldFail    = true
 	shouldNotFail = false
 )
-
-func randomDockerName() string {
-	return RandID(29) + fmt.Sprintf("%d", GinkgoConfig.ParallelNode)
-}
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	// before start we have to download the docker images

--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -100,7 +99,7 @@ var _ = Describe("run", func() {
 	}
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 
 		for i := 0; i < loopDevices; i++ {
 			diskFile, loopFile, err = createLoopDevice()


### PR DESCRIPTION
Use randomDockerName to generate random names since this function
is designed to always generate unique random names.

fixes #1334

Signed-off-by: Julio Montes <julio.montes@intel.com>