### PR TITLE
k8s: e2e: skip failing conformance tests

### DIFF
--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# We need to skip some e2e conformance tests as they
+# are not running correctly using kata-runtime.
+
+containerd:
+  - SchedulerPredicates
+  - should ensure that all pods are removed when a namespace is deleted
+
+cri-o:
+  - InitContainer
+  - Projected downwardAPI
+  - Downward API


### PR DESCRIPTION
There are some tests that have been faling when
running with kata, lets add a list of these tests
and skip them when running the conformance suite.

`skipped_tests_e2e.yaml` has a list of the tests that
currently fail with containerd and cri-o.

We are still investigating the root cause of the failures
on: #1396

Fixes: #1401.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>