### PR TITLE
k8s: add test to verify block volume support

### DIFF
--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	get_pod_config_dir
+
+	pod_name="pod-block-pv"
+	ctr_dev_path="/dev/xda"
+	vol_capacity="500M"
+
+	# Create Loop Device
+	tmp_disk_image=$(mktemp --tmpdir disk.XXXXXX.img)
+	sudo truncate "$tmp_disk_image" --size "$vol_capacity"
+	loop_dev=$(sudo losetup -f)
+	sudo losetup "$loop_dev" "$tmp_disk_image"
+}
+
+@test "Block Storage Support" {
+	# Create Storage Class
+	kubectl create -f volume/local-storage.yaml
+
+	# Create Persistent Volume
+	tmp_pv_yaml=$(mktemp --tmpdir block_persistent_vol.XXXXX.yaml)
+	sed -e "s|LOOP_DEVICE|${loop_dev}|" volume/block-loop-pv.yaml > "$tmp_pv_yaml"
+	sed -i "s|HOSTNAME|$(hostname)|" "$tmp_pv_yaml"
+	sed -i "s|CAPACITY|${vol_capacity}|" "$tmp_pv_yaml"
+	kubectl create -f "$tmp_pv_yaml"
+
+	# Create Persistent Volume Claim
+	tmp_pvc_yaml=$(mktemp --tmpdir block_persistent_vol.XXXXX.yaml)
+	sed -e "s|CAPACITY|${vol_capacity}|" volume/block-loop-pvc.yaml > "$tmp_pvc_yaml"
+	kubectl create -f "$tmp_pvc_yaml"
+
+	# Create Workload using Volume
+	tmp_pod_yaml=$(mktemp --tmpdir pod-pv.XXXXX.yaml)
+	sed -e "s|DEVICE_PATH|${ctr_dev_path}|" "${pod_config_dir}/${pod_name}.yaml" > "$tmp_pod_yaml"
+	kubectl create -f "$tmp_pod_yaml"
+	kubectl wait --for condition=ready "pod/${pod_name}"
+
+	# Verify persistent volume claim is bound
+	kubectl get pvc | grep "Bound"
+
+	# make fs, mount device and write on it
+	kubectl exec "$pod_name" -- sh -c "mkfs -t ext4 $ctr_dev_path"
+	ctr_mount_path="/mnt"
+	ctr_message="Hello World"
+	ctr_file="${ctr_mount_path}/file.txt"
+	kubectl exec "$pod_name" -- sh -c "mount $ctr_dev_path $ctr_mount_path"
+	kubectl exec "$pod_name" -- sh -c "echo $ctr_message > $ctr_file"
+	kubectl exec "$pod_name" -- sh -c "grep '$ctr_message' $ctr_file"
+}
+
+teardown() {
+	# Delete k8s resources
+	kubectl delete pod "$pod_name"
+	kubectl delete pvc block-loop-pvc
+	kubectl delete pv block-loop-pv
+	kubectl delete storageclass local-storage
+
+	# Delete temporary yaml files
+	rm -f "$tmp_pv_yaml"
+	rm -f "$tmp_pvc_yaml"
+	rm -f "$tmp_pod_yaml"
+
+	# Remove image and loop device
+	sudo losetup -d "$loop_dev"
+	rm -f "$tmp_disk_image"
+}
+

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -44,5 +44,6 @@ bats k8s-sysctls.bats
 bats k8s-volume.bats
 bats k8s-projected-volume.bats
 bats k8s-memory.bats
+bats k8s-block-volume.bats
 ./cleanup_env.sh
 popd

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-block-pv
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  runtimeClassName: kata
+  containers:
+    - name: my-container
+      image: debian
+      command: ["tail", "-f", "/dev/null"]
+      volumeDevices:
+        - devicePath: DEVICE_PATH
+          name: my-volume
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        capabilities:
+          add: ["SYS_ADMIN"]
+  volumes:
+    - name: my-volume
+      persistentVolumeClaim:
+        claimName: block-loop-pvc

--- a/integration/kubernetes/untrusted_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-block-pv.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-block-pv
+  annotations:
+    io.kubernetes.cri-o.TrustedSandbox: "false"
+    io.kubernetes.cri.untrusted-workload: "true"
+spec:
+  containers:
+    - name: my-container
+      image: debian
+      command: ["tail", "-f", "/dev/null"]
+      volumeDevices:
+        - devicePath: DEVICE_PATH
+          name: my-volume
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        capabilities:
+          add: ["SYS_ADMIN"]
+  volumes:
+    - name: my-volume
+      persistentVolumeClaim:
+        claimName: block-loop-pvc

--- a/integration/kubernetes/volume/block-loop-pv.yaml
+++ b/integration/kubernetes/volume/block-loop-pv.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: block-loop-pv
+spec:
+  capacity:
+    storage: CAPACITY
+  volumeMode: Block
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-storage
+  local:
+    path: LOOP_DEVICE
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: In
+            values:
+            - HOSTNAME
+

--- a/integration/kubernetes/volume/block-loop-pvc.yaml
+++ b/integration/kubernetes/volume/block-loop-pvc.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: block-loop-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: local-storage
+  volumeMode: Block
+  resources:
+    requests:
+      storage: CAPACITY
+

--- a/integration/kubernetes/volume/local-storage.yaml
+++ b/integration/kubernetes/volume/local-storage.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This test creates a block loop device and passes it
to a pod as a persistent volume. Then we create a
file system on the device inside the container and
write to it.

Fixes: #1358.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>