### PR TITLE
vm_factory: Add test for vm template init check

### DIFF
--- a/integration/vm_factory/vm_templating_test.sh
+++ b/integration/vm_factory/vm_templating_test.sh
@@ -35,6 +35,9 @@ disable_vm_template_config() {
 init_vm_template() {
 	echo "init vm template"
 	sudo -E PATH=$PATH "$kata_runtime_bin" factory init
+
+	{ sudo -E PATH=$PATH "$kata_runtime_bin" factory init ; res=$?; } || true
+	[ $res -ne 0 ] || die "factory init already called so expected 2nd call to fail"
 }
 
 destroy_vm_template() {


### PR DESCRIPTION
According to the issue in
https://github.com/kata-containers/runtime/issues/1514,
runtime add vm template init check in
https://github.com/kata-containers/runtime/pull/1547.

Add test for this check.

Fixes: #1480

Signed-off-by: Hui Zhu <teawater@hyper.sh>