### PR TITLE
integration/docker: enable Check cgroup paths test

### DIFF
--- a/integration/docker/cgroups_test.go
+++ b/integration/docker/cgroups_test.go
@@ -224,7 +224,6 @@ var _ = Describe("Check cgroup paths", func() {
 
 	DescribeTable("with a parent cgroup",
 		func(parentCgroup string) {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/1365")
 			args = append(args, "--cgroup-parent", parentCgroup, Image)
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())


### PR DESCRIPTION
Issue https://github.com/kata-containers/runtime/issues/1365 was fixed

fixes #1430

Signed-off-by: Julio Montes <julio.montes@intel.com>