### PR TITLE
metrics: report: document grabdata commandline

### DIFF
--- a/metrics/report/README.md
+++ b/metrics/report/README.md
@@ -31,6 +31,17 @@ generating the report.
 > large containers (i.e. 8Gbyte RAM) and may fail to produce some results on a memory
 > constrained system.
 
+You can restrict the subset of tests run by `grabdata.sh` via its commandline parameters:
+
+| Option | Description |
+| ------ | ----------- |
+| -a | Run all tests (default) |
+| -d | Run the density tests |
+| -h | Print this help |
+| -n | Run the networking tests |
+| -s | Run the storage tests |
+| -t | Run the time tests |
+
 ## Report generation
 
 Report generation is provided by the `makereport.sh` script. By default this script 


### PR DESCRIPTION
`grabdata.sh` takes a number of commandline arguments, that can be
very useful when you are only interested in a subset of tests and want
to save a bunch of time not running tests you are not interested in.

Add details of those to the documentation.

Fixes: #1162

Signed-off-by: Graham Whaley <graham.whaley@intel.com>