### PR TITLE
test: Add sysctl test for networking

### DIFF
--- a/integration/docker/sysctls_test.go
+++ b/integration/docker/sysctls_test.go
@@ -44,4 +44,14 @@ var _ = Describe("sysctls", func() {
 			Expect(stdout).To(ContainSubstring(kernelValue))
 		})
 	})
+
+	Context("sysctls for net", func() {
+		It("should be applied", func() {
+			pmtuValue := "1024"
+			args = []string{"--name", id, "--rm", "--sysctl", "net.ipv4.route.min_pmtu=" + pmtuValue, Image, "cat", "/proc/sys/net/ipv4/route/min_pmtu"}
+			stdout, _, exitCode = dockerRun(args...)
+			Expect(exitCode).To(Equal(0))
+			Expect(stdout).To(ContainSubstring(pmtuValue))
+		})
+	})
 })


### PR DESCRIPTION
This adds a docker integration test for sysctl for networking.

Fixes #1388

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>