### PR TITLE
ci: k8s: install cni 0.6.0

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -33,6 +33,10 @@ deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 chronic sudo -E apt update
+
+# This is a workaround due to issue: https://github.com/kubernetes/kubernetes/issues/75683
+chronic sudo -E apt install kubernetes-cni=0.6.0-00
+
 chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 
 if [ "${use_runtime_class}"  == true ]; then


### PR DESCRIPTION
Install cni 0.6.0 to be able to install
kuberentes 1.13.
This is a workaround needed until
https://github.com/kubernetes/kubernetes/issues/75683
gets fixed.

Fixes: #1352.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>