### PR TITLE
backport: lint: Switch golang linter to golangci-lint

### DIFF
--- a/.ci/.golangci.yml
+++ b/.ci/.golangci.yml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+run:
+  concurrency: 4
+  deadline: 600s
+  skip-dirs:
+    - vendor
+# Ignore auto-generated protobuf code.
+  skip-files:
+    - ".*\\.pb\\.go$"
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - gocyclo
+    - gofmt
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+
+linters-settings:
+  gocyclo:
+    min_complexity: 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language: go
 go_import_path: github.com/kata-containers/tests
 
 go:
-  - "1.10.x"
+  - "1.11.x"
   - stable
 
 env:

--- a/cmd/checkmetrics/main.go
+++ b/cmd/checkmetrics/main.go
@@ -97,7 +97,7 @@ func processMetricsBaseline(context *cli.Context) (err error) {
 		default:
 			{
 				log.Warnf("Unknown type [%s] for metric [%s]", m.Type, m.Name)
-				summary = (&metricsCheck{}).genErrorLine(false, m.Name, "Unsupported Type", fmt.Sprintf("%s", m.Type))
+				summary = (&metricsCheck{}).genErrorLine(false, m.Name, "Unsupported Type", fmt.Sprint(m.Type))
 				fails++
 			}
 		}

--- a/cmd/log-parser/display.go
+++ b/cmd/log-parser/display.go
@@ -126,7 +126,7 @@ func (d *DisplayHandlers) Get() []string {
 		formats = append(formats, f)
 	}
 
-	sort.Sort(sort.StringSlice(formats))
+	sort.Strings(formats)
 
 	return formats
 }

--- a/cmd/log-parser/main.go
+++ b/cmd/log-parser/main.go
@@ -252,7 +252,7 @@ func showSummary(entries *LogEntries, files []string) {
 		counts[file] = count
 	}
 
-	sort.Sort(sort.StringSlice(files))
+	sort.Strings(files)
 
 	recordCount := entries.Len()
 	fileCount := len(files)

--- a/integration/docker/cgroups_test.go
+++ b/integration/docker/cgroups_test.go
@@ -20,7 +20,7 @@ type cgroupType string
 
 const (
 	cgroupCPU    cgroupType = "cpu"
-	cgroupCpuset            = "cpuset"
+	cgroupCpuset cgroupType = "cpuset"
 )
 
 const (

--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -279,11 +279,7 @@ func IsRunningDockerContainer(name string) bool {
 
 	output := strings.TrimSpace(stdout)
 	tests.LogIfFail("container running: " + output)
-	if output == "false" {
-		return false
-	}
-
-	return true
+	return !(output == "false")
 }
 
 // ExistDockerContainer returns true if any of next cases is true:
@@ -341,31 +337,19 @@ func ExistDockerContainer(name string) bool {
 // RemoveDockerContainer removes a container using docker rm -f
 func RemoveDockerContainer(name string) bool {
 	_, _, exitCode := dockerRm("-f", name)
-	if exitCode != 0 {
-		return false
-	}
-
-	return true
+	return (exitCode == 0)
 }
 
 // StopDockerContainer stops a container
 func StopDockerContainer(name string) bool {
 	_, _, exitCode := dockerStop(name)
-	if exitCode != 0 {
-		return false
-	}
-
-	return true
+	return (exitCode == 0)
 }
 
 // KillDockerContainer kills a container
 func KillDockerContainer(name string) bool {
 	_, _, exitCode := dockerKill(name)
-	if exitCode != 0 {
-		return false
-	}
-
-	return true
+	return (exitCode == 0)
 }
 
 func randomDockerName() string {

--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -112,9 +112,7 @@ var _ = Describe("run", func() {
 
 		dockerArgs = append(dockerArgs, "--rm", "--name", id, Image, "stat")
 
-		for _, lf := range loopFiles {
-			dockerArgs = append(dockerArgs, lf)
-		}
+		dockerArgs = append(dockerArgs, loopFiles...)
 	})
 
 	AfterEach(func() {

--- a/versions.yaml
+++ b/versions.yaml
@@ -48,3 +48,11 @@ externals:
     description: "cri-o dependency used for building documentation"
     url: "https://github.com/cpuguy83/go-md2man"
     version: "v1.0.8"
+
+  golangci-lint:
+    description: "utility to run various golang linters"
+    url: "github.com/golangci/golangci-lint"
+    # Using HEAD for now as v1.15.0 does not compile with golang 1.12+. Will be
+    # pegged to the next release once it comes out.
+    # https://github.com/kata-containers/tests/issues/1329
+    version: "HEAD"


### PR DESCRIPTION
gometalinter is deprecated and will be archived April '19. The
suggestion is to switch to golangci-lint which is apparently 5x faster
than gometalinter.

Fixes #1323

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>