### PR TITLE
tests: Skip unit tests on RHEL

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -9,6 +9,9 @@ set -e
 
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+# Unit test issue for RHEL
+unit_issue="https://github.com/kata-containers/runtime/issues/1517"
+
 # Signify to all scripts that they are running in a CI environment
 [ -z "${KATA_DEV_MODE}" ] && export CI=true
 
@@ -125,6 +128,8 @@ if [ -z "${METRICS_CI}" ]
 then
 	if [ "${kata_repo}" != "${tests_repo}" ]
 	then
+		[ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ] && skip "unit tests not working see: ${unit_issue}"
+
 		if [ "${ID}" == "centos" ] && [ "${kata_repo}" == "${runtime_repo}" ]
 		then
 			echo "INFO: unit tests skipped for $kata_repo in $ID"


### PR DESCRIPTION
Unit tests on RHEL are failing https://github.com/kata-containers/runtime/issues/1517.
In order to enable a CI, we will skip them until the issue is fixed.

Fixes #1455

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>