### PR TITLE
tests: Skip shimv2 tests on SLES

### DIFF
--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 extract_kata_env
 
-if [[ "$ID" =~ ^opensuse.*$ ]]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -19,7 +19,7 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
-if [[ "$ID" =~ ^opensuse.*$ ]]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit


### PR DESCRIPTION
shim2 tests are not working on SLES https://github.com/kata-containers/tests/issues/1251.

Fixes #1391

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>