### PR TITLE
gocache: clean GOCACHE on AArch64

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -317,5 +317,14 @@ gen_clean_arch() {
 	fi
 	info "Remove Kata package repo registrations"
 	delete_kata_repo_registrations
+
+	info "Clean GOCACHE"
+	if command -v go > /dev/null; then
+		GOCACHE=${GOCACHE:-$(go env GOCACHE)}
+	else
+		# if go isn't installed, try default dir
+		GOCACHE=${GOCACHE:-$HOME/.cache/go-build}
+	fi
+	[ -d "$GOCACHE" ] && sudo rm -rf ${GOCACHE}/*
 }
 


### PR DESCRIPTION
Go command caches build outputs under `$GOCACHE`, The default location for cache data is a subdirectory named `go-build/` in the standard user cache directory, like `$XDG_CACHE_HOME` in linux.
Since some CI, including ARM CI, is running on bare metal. We need to clean` GOCACHE` before each run.

Fixes: #1365

Signed-off-by: Penny Zheng <penny.zheng@arm.com>