### PR TITLE
ci: Do not remove docker at opensuse

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -184,6 +184,7 @@ install_docker(){
 
 # This function removes the installed docker package.
 remove_docker(){
+	[[ "$ID" =~ ^opensuse.*$ ]] && return
 	pkg_name=$(get_docker_package_name)
 	if [ -z "$pkg_name" ]; then
 		die "Docker not found in this system"
@@ -197,7 +198,7 @@ remove_docker(){
 			sudo dnf -y remove ${pkg_name}
 		elif [ "$ID" == "centos" ]; then
 			sudo yum -y remove ${pkg_name}
-		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
+		elif [ "$ID" == "sles" ]; then
 			sudo zypper -n remove ${pkg_name}
 		else
 			die "This script doesn't support your Linux distribution"


### PR DESCRIPTION
The jenkins job for opensuse already does the docker installation and we are
having issues sometimes while docker installation as it is already installed
and we can not remove it.

Fixes #1326

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>