### PR TITLE
ci: remove unexistent blogbench URL

### DIFF
--- a/metrics/storage/README.md
+++ b/metrics/storage/README.md
@@ -14,6 +14,6 @@ which variables are available.
 
 ## `blogbench` test
 
-The `blogbench` script is based on the [blogbench program](https://www.pureftpd.org/project/blogbench)
+The `blogbench` script is based on the blogbench program
 which is designed to emulate a busy blog server with a number of concurrent threads
 performing a mixture of reads, writes and rewrites.


### PR DESCRIPTION
blogbench URL https://www.pureftpd.org/project/blogbench
doesn't exist anymore. Seems that our CI has been failing
when testing master branch since March 19th. Lets remove this
unexistent URL.

Fixes: #1386.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>