### PR TITLE
test: Add K8s tests for sysctl

### DIFF
--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="sysctl-test"
+	get_pod_config_dir
+}
+
+@test "Setting sysctl" {
+	# Create pod
+	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Check sysctl configuration
+	cmd="cat /proc/sys/kernel/shm_rmid_forced"
+	result=$(kubectl exec $pod_name -- sh -c "$cmd")
+	[ "${result}" = 0 ]
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/kubeadm/config.yaml
+++ b/integration/kubernetes/kubeadm/config.yaml
@@ -2,6 +2,8 @@ apiVersion: kubeadm.k8s.io/v1alpha3
 kind: InitConfiguration
 nodeRegistration:
   criSocket: CRI_RUNTIME_SOCKET
+  kubeletExtraArgs:
+    allowed-unsafe-sysctls: "kernel.msg*,kernel.shm.*,net.*"
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -40,6 +40,7 @@ bats k8s-liveness-probes.bats
 bats k8s-attach-handlers.bats
 bats k8s-qos-pods.bats
 bats k8s-pod-quota.bats
+bats k8s-sysctls.bats
 bats k8s-volume.bats
 bats k8s-projected-volume.bats
 bats k8s-memory.bats

--- a/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-test
+spec:
+  runtimeClassName: kata
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+  containers:
+  - name: test
+    securityContext:
+      privileged: true
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]
+  initContainers:
+  - name: init-sys
+    securityContext:
+      privileged: true
+    image: busybox
+    command: ['sh', '-c', 'echo "64000" > /proc/sys/vm/max_map_count']

--- a/integration/kubernetes/untrusted_workloads/pod-sysctl.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-sysctl.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-test
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+  containers:
+  - name: test
+    securityContext:
+      privileged: true
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]
+  initContainers:
+  - name: init-sys
+    securityContext:
+      privileged: true
+    image: busybox
+    command: ['sh', '-c', 'echo "64000" > /proc/sys/vm/max_map_count']


### PR DESCRIPTION
This sets sysctls for a kubernetes pod.

Fixes #1339

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>