### PR TITLE
ci: Add sudo while adding the repository

### DIFF
--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -13,7 +13,7 @@ source "${cidir}/lib.sh"
 
 echo "Add epel repository"
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-yum install "$epel_url"
+sudo -E yum install "$epel_url"
 
 echo "Update repositories"
 sudo -E yum -y update


### PR DESCRIPTION
We need sudo to enable epel repository in RHEL.

Fixes #1377

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>