### PR TITLE
lint: set golangci-lint.version to v1.16.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -52,11 +52,4 @@ externals:
   golangci-lint:
     description: "utility to run various golang linters"
     url: "github.com/golangci/golangci-lint"
-    # Using d278457390d8c314192c08a7024e4648c40883af for now as
-    # v1.15.0 does not compile with golang 1.12+ and HEAD cannot
-    # pass test with golang 1.10.8.
-    # Will be pegged to other version once there is a verion
-    # can work OK with golang 1.12+ and golang 1.10.8.
-    # https://github.com/kata-containers/tests/issues/1329
-    # https://github.com/kata-containers/tests/issues/1345
-    version: "d278457390d8c314192c08a7024e4648c40883af"
+    version: "v1.16.0"


### PR DESCRIPTION
I would like to handle issue #1381 in 3 steps:
1 step is change golangci-lint.version to introduce v1.16.0 to introduce 8319caf63f0f5fd38b2439c7379823d656fb404e(Makefile: Add target build).
2 step is wait 1 or 2 weeks to make sure golangci-lint v1.16.0 is work OK for each project in multi-arch.
3 step add a patch to change golangci-lint build command from "make" to "make build".