### PR TITLE
lib/common: extract_kata_env: Convert $rpath to pathname

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -61,6 +61,7 @@ get_docker_kata_path(){
 extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
+	rpath=$(command -v "$rpath")
 
 	# If we can execute the path handed back to us
 	if [ -x "$rpath" ]; then


### PR DESCRIPTION
Cannot pass vm_templating_test.sh if kata-runtime is not pathname
in docker config because extract_kata_env determines $rpath
cannot execute.

Convert $rpath to pathname to handle the issue.

Fixes: #1347

Signed-off-by: Hui Zhu <teawater@hyper.sh>