### PR TITLE
ci: Remove lock before removing docker SLES

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -198,6 +198,7 @@ remove_docker(){
 		elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
 			sudo yum -y remove ${pkg_name}
 		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
+			sudo zypper removelock ${pkg_name}
 			sudo zypper -n remove ${pkg_name}
 		else
 			die "This script doesn't support your Linux distribution"


### PR DESCRIPTION
We have random failures while trying to remove docker packages on SLES and it
is related with the lock of the package. This will removelock and then remove
all the packages.

Fixes #1457

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>