### PR TITLE
clean-up: clean stale kata resource on ARM CI

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -300,7 +300,7 @@ gen_clean_arch() {
 	docker_storage_driver=$(timeout ${KATA_DOCKER_TIMEOUT} docker info --format='{{.Driver}}')
 	stale_docker_mount_point_union=( "/var/lib/docker/containers" "/var/lib/docker/${docker_storage_driver}" )
 	stale_docker_dir_union=( "/var/lib/docker" )
-	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" )
+	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" "/usr/share/kata-containers" "/usr/share/defaults/kata-containers" )
 
 	info "kill stale process"
 	kill_stale_process


### PR DESCRIPTION
Logging into ARM CI, Found out quite a big surprise there.
```
root@testing-1:/usr/share# du -sh -- *
142G    kata-containers
```
I suppose, it won't cost them too much time to eat up my whole `/`
Directories `/usr/share/kata-containers` and `/usr/share/defaults/kata-containers` must be cleaned up before each run.

Fixes: #1373

Signed-off-by: Penny Zheng <penny.zheng@arm.com>