### PR TITLE
test: backport fixes to stable-1.6 branch

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -33,6 +33,10 @@ deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 chronic sudo -E apt update
+
+# This is a workaround due to issue: https://github.com/kubernetes/kubernetes/issues/75683
+chronic sudo -E apt install kubernetes-cni=0.6.0-00
+
 chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 
 if [ "${use_runtime_class}"  == true ]; then

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -317,5 +317,14 @@ gen_clean_arch() {
 	fi
 	info "Remove Kata package repo registrations"
 	delete_kata_repo_registrations
+
+	info "Clean GOCACHE"
+	if command -v go > /dev/null; then
+		GOCACHE=${GOCACHE:-$(go env GOCACHE)}
+	else
+		# if go isn't installed, try default dir
+		GOCACHE=${GOCACHE:-$HOME/.cache/go-build}
+	fi
+	[ -d "$GOCACHE" ] && sudo rm -rf ${GOCACHE}/*
 }
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -20,7 +20,12 @@ KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
 export KATA_DOCKER_TIMEOUT=30
 
 # Ensure GOPATH set
-export GOPATH=${GOPATH:-$(go env GOPATH)}
+if command -v go > /dev/null; then
+	export GOPATH=${GOPATH:-$(go env GOPATH)}
+else
+	# if go isn't installed, set default location for GOPATH
+	export GOPATH="${GOPATH:-$HOME/go}"
+fi
 
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -300,7 +300,7 @@ gen_clean_arch() {
 	docker_storage_driver=$(timeout ${KATA_DOCKER_TIMEOUT} docker info --format='{{.Driver}}')
 	stale_docker_mount_point_union=( "/var/lib/docker/containers" "/var/lib/docker/${docker_storage_driver}" )
 	stale_docker_dir_union=( "/var/lib/docker" )
-	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" )
+	stale_kata_dir_union=( "/var/lib/vc" "/run/vc" "/usr/share/kata-containers" "/usr/share/defaults/kata-containers" )
 
 	info "kill stale process"
 	kill_stale_process

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -54,7 +54,10 @@ install_docker() {
 	docker_version=$(get_version "externals.docker.version")
 	docker_version=${docker_version/v/}
 	docker_version=${docker_version/-*/}
-	if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
+
+	sudo systemctl restart docker
+
+	if ( ! sudo docker version | grep -q "$docker_version" ) && [ "$CI" == true ]; then
 		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
 	fi
 }

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 ifeq ($(KATA_HYPERVISOR),firecracker)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-else ifeq ($(ARCH),aarch64)
+else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x))
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else ifneq (${FOCUS},)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ else ifneq (${FOCUS},)
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
 	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ functional: ginkgo
 ifeq (${RUNTIME},)
 	$(error RUNTIME is not set)
 else
-	./ginkgo -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+	./ginkgo -failFast -v functional/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif
 
@@ -59,17 +59,17 @@ ifeq ($(RUNTIME),)
 endif
 
 ifeq ($(KATA_HYPERVISOR),firecracker)
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else ifeq ($(ARCH),aarch64)
-	./ginkgo -v -focus "${FOCUS}" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
-	./ginkgo -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 # The time limit in seconds for each test
-TIMEOUT := 60
+TIMEOUT := 120
 
 # union for 'make test'
 UNION := functional docker crio docker-compose network netmon \

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,6 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
-# Number of processor units available
-NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
-# Number of `go test` processes that ginkgo will spawn.
-GINKGO_NODES := $(shell echo $(NPROCS)\-2 | bc)
-
 # Load architecture-dependent settings
 ifneq ($(wildcard $(ARCH_FILE)),)
 include $(ARCH_FILE)
@@ -69,7 +64,7 @@ else ifneq (${FOCUS},)
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -p -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
 	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,15 @@ ifeq ($(KATA_HYPERVISOR),firecracker)
 else ifeq ($(ARCH),aarch64)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+else ifneq (${FOCUS},)
+	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 	# Run tests in parallel, skip tests that need to be run serialized
-	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -focus "${FOCUS}" -skip "${SKIP}" -skip "\[Serial Test\]" \
+	./ginkgo -failFast -nodes=${GINKGO_NODES} -v -skip "${SKIP}" -skip "\[Serial Test\]" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	# Now run serialized tests
-	./ginkgo -failFast -v -focus "${FOCUS}" -focus "\[Serial Test\]" -skip "${SKIP}" \
+	./ginkgo -failFast -v -focus "\[Serial Test\]" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 	bash sanity/check_sanity.sh
 endif

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,5 +9,5 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
-'test "ctr stats"'
+'test "ctr stats output"'
 );

--- a/integration/docker/commit_test.go
+++ b/integration/docker/commit_test.go
@@ -14,12 +14,14 @@ var _ = Describe("docker commit", func() {
 		id       string
 		exitCode int
 		stdout   string
+		repoName string
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
 		_, _, exitCode = dockerRun("-td", "--name", id, Image, "sh")
 		Expect(exitCode).To(Equal(0))
+		repoName = randomDockerRepoName()
 	})
 
 	AfterEach(func() {
@@ -29,20 +31,19 @@ var _ = Describe("docker commit", func() {
 
 	Context("commit a container with new configurations", func() {
 		It("should have the new configurations", func() {
-			imageName := "test/container-test"
-			_, _, exitCode = dockerCommit("-m", "test_commit", id, imageName)
+			_, _, exitCode = dockerCommit("-m", "test_commit", id, repoName)
 			Expect(exitCode).To(Equal(0))
 
 			stdout, _, exitCode = dockerImages()
 			Expect(exitCode).To(Equal(0))
-			Expect(stdout).To(ContainSubstring(imageName))
+			Expect(stdout).To(ContainSubstring(repoName))
 
-			_, _, exitCode = dockerRmi(imageName)
+			_, _, exitCode = dockerRmi(repoName)
 			Expect(exitCode).To(Equal(0))
 
 			stdout, _, exitCode = dockerImages()
 			Expect(exitCode).To(Equal(0))
-			Expect(stdout).NotTo(ContainSubstring(imageName))
+			Expect(stdout).NotTo(ContainSubstring(repoName))
 		})
 	})
 })

--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Hot plug CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		waitTime = 5
 		maxTries = 5
 		args = []string{"--rm", "--name", id}
@@ -127,7 +127,7 @@ var _ = Describe("CPU constraints", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "--name", id}
 	})
 
@@ -195,7 +195,7 @@ var _ = Describe("Hot plug CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "--name", id}
 		cpus = 2
 	})
@@ -240,7 +240,7 @@ var _ = Describe("Update number of CPUs", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		waitTime = 5
 		maxTries = 5
 
@@ -332,7 +332,7 @@ var _ = Describe("Update CPU constraints", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 
 		updateArgs = []string{}
 		execArgs = []string{}
@@ -424,7 +424,7 @@ var _ = Describe("CPUs and CPU set", func() {
 	)
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 		args = []string{"--rm", "-dt", "--name", id, Image, "sh"}
 		cpuTests = []cpuTest{
 			{"1", "0-1", "2"},

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/kata-containers/tests"
+	ginkgoconf "github.com/onsi/ginkgo/config"
 )
 
 const (
@@ -365,6 +366,11 @@ func KillDockerContainer(name string) bool {
 	}
 
 	return true
+}
+
+// returns a random and valid repository name
+func randomDockerRepoName() string {
+	return strings.ToLower(tests.RandID(14)) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)
 }
 
 // dockerRm removes a container

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -368,6 +368,10 @@ func KillDockerContainer(name string) bool {
 	return true
 }
 
+func randomDockerName() string {
+	return tests.RandID(29) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)
+}
+
 // returns a random and valid repository name
 func randomDockerRepoName() string {
 	return strings.ToLower(tests.RandID(14)) + fmt.Sprint(ginkgoconf.GinkgoConfig.ParallelNode)

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -7,7 +7,6 @@ package docker
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/kata-containers/tests"
 )
@@ -51,6 +52,8 @@ var cidDirectory string
 
 // AlpineImage is the alpine image
 var AlpineImage string
+
+var images []string
 
 // versionDockerImage is the definition in the yaml for the Alpine image
 type versionDockerImage struct {
@@ -96,6 +99,16 @@ func init() {
 
 	// Define Alpine image with its proper version
 	AlpineImage = "alpine:" + versions.Docker.Alpine.Version
+
+	images = []string{
+		Image,
+		AlpineImage,
+		PostgresImage,
+		DebianImage,
+		FedoraImage,
+		CentosImage,
+		StressImage,
+	}
 }
 
 func cidFilePath(containerName string) string {

--- a/integration/docker/load_test.go
+++ b/integration/docker/load_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (
@@ -10,19 +14,20 @@ import (
 
 var _ = Describe("load", func() {
 	var (
-		id        string
-		imageName string
-		exitCode  int
+		id       string
+		repoName string
+		exitCode int
 	)
 
 	BeforeEach(func() {
 		id = randomDockerName()
 		_, _, exitCode = dockerRun("-td", "--name", id, Image)
 		Expect(exitCode).To(Equal(0))
+		repoName = randomDockerRepoName()
 	})
 
 	AfterEach(func() {
-		_, _, exitCode = dockerRmi(imageName)
+		_, _, exitCode = dockerRmi(repoName)
 		Expect(exitCode).To(Equal(0))
 		Expect(RemoveDockerContainer(id)).To(BeTrue())
 		Expect(ExistDockerContainer(id)).NotTo(BeTrue())
@@ -37,13 +42,12 @@ var _ = Describe("load", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer os.Remove(file.Name())
 				Expect(file.Name()).To(BeAnExistingFile())
-				imageName = "test/container-test"
-				_, _, exitCode = dockerCommit(id, imageName)
+				_, _, exitCode = dockerCommit(id, repoName)
 				Expect(exitCode).To(Equal(0))
-				_, _, exitCode = dockerSave(imageName, "--output", file.Name())
+				_, _, exitCode = dockerSave(repoName, "--output", file.Name())
 				Expect(exitCode).To(Equal(0))
 				stdout, _, _ := dockerLoad("--input", file.Name())
-				Expect(stdout).To(ContainSubstring(imageName))
+				Expect(stdout).To(ContainSubstring(repoName))
 			})
 		})
 	})

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 
 	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -22,7 +24,7 @@ const (
 )
 
 func randomDockerName() string {
-	return RandID(30)
+	return RandID(29) + fmt.Sprintf("%d", GinkgoConfig.ParallelNode)
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	. "github.com/kata-containers/tests"
@@ -24,44 +25,50 @@ func randomDockerName() string {
 	return RandID(30)
 }
 
-func TestIntegration(t *testing.T) {
+var _ = SynchronizedBeforeSuite(func() []byte {
 	// before start we have to download the docker images
-	images := []string{
-		Image,
-		AlpineImage,
-		PostgresImage,
-		DebianImage,
-		FedoraImage,
-		CentosImage,
-		StressImage,
-	}
-
 	for _, i := range images {
 		// vish/stress is single-arch image only for amd64
 		if i == StressImage && runtime.GOARCH != "amd64" {
 			//check if vish/stress has already been built
 			argsImage := []string{"--format", "'{{.Repository}}:{{.Tag}}'", StressImage}
 			imagesStdout, _, imagesExitcode := dockerImages(argsImage...)
-			if imagesExitcode != 0 {
-				t.Fatalf("failed to docker images --format '{{.Repository}}:{{.Tag}}' %s\n", StressImage)
-			}
+			Expect(imagesExitcode).To(BeZero())
 			if imagesStdout == "" {
 				gopath := os.Getenv("GOPATH")
 				entirePath := filepath.Join(gopath, StressDockerFile)
 				argsBuild := []string{"-t", StressImage, entirePath}
 				_, _, buildExitCode := dockerBuild(argsBuild...)
-				if buildExitCode != 0 {
-					t.Fatalf("failed to build stress image in %s\n", runtime.GOARCH)
-				}
+				Expect(buildExitCode).To(BeZero())
 			}
 		} else {
 			_, _, exitCode := dockerPull(i)
-			if exitCode != 0 {
-				t.Fatalf("failed to pull docker image: %s\n", i)
-			}
+			Expect(exitCode).To(BeZero())
 		}
 	}
 
+	return nil
+}, func(data []byte) {
+	// check whether all images were downloaded
+	stdout, _, exitCode := dockerImages("--format", "{{.Repository}}")
+	Expect(exitCode).To(BeZero())
+
+	dockerImages := strings.Split(stdout, "\n")
+	for _, i := range images {
+		found := false
+		// remove tag
+		i = strings.Split(i, ":")[0]
+		for _, dockerImage := range dockerImages {
+			if i == dockerImage {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+	}
+})
+
+func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Suite")
 }

--- a/integration/docker/main_test.go
+++ b/integration/docker/main_test.go
@@ -5,16 +5,13 @@
 package docker
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
-	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -22,10 +19,6 @@ const (
 	shouldFail    = true
 	shouldNotFail = false
 )
-
-func randomDockerName() string {
-	return RandID(29) + fmt.Sprintf("%d", GinkgoConfig.ParallelNode)
-}
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	// before start we have to download the docker images

--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -100,7 +99,7 @@ var _ = Describe("run", func() {
 	}
 
 	BeforeEach(func() {
-		id = RandID(30)
+		id = randomDockerName()
 
 		for i := 0; i < loopDevices; i++ {
 			diskFile, loopFile, err = createLoopDevice()

--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -23,7 +23,7 @@ setup() {
 
 @test "[insert data] insert data in an aerospike container" {
 	image="aerospike/aerospike-server"
-	docker run --runtime=$RUNTIME -d --name aerospike $image
+	docker run -m 6G --runtime=$RUNTIME -d --name aerospike $image
 	status=1
 	set +e
 	for i in $(seq 1 5); do

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -61,6 +61,7 @@ get_docker_kata_path(){
 extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
+	rpath=$(command -v "$rpath")
 
 	# If we can execute the path handed back to us
 	if [ -x "$rpath" ]; then

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -61,7 +61,9 @@ get_docker_kata_path(){
 extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
-	rpath=$(command -v "$rpath")
+	if [ -n "$rpath" ]; then
+		rpath=$(command -v "$rpath")
+	fi
 
 	# If we can execute the path handed back to us
 	if [ -x "$rpath" ]; then

--- a/metrics/storage/README.md
+++ b/metrics/storage/README.md
@@ -14,6 +14,6 @@ which variables are available.
 
 ## `blogbench` test
 
-The `blogbench` script is based on the [blogbench program](https://www.pureftpd.org/project/blogbench)
+The `blogbench` script is based on the blogbench program
 which is designed to emulate a busy blog server with a number of concurrent threads
 performing a mixture of reads, writes and rewrites.

--- a/rand.go
+++ b/rand.go
@@ -13,10 +13,9 @@ const letters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 const lettersMask = 63
 
-var randSrc = rand.NewSource(time.Now().UnixNano())
-
 // RandID returns a random string
 func RandID(n int) string {
+	randSrc := rand.NewSource(time.Now().UnixNano())
 	b := make([]byte, n)
 	for i := 0; i < n; {
 		if j := int(randSrc.Int63() & lettersMask); j < len(letters) {


### PR DESCRIPTION
56144e6 test: Fix aerospike test
4ac87b1 ci: remove unexistent blogbench URL
c49cb1a clean-up: clean stale kata resource on ARM CI
76ced81 gocache: clean GOCACHE on AArch64
beed7b4 ci: Fix that the docker installation sometimes fails in opensuse
260eae7 lib: extract_kata_env: don't rely on docker output
3f7b06e ci: k8s: install cni 0.6.0
1d80ad3 lib/common: extract_kata_env: Convert $rpath to pathname
98a0b26 integration/docker: Don't use RandID directly
a6a3e5c integration/docker: make API consistent
111ede9 integration/docker: use random repo names
edd730c s390x: run docker test in serial
6c74b58 integration/docker: include number of parallel node in the container's name
b08fa57 ci: fix `.ci/lib.sh` to not require go installed
b513620 makefile: run docker tests faster
4b69b6e makefile: increase timeout
c1d006b integration/docker: pull images before running tests
883afae cri-o: fix name of skipped test
8c653d9 makefile: honor FOCUS environment variable
3ac2459 integration/functional: stop running the tests after a failure occurs
