### PR TITLE
test: Add docker integration test for sysctl kernel

### DIFF
--- a/integration/docker/sysctls_test.go
+++ b/integration/docker/sysctls_test.go
@@ -34,4 +34,14 @@ var _ = Describe("sysctls", func() {
 			Expect(stdout).To(ContainSubstring(fsValue))
 		})
 	})
+
+	Context("sysctls for kernel", func() {
+		It("should be applied", func() {
+			kernelValue := "1024"
+			args = []string{"--name", id, "--rm", "--sysctl", "kernel.shmmax=" + kernelValue, Image, "cat", "/proc/sys/kernel/shmmax"}
+			stdout, _, exitCode = dockerRun(args...)
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring(kernelValue))
+		})
+	})
 })


### PR DESCRIPTION
This adds a docker integration sysctl test to modify the kernel subsystem.

Fixes #1337

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>