### PR TITLE
integration/containerd: don't delete kata config in the snap CI

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -29,6 +29,7 @@ readonly runc_runtime_bin=$(command -v "runc")
 readonly CRITEST=${GOPATH}/bin/critest
 
 # Flag to do tasks for CI
+SNAP_CI=${SNAP_CI:-""}
 CI=${CI:-""}
 
 # Default CNI directory
@@ -77,8 +78,13 @@ ci_cleanup() {
 	fi
 
 	ID=${ID:-""}
-	if [ "$ID" == ubuntu ] &&  [ -n "${CI}" ] ;then
-		[ -f "${kata_config}" ] && sudo rm "${kata_config}"
+	if [ "$ID" == ubuntu ]; then
+		if [ -n "${SNAP_CI}" ]; then
+			# restore default configuration
+			sudo cp "${default_kata_config}" "${kata_config}"
+		elif [ -n "${CI}" ] ;then
+			[ -f "${kata_config}" ] && sudo rm "${kata_config}"
+		fi
 	fi
 }
 


### PR DESCRIPTION
The default configuration file of kata snap can't be modified, since it's in
a read-only filesystem, instead the tests can modify file in
/etc/kata-containers/ hence it shouldn't be deleted.

fixes #1453

Signed-off-by: Julio Montes <julio.montes@intel.com>