### PR TITLE
metrics: ci: update slave bounds check values

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 155950.0
+midval = 132458.0
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 56192.0
+midval = 55879.5
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
Based on the results of the last 24h of jenkins builds for
the tests and runtime repos:
  tests: #723-731
  runtime: #758-772

Set new bounds values:

  what   value
  boot   0.85s
  ksm    55879.5m
  noksm  132458m

Fixes: #1375

Signed-off-by: Graham Whaley <graham.whaley@intel.com>