### PR TITLE
lib: extract_kata_env: don't rely on docker output

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -61,7 +61,9 @@ get_docker_kata_path(){
 extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
-	rpath=$(command -v "$rpath")
+	if [ -n "$rpath" ]; then
+		rpath=$(command -v "$rpath")
+	fi
 
 	# If we can execute the path handed back to us
 	if [ -x "$rpath" ]; then


### PR DESCRIPTION
We are getting the runtime path (rpath) from docker info, but
it may be the case where we try to run `extract_kata_env` and
not running docker, so we shouldn't fail to get the kata
runtime path if docker service is down or not healthy.

Fixes: #1356.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>