### PR TITLE
ci: Update timestamp URL

### DIFF
--- a/cmd/log-parser/README.md
+++ b/cmd/log-parser/README.md
@@ -37,7 +37,7 @@ The tool requires that the following fields are defined for each log record:
 - Source field (`source`): a single word that specifies the name of a unique
   part of the system (e.g. `proxy`, `runtime`, `shim`).
 
-- Timestamp field (`time`): in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt)
+- Timestamp field (`time`): in [RFC3339](https://tools.ietf.org/html/rfc3339)
   format and including a nanosecond value.
 
 Additional to the fields above, the tool also expects the following field:


### PR DESCRIPTION
The URL https://www.ietf.org/rfc/rfc3339.txt does not exist and that
is making the ci at master to fail. With this we update the timestamp URL
to an existing one.

Fixes #1428

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>