### PR TITLE
k8s: fix e2e script and yaml file

### DIFF
--- a/integration/kubernetes/e2e_conformance/run.sh
+++ b/integration/kubernetes/e2e_conformance/run.sh
@@ -72,7 +72,7 @@ run_sonobuoy() {
 	[ "$CI" == true ] && cat "$e2e_result_log"
 
 	# Check for Success message on the logs.
-	grep -aq " 0 Failed" "$e2e_result_log"
+	grep -aq " 0 Failed" "$e2e_result_log" || die "A failure has been found"
 	grep -aq "SUCCESS" "$e2e_result_log" && \
 		info " k8s e2e conformance using Kata runtime finished successfully"
 	popd

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -10,7 +10,7 @@ containerd:
   - SchedulerPredicates
   - should ensure that all pods are removed when a namespace is deleted
 
-cri-o:
+crio:
   - InitContainer
   - Projected downwardAPI
   - Downward API


### PR DESCRIPTION
Use `die` to fail the e2e `run.sh` script when a `grep`
finds a failure in the e2e log.

In addition, remove dash from cri-o in skipped_tests_e2e.yaml
We use `CRI_RUNTIME` to specify which runtime interface we are
using to launch k8s and to know which tests we need to skip for e2e
testing.
Specifically for cri-o, we use `CRI_RUNTIME=crio`, so we
need to remove the dash (-) from cri-o in the skipped_tests_e2e.yaml
file, so that the tests listed there are properly skipped.    
