### PR TITLE
test: Fix aerospike test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -23,7 +23,7 @@ setup() {
 
 @test "[insert data] insert data in an aerospike container" {
 	image="aerospike/aerospike-server"
-	docker run --runtime=$RUNTIME -d --name aerospike $image
+	docker run -m 6G --runtime=$RUNTIME -d --name aerospike $image
 	status=1
 	set +e
 	for i in $(seq 1 5); do


### PR DESCRIPTION
Aerospike server needs at least 6G of memory to run.

Fixes #1394

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>