### PR TITLE
ci: setup: always install/update golang on setup

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -128,6 +128,7 @@ install_extra_tools() {
 }
 
 main() {
+	bash -f "${cidir}/install_go.sh" -p -f
 	setup_distro_env
 	install_docker
 	enable_nested_virtualization


### PR DESCRIPTION
Always try to install/update the version of golang.sh we have when
running setup.sh. For Jenkins, this is done already by the jenkins
specific script, but for other CIs and for hand-running the setup
it would be nice to always try to do it before we do anything else.

Fixes: #1464

Signed-off-by: Graham Whaley <graham.whaley@intel.com>