### PR TITLE
static-checks: Exclude systemd unit files from SPDX license check

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -310,6 +310,12 @@ check_license_headers()
 		--exclude="*.yaml" \
 		--exclude="*.pb.go" \
 		--exclude="*.gpl.c" \
+		--exclude="*.target" \
+		--exclude="*.service" \
+		--exclude="*.path" \
+		--exclude="*.socket" \
+		--exclude="*.mount" \
+		--exclude="*.device" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
This is required for systemd target and service files we have in
agent repo. While at it, adding all systemd units types here.

Fixes #1350

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>