### PR TITLE
vm_factory: Add check for storage related vm template leak

### DIFF
--- a/integration/vm_factory/vm_templating_test.sh
+++ b/integration/vm_factory/vm_templating_test.sh
@@ -54,6 +54,22 @@ check_vm_template_factory() {
 	[ $res -eq 1 ] || die "template factory is not set up, missing state file"
 }
 
+clean_storage_in_dir() {
+	for file in $(ls $1); do
+		sudo rm -rf $1/$file
+	done
+}
+
+clean_storage() {
+	clean_storage_in_dir ${VC_POD_DIR}
+	clean_storage_in_dir ${RUN_SBS_DIR}
+}
+
+check_storage_leak() {
+	check_pods_in_dir ${VC_POD_DIR}
+	check_pods_in_dir ${RUN_SBS_DIR}
+}
+
 clean_vm_template() {
 	while [ $(mount | grep ${template_tmpfs_path} | wc -l) -ne 0 ]
 	do
@@ -66,6 +82,7 @@ clean_vm_template() {
 setup() {
 	clean_env
 	extract_kata_env
+	clean_storage
 	clean_vm_template
 }
 
@@ -133,6 +150,9 @@ setup
 echo "Running vm templating test"
 test_factory_init_destroy
 test_docker_create_auto_init_vm_factory
+
+echo "check storage leak after vm templating test"
+check_storage_leak
 
 echo "Ending vm templating test"
 teardown

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -10,6 +10,9 @@
 # Place where virtcontainers keeps its active pod info
 VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
 
+# Sandbox runtime directory
+RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"
+
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 die() {
@@ -155,17 +158,24 @@ check_processes() {
 	done
 }
 
-# Checks that pods were not left
-check_pods() {
-	if [ -d ${VC_POD_DIR} ]; then
+# Checks that pods were not left in a directory
+check_pods_in_dir() {
+    local DIR=$1
+    if [ -d ${DIR} ]; then
 		# Verify that pods were not left
-		pods_number=$(ls ${VC_POD_DIR} | wc -l)
+		pods_number=$(ls ${DIR} | wc -l)
 		if [ ${pods_number} -ne 0 ]; then
-			die "${pods_number} pods left and found at ${VC_POD_DIR}"
+            ls ${DIR}
+			die "${pods_number} pods left and found at ${DIR}"
 		fi
 	else
-		echo "Not ${VC_POD_DIR} directory found"
+		echo "Not ${DIR} directory found"
 	fi
+}
+
+# Checks that pods were not left
+check_pods() {
+	check_pods_in_dir ${VC_POD_DIR}
 }
 
 # Check that runtimes are not running, they should be transient


### PR DESCRIPTION
According to the issue in
https://github.com/kata-containers/runtime/issues/1452,
There is storage related vm template leak in /var/lib/vc/sbs and
/run/vc/sbs that is fixed in
https://github.com/kata-containers/runtime/pull/1491.

Add check for this issue.

Fixes: #1426

Signed-off-by: Hui Zhu <teawater@hyper.sh>