### PR TITLE
ci: Fix GNU parallel installation on SLES

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -83,5 +83,4 @@ echo "Install haveged"
 chronic sudo -E zypper -n install haveged
 
 echo "Install GNU parallel"
-chronic sudo -E yum -y install perl bzip2 make
-build_install_parallel
+chronic sudo -E zypper -n install gnu_parallel


### PR DESCRIPTION
Yum command does not exist on SLES. This will fix the GNU
parallel installation.

Fixes #1445

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>