### PR TITLE
test: Skip ipvlan test for RHEL

### DIFF
--- a/integration/network/disable_net/net_none.bats
+++ b/integration/network/disable_net/net_none.bats
@@ -12,9 +12,11 @@ PAYLOAD="tail -f /dev/null"
 NAME="test"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 issue="https://github.com/kata-containers/runtime/issues/1197"
+net_issue="https://github.com/kata-containers/runtime/issues/906"
 
 setup () {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	clean_env
 
 	# Check that processes are not running
@@ -25,6 +27,7 @@ setup () {
 
 @test "Disable_new_netns equal to false" {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	extract_kata_env
 
 	sudo sed -i 's/#disable_new_netns = true/disable_new_netns = false/g' ${RUNTIME_CONFIG_PATH}
@@ -52,6 +55,7 @@ setup () {
 
 @test "Disable net" {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	extract_kata_env
 
 	# Get the name of the network name at the configuration.toml
@@ -86,6 +90,7 @@ setup () {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	clean_env
 
 	# Check that processes are not running

--- a/integration/network/ipvlan/ipvlan_driver.bats
+++ b/integration/network/ipvlan/ipvlan_driver.bats
@@ -21,7 +21,7 @@ PAYLOAD="tail -f /dev/null"
 
 setup() {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	clean_env
 
@@ -56,7 +56,7 @@ setup() {
 
 @test "ping container with ipvlan driver with mode l2" {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	NETWORK_NAME="ipvlan2"
 	NETWORK_MODE="l2"
@@ -80,7 +80,7 @@ setup() {
 
 @test "ping container with ipvlan driver with mode l3" {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	NETWORK_NAME="ipvlan3"
 	NETWORK_MODE="l3"


### PR DESCRIPTION
ipvlan tests can not be run on RHEL mainly because ipvlan needs a
kernel version greater than 4.2

Fixes #1406

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>