### PR TITLE
backport tests for stable 1.5

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -9,13 +9,40 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly runtime_path=$(which ${RUNTIME:-kata-runtime})
+# `use_runtime_class` should be set to:
+# - true if we will test using k8s RuntimeClass feature or
+# - false (default) if we will test using the old trusted/untrusted annotations.
+use_runtime_class=${use_runtime_class:-false}
+
+readonly kata_runtime_path=$(command -v kata-runtime)
+readonly runc_path=$(command -v runc)
 
 sudo mkdir -p /etc/containerd/
-cat << EOT | sudo tee /etc/containerd/config.toml
+
+if [ "${use_runtime_class}"  == true ]; then
+	cat << EOT | sudo tee /etc/containerd/config.toml
 [plugins]
+  [plugins.cri]
     [plugins.cri.containerd]
-          [plugins.cri.containerd.untrusted_workload_runtime]
-	          runtime_type = "io.containerd.runtime.v1.linux"
-		          runtime_engine = "${runtime_path}"
+      [plugins.cri.containerd.runtimes.runc]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        [plugins.cri.containerd.runtimes.runc.options]
+          Runtime = "runc"
+          RuntimeRoot = "${runc_path}"
+      [plugins.cri.containerd.runtimes.kata]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        [plugins.cri.containerd.runtimes.kata.options]
+          Runtime = "kata-runtime"
+          RuntimeRoot = "${kata_runtime_path}"
 EOT
+
+else
+	cat << EOT | sudo tee /etc/containerd/config.toml
+[plugins]
+  [plugins.cri.containerd]
+    [plugins.cri.containerd.untrusted_workload_runtime]
+      runtime_type = "io.containerd.runtime.v1.linux"
+      runtime_engine = "${kata_runtime_path}"
+EOT
+
+fi

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -57,7 +57,7 @@ get_packaged_kernel_version() {
 			awk '/'$packaged_kernel'/ {print $2}' |
 			tail -1 |
 			cut -d'-' -f1)
-	elif [ "$ID" == "centos" ]; then
+	elif [ "$ID" == "centos" ] || [ "$ID"  == "rhel" ]; then
 		kernel_version=$(sudo yum --showduplicate list $packaged_kernel | awk '/'$packaged_kernel'/ {print $2}' | cut -d'-' -f1)
 	fi
 
@@ -80,7 +80,7 @@ install_packaged_kernel(){
 		chronic sudo apt install -y "$packaged_kernel" || rc=1
 	elif [ "$ID"  == "fedora" ]; then
 		chronic sudo dnf install -y "$packaged_kernel" || rc=1
-	elif [ "$ID"  == "centos" ]; then
+	elif [ "$ID"  == "centos" ] || [ "$ID"  == "rhel" ]; then
 		chronic sudo yum install -y "$packaged_kernel" || rc=1
 	else
 		die "Unrecognized distro"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -26,7 +26,7 @@ get_packaged_qemu_commit() {
 	elif [ "$ID" == "centos" ]; then
 		qemu_commit=$(sudo yum --showduplicate list $PACKAGED_QEMU \
 			| awk '/'$PACKAGED_QEMU'/ {print $2}' | cut -d'-' -f1 | cut -d'.' -f4)
-	elif [[ "$ID" =~ ^opensuse.*$ ]]; then
+	elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 		qemu_commit=$(sudo zypper info $PACKAGED_QEMU \
 			| grep "Version" | sed -E "s/.+\+git\.([0-9a-f]+).+/\1/")
 	fi
@@ -47,7 +47,7 @@ install_packaged_qemu() {
 	elif [ "$ID"  == "centos" ]; then
 		chronic sudo yum remove -y "$PACKAGED_QEMU" || true
 		chronic sudo yum install -y "$PACKAGED_QEMU" || rc=1
-	elif [[ "$ID" =~ ^opensuse.*$ ]]; then
+	elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 		chronic sudo zypper -n remove "$PACKAGED_QEMU" || true
 		chronic sudo zypper -n install "$PACKAGED_QEMU" || rc=1
 	else

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -23,7 +23,7 @@ get_packaged_qemu_commit() {
 	elif [ "$ID" == "fedora" ]; then
 		qemu_commit=$(sudo dnf --showduplicate list ${PACKAGED_QEMU}.${QEMU_ARCH} \
 			| awk '/'$PACKAGED_QEMU'/ {print $2}' | cut -d'-' -f1 | cut -d'.' -f4)
-	elif [ "$ID" == "centos" ]; then
+	elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
 		qemu_commit=$(sudo yum --showduplicate list $PACKAGED_QEMU \
 			| awk '/'$PACKAGED_QEMU'/ {print $2}' | cut -d'-' -f1 | cut -d'.' -f4)
 	elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
@@ -44,7 +44,7 @@ install_packaged_qemu() {
 	elif [ "$ID"  == "fedora" ]; then
 		chronic sudo dnf remove -y "$PACKAGED_QEMU" || true
 		chronic sudo dnf install -y "$PACKAGED_QEMU" || rc=1
-	elif [ "$ID"  == "centos" ]; then
+	elif [ "$ID"  == "centos" ] || [ "$ID"  == "rhel" ]; then
 		chronic sudo yum remove -y "$PACKAGED_QEMU" || true
 		chronic sudo yum install -y "$PACKAGED_QEMU" || rc=1
 	elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -12,6 +12,7 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+MACHINETYPE="${MACHINETYPE:-pc}"
 
 arch=$("${cidir}"/kata-arch.sh -d)
 
@@ -101,6 +102,11 @@ elif [ "$KATA_HYPERVISOR" == "nemu" ]; then
 	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
 else
 	echo "Kata runtime will not set as a default in Docker"
+fi
+
+if [ "$MACHINETYPE" == "q35" ]; then
+	echo "Use machine_type q35"
+	sudo sed -i -e 's|machine_type = "pc"|machine_type = "q35"|' "${runtime_config_path}"
 fi
 
 if [ "$KATA_HYPERVISOR" == "firecracker" ]; then

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -9,6 +9,9 @@ set -e
 
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+# Unit test issue for RHEL
+unit_issue="https://github.com/kata-containers/runtime/issues/1517"
+
 # Signify to all scripts that they are running in a CI environment
 [ -z "${KATA_DEV_MODE}" ] && export CI=true
 
@@ -125,6 +128,8 @@ if [ -z "${METRICS_CI}" ]
 then
 	if [ "${kata_repo}" != "${tests_repo}" ]
 	then
+		[ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ] && skip "unit tests not working see: ${unit_issue}"
+
 		if [ "${ID}" == "centos" ] && [ "${kata_repo}" == "${runtime_repo}" ]
 		then
 			echo "INFO: unit tests skipped for $kata_repo in $ID"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -54,7 +54,10 @@ install_docker() {
 	docker_version=$(get_version "externals.docker.version")
 	docker_version=${docker_version/v/}
 	docker_version=${docker_version/-*/}
-	if ! sudo docker version | grep -q "$docker_version" && [ "$CI" == true ]; then
+
+	sudo systemctl restart docker
+
+	if ( ! sudo docker version | grep -q "$docker_version" ) && [ "$CI" == true ]; then
 		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install -f
 	fi
 }

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -35,6 +35,8 @@ setup_distro_env() {
 		bash -f "${cidir}/setup_env_debian.sh"
 	elif [[ "$ID" =~ ^opensuse.*$ ]]; then
 		bash -f "${cidir}/setup_env_opensuse.sh"
+	elif [ "$ID" == sles ]; then
+		bash -f "${cidir}/setup_env_sles.sh"
 	else
 		die "ERROR: Unrecognised distribution: ${ID}."
 		exit 1

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -37,10 +37,13 @@ setup_distro_env() {
 		bash -f "${cidir}/setup_env_opensuse.sh"
 	elif [ "$ID" == sles ]; then
 		bash -f "${cidir}/setup_env_sles.sh"
+	elif [ "$ID" == rhel ]; then
+		bash -f "${cidir}/setup_env_rhel.sh"
 	else
 		die "ERROR: Unrecognised distribution: ${ID}."
 		exit 1
 	fi
+
 	sudo systemctl start haveged
 }
 

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -142,5 +142,8 @@ main() {
 	sync
 	sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"
 
+	if [ "$ID" == rhel ]; then
+		sudo -E PATH=$PATH bash -c "echo 1 > /proc/sys/fs/may_detach_mounts"
+	fi
 }
 main $*

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -13,7 +13,7 @@ source "${cidir}/lib.sh"
 
 echo "Add epel repository"
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-sudo -E yum install "$epel_url"
+sudo -E yum install -y "$epel_url"
 
 echo "Update repositories"
 sudo -E yum -y update

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "/etc/os-release" || "source /usr/lib/os-release"
+source "${cidir}/lib.sh"
+
+echo "Add epel repository"
+epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+yum install "$epel_url"
+
+echo "Update repositories"
+sudo -E yum -y update
+
+echo "Install chronic"
+sudo -E yum install -y moreutils
+
+echo "Install kata containers dependencies"
+chronic sudo -E yum install -y libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 device-mapper-devel libtool-ltdl bzip2 m4 \
+	patch gettext-devel automake alien autoconf bc pixman-devel coreutils
+
+echo "Install qemu dependencies"
+chronic sudo -E yum install -y libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel
+
+echo "Install nemu dependencies"
+chronic sudo -E yum install -y brlapi
+
+echo "Install kernel dependencies"
+chronic sudo -E yum -y install elfutils-libelf-devel flex
+
+echo "Install CRI-O dependencies for RHEL"
+chronic sudo -E yum install -y glibc-static libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs \
+	btrfs-progs-devel util-linux gpgme-devel glib2-devel glibc-devel libselinux-devel ostree-devel \
+	pkgconfig
+
+echo "Install bison binary"
+chronic sudo -E yum install -y bison
+
+echo "Install libgudev1-devel"
+chronic sudo -E yum install -y libgudev1-devel
+
+echo "Install Build Tools"
+chronic sudo -E yum install -y python pkgconfig zlib-devel ostree-devel
+
+echo "Install YAML validator"
+chronic sudo -E yum install -y yamllint
+
+echo "Install tools for metrics tests"
+chronic sudo -E yum install -y jq smem
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="${KATA_OBS_REPO_BASE}/RHEL_7/home:katacontainers:releases:$(arch):master.repo"
+	sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
+	repo_file="/etc/yum.repos.d/home\:katacontainers\:releases\:$(arch)\:master.repo"
+	sudo bash -c "echo timeout=10 >> $repo_file"
+	sudo bash -c "echo retries=2 >> $repo_file"
+fi
+
+echo "Install cri-containerd dependencies"
+chronic sudo -E yum install -y libseccomp-devel btrfs-progs-devel
+
+echo "Install crudini"
+chronic sudo -E yum install -y crudini
+
+echo "Install procenv"
+chronic sudo -E yum install -y procenv
+
+echo "Install haveged"
+chronic sudo -E yum install -y haveged
+
+if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+	echo "Install ${KATA_KSM_THROTTLER_JOB}"
+	sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
+fi

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -13,7 +13,7 @@ source "${cidir}/lib.sh"
 
 echo "Add epel repository"
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-yum install "$epel_url"
+sudo -E yum install "$epel_url"
 
 echo "Update repositories"
 sudo -E yum -y update

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -42,6 +42,10 @@ chronic sudo -E zypper -n install libcap-devel libattr1 libcap-ng-devel librbd-d
 echo "Install kernel dependencies"
 chronic sudo -E zypper -n install libelf-devel flex
 
+echo "Install CRI-O dependencies"
+chronic sudo -E zypper -n install libglib-2_0-0 libseccomp-devel libapparmor-devel libgpg-error-devel \
+	glibc-devel-static libgpgme-devel libassuan-devel glib2-devel glibc-devel util-linux
+
 echo "Install bison binary"
 chronic sudo -E zypper -n install bison
 

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "/etc/os-release" || source "/usr/lib/os-release"
+source "${cidir}/lib.sh"
+
+echo "Add repo for perl-IPC-Run"
+perl_repo="https://download.opensuse.org/repositories/devel:languages:perl/SLE_${VERSION//-/_}/devel:languages:perl.repo"
+sudo -E zypper addrepo --no-gpgcheck ${perl_repo}
+sudo -E zypper refresh
+
+echo "Install perl-IPC-Run"
+sudo -E zypper -n install perl-IPC-Run
+
+echo "Add repo for moreutils"
+moreutils_repo="https://download.opensuse.org/repositories/utilities/SLE_${VERSION//-/_}_Backports/utilities.repo"
+sudo -E zypper addrepo --no-gpgcheck ${moreutils_repo}
+sudo -E zypper refresh
+
+echo "Install chronic"
+sudo -E zypper -n install moreutils
+
+echo "Install curl"
+chronic sudo -E zypper -n install curl
+
+echo "Install git"
+chronic sudo -E zypper -n install git
+
+echo "Install kata containers dependencies"
+chronic sudo -E zypper -n install libtool automake autoconf bc libpixman-1-0-devel coreutils
+
+echo "Install qemu dependencies"
+chronic sudo -E zypper -n install libcap-devel libattr1 libcap-ng-devel librbd-devel
+
+echo "Install kernel dependencies"
+chronic sudo -E zypper -n install libelf-devel flex
+
+echo "Install bison binary"
+chronic sudo -E zypper -n install bison
+
+echo "Install libudev-dev"
+chronic sudo -E zypper -n install libudev-devel
+
+echo "Install Build Tools"
+chronic sudo -E zypper -n install -t pattern "Basis-Devel" && sudo -E zypper -n install python zlib-devel
+
+echo "Install tools for metrics tests"
+chronic sudo -E zypper -n install  jq
+
+if [ "$(arch)" == "x86_64" ]; then
+	echo "Install Kata Containers OBS repository"
+	obs_url="${KATA_OBS_REPO_BASE}/SLE_${VERSION//-/_}/"
+	chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
+fi
+
+echo -e "Install cri-containerd dependencies"
+chronic sudo -E zypper -n install libseccomp-devel libapparmor-devel make pkg-config
+
+echo "Install patch"
+chronic sudo -E zypper -n install patch
+
+echo "Add crudini repo"
+VERSIONID="12_SP1"
+crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
+chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
+chronic sudo -E zypper refresh
+
+echo "Install crudini"
+chronic sudo -E zypper -n install crudini
+
+echo "Install haveged"
+chronic sudo -E zypper -n install haveged

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -271,6 +271,7 @@ check_collect_script()
 	[ -z "$cmdpath" ] && info "$msg not found" && return
 
 	info "Checking $msg"
+
 	sudo -E PATH="$PATH" chronic $cmd
 }
 

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -112,7 +112,7 @@ install_docker(){
 			sudo -E dnf makecache
 			docker_version_full=$(dnf --showduplicate list "$pkg_name" | grep "$docker_version" | awk '{print $2}' | tail -1)
 			sudo -E dnf -y install "${pkg_name}-${docker_version_full}"
-		elif [ "$ID" == "centos" ]; then
+		elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
 			sudo -E yum install -y yum-utils
 			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"
 			sudo yum-config-manager --add-repo "$repo_url"
@@ -195,7 +195,7 @@ remove_docker(){
 			sudo apt -y purge ${pkg_name}
 		elif [ "$ID" == "fedora" ]; then
 			sudo dnf -y remove ${pkg_name}
-		elif [ "$ID" == "centos" ]; then
+		elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
 			sudo yum -y remove ${pkg_name}
 		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 			sudo zypper -n remove ${pkg_name}
@@ -216,7 +216,7 @@ get_docker_version(){
 get_docker_package_name(){
 	if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		dpkg --get-selections | awk '/docker/ {print $1}'
-	elif [ "$ID" == "fedora" ] || [ "$ID" == "centos" ] || [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
+	elif [ "$ID" == "fedora" ] || [ "$ID" == "centos" ] || [ "$ID" == "rhel" ] || [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 		rpm -qa | grep docker | grep -v selinux
 	else
 		die "This script doesn't support your Linux distribution"

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -127,7 +127,7 @@ install_docker(){
 			sudo -E apt-get update
 			docker_version_full=$(apt-cache madison $pkg_name | grep "$docker_version" | awk '{print $3}' | head -1)
 			sudo -E apt-get -y install "${pkg_name}=${docker_version_full}"
-		elif [[ "$ID" =~ ^opensuse.*$ ]]; then
+		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 			sudo zypper removelock docker
 			sudo zypper -n  install 'docker<18.09'
 			sudo zypper addlock docker
@@ -197,7 +197,7 @@ remove_docker(){
 			sudo dnf -y remove ${pkg_name}
 		elif [ "$ID" == "centos" ]; then
 			sudo yum -y remove ${pkg_name}
-		elif [[ "$ID" =~ ^opensuse.*$ ]]; then
+		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 			sudo zypper -n remove ${pkg_name}
 		else
 			die "This script doesn't support your Linux distribution"
@@ -216,7 +216,7 @@ get_docker_version(){
 get_docker_package_name(){
 	if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 		dpkg --get-selections | awk '/docker/ {print $1}'
-	elif [ "$ID" == "fedora" ] || [ "$ID" == "centos" ] || [[ "$ID" =~ ^opensuse.*$ ]]; then
+	elif [ "$ID" == "fedora" ] || [ "$ID" == "centos" ] || [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 		rpm -qa | grep docker | grep -v selinux
 	else
 		die "This script doesn't support your Linux distribution"

--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 extract_kata_env
 
-if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ] || [ "$ID" == rhel ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit

--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 extract_kata_env
 
-if [[ "$ID" =~ ^opensuse.*$ ]]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit

--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -10,7 +10,14 @@
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 source "${SCRIPT_PATH}/../../../metrics/lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
 extract_kata_env
+
+if [[ "$ID" =~ ^opensuse.*$ ]]; then
+	issue="https://github.com/kata-containers/tests/issues/1251"
+	echo "Skip shimv2 on $ID, see: $issue"
+	exit
+fi
 
 if [ -z $INITRD_PATH ]; then
 	echo "Skipping vm templating test as initrd is not set"

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -19,6 +19,12 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
+if [[ "$ID" =~ ^opensuse.*$ ]]; then
+	issue="https://github.com/kata-containers/tests/issues/1251"
+	echo "Skip shimv2 on $ID, see: $issue"
+	exit
+fi
+
 if [ "$ID" != "centos" ]; then
 	${SCRIPT_PATH}/../cri/integration-tests.sh
 else

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -19,7 +19,7 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
-if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ] || [ "$ID" == rhel ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -19,7 +19,7 @@ echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"
 
-if [[ "$ID" =~ ^opensuse.*$ ]]; then
+if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ]; then
 	issue="https://github.com/kata-containers/tests/issues/1251"
 	echo "Skip shimv2 on $ID, see: $issue"
 	exit

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,4 +9,5 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
+'test "ctr stats"'
 );

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -10,4 +10,6 @@
 declare -a skipCRIOTests=(
 'test "ctr oom"'
 'test "ctr stats output"'
+'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
+'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
 );

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -9,5 +9,5 @@
 
 declare -a skipCRIOTests=(
 'test "ctr oom"'
-'test "ctr stats"'
+'test "ctr stats output"'
 );

--- a/integration/network/disable_net/net_none.bats
+++ b/integration/network/disable_net/net_none.bats
@@ -12,9 +12,11 @@ PAYLOAD="tail -f /dev/null"
 NAME="test"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 issue="https://github.com/kata-containers/runtime/issues/1197"
+net_issue="https://github.com/kata-containers/runtime/issues/906"
 
 setup () {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	clean_env
 
 	# Check that processes are not running
@@ -25,6 +27,7 @@ setup () {
 
 @test "Disable_new_netns equal to false" {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	extract_kata_env
 
 	sudo sed -i 's/#disable_new_netns = true/disable_new_netns = false/g' ${RUNTIME_CONFIG_PATH}
@@ -52,6 +55,7 @@ setup () {
 
 @test "Disable net" {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	extract_kata_env
 
 	# Get the name of the network name at the configuration.toml
@@ -86,6 +90,7 @@ setup () {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" = "firecracker" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${net_issue}"
 	clean_env
 
 	# Check that processes are not running

--- a/integration/network/ipvlan/ipvlan_driver.bats
+++ b/integration/network/ipvlan/ipvlan_driver.bats
@@ -21,7 +21,7 @@ PAYLOAD="tail -f /dev/null"
 
 setup() {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	clean_env
 
@@ -56,7 +56,7 @@ setup() {
 
 @test "ping container with ipvlan driver with mode l2" {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	NETWORK_NAME="ipvlan2"
 	NETWORK_MODE="l2"
@@ -80,7 +80,7 @@ setup() {
 
 @test "ping container with ipvlan driver with mode l3" {
 	issue="https://github.com/kata-containers/runtime/issues/906"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "${ID}" == "rhel" ] && skip "test not working with ${ID} see: ${issue}"
 
 	NETWORK_NAME="ipvlan3"
 	NETWORK_MODE="l3"

--- a/integration/network/macvlan/macvlan_driver.bats
+++ b/integration/network/macvlan/macvlan_driver.bats
@@ -24,7 +24,7 @@ PAYLOAD_ARGS="tail -f /dev/null"
 
 setup () {
 	issue="https://github.com/kata-containers/runtime/issues/905"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "$ID" == rhel ] && skip "test not working with ${ID} see: ${issue}"
 
 	clean_env
 
@@ -36,7 +36,7 @@ setup () {
 
 @test "ping container with macvlan driver" {
 	issue="https://github.com/kata-containers/runtime/issues/905"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "$ID" == rhel ] && skip "test not working with ${ID} see: ${issue}"
 
 	# Create network
 	docker network create -d ${NETWORK_DRIVER} ${NETWORK_NAME}
@@ -58,7 +58,7 @@ setup () {
 
 teardown() {
 	issue="https://github.com/kata-containers/runtime/issues/905"
-	[ "${ID}" == "centos" ] && skip "test not working with ${ID} see: ${issue}"
+	[ "${ID}" == "centos" ] || [ "$ID" == rhel ] && skip "test not working with ${ID} see: ${issue}"
 
 	# Remove network
 	docker network rm ${NETWORK_NAME}

--- a/integration/swarm/swarm.bats
+++ b/integration/swarm/swarm.bats
@@ -31,12 +31,12 @@ setup() {
 	swarm_interface_arg=""
 	for i in ${interfaces[@]}; do
 		check_ip_address=$(ip a show dev ${i} | awk '/inet / {print $2}' | cut -d'/' -f1)
-		if [ "$(cat /sys/class/net/${i}/operstate)" == "up" ] && [ -n ${check_ip_address} ]; then
-			swarm_interface_arg="--advertise-addr ${check_ip_address}"
+		if [ "$(cat /sys/class/net/${i}/operstate)" == "up" ] && [ -n "${check_ip_address}" ]; then
+			swarm_interface_arg="${check_ip_address}"
 			break;
 		fi
 	done
-	docker swarm init ${swarm_interface_arg}
+	docker swarm init --advertise-addr "${swarm_interface_arg}"
 	nginx_command="hostname > /usr/share/nginx/html/hostname; nginx -g \"daemon off;\""
 	docker service create \
 		--name "${SERVICE_NAME}" --replicas $number_of_replicas \


### PR DESCRIPTION
6d8c449 tests: Skip unit tests on RHEL
76d2739 test: shimv2 test not working on RHEL
b465304 ci: Fix RHEL script
5378477 test: Fix swarm test instability on RHEL
ff95c4d test: Skip ipvlan test for RHEL
6f71ebd test: Skip macvlan tests for RHEL
bac94c6 ci: Add q35 setup
c0914c6 tests: Skip shimv2 tests on SLES
aefce29 test: Skip shimv2 on openSUSE Leap
3287358 ci: Add sudo while adding the repository
26e92d9 ci: containerd: add config for runtimeclass
908bbfd cri-o: skip new tests introduced in cri-o repo
44142c8 ci: Add installation RHEL scripts.
09d4881 ci: Fix that the docker installation sometimes fails in opensuse
4553da1 cri-o: fix name of skipped test
9d7c47b integration: cri-o: Skip 'ctr stats'
cf6b25f test: Add CRI-O dependencies for SLES setup
960d807 ci: Add installation script for SLES
