### PR TITLE
k8s: volume test: wait for physical volume to be available

### DIFF
--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -35,13 +35,14 @@ setup() {
 	# Create the persistent volume
 	kubectl create -f "$pod_yaml"
 
-	# Check the persistent volume
-	kubectl get pv $volume_name | grep Available
+	# Check the persistent volume is Available
+	cmd="kubectl get pv $volume_name | grep Available"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Create the persistent volume claim
 	kubectl create -f "${pod_config_dir}/volume-claim.yaml"
 
-	# Check the persistent volume claim
+	# Check the persistent volume claim is Bound.
 	cmd="kubectl get pvc $volume_claim | grep Bound"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 


### PR DESCRIPTION
Instead of checking that the physical volume is available right
after the `kubectl create pv` command is run, check if it becomes
available every 2s for a maximum of 10s.

Fixes: #1440.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>