### PR TITLE
cri-o: skip new tests introduced in cri-o repo

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -10,4 +10,6 @@
 declare -a skipCRIOTests=(
 'test "ctr oom"'
 'test "ctr stats output"'
+'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
+'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
 );


### PR DESCRIPTION
skip two new tests that are failing with the kata CI
related: https://github.com/kubernetes-sigs/cri-o/pull/2173

Fixes: #1367.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>