### PR TITLE
k8s: Remove untrusted annotations when using runtimeclass

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -2,9 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-block-pv
-  annotations:
-    io.kubernetes.cri-o.TrustedSandbox: "false"
-    io.kubernetes.cri.untrusted-workload: "true"
 spec:
   runtimeClassName: kata
   containers:


### PR DESCRIPTION
Remove untrusted annotations for pod definition
`runtimeclass_workloads/pod-block-pv.yaml`. When using containerd,
we will receive an error when we have added runtimeclass and old
untrusted annotations to the pod definition.

Fixes: #1384.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>