### PR TITLE
test: Add docker integration for --sysctl ip forward

### DIFF
--- a/integration/docker/sysctls_test.go
+++ b/integration/docker/sysctls_test.go
@@ -5,6 +5,8 @@
 package docker
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -52,6 +54,16 @@ var _ = Describe("sysctls", func() {
 			stdout, _, exitCode = dockerRun(args...)
 			Expect(exitCode).To(Equal(0))
 			Expect(stdout).To(ContainSubstring(pmtuValue))
+		})
+	})
+
+	Context("sysctl for IP forwarding", func() {
+		It("should be applied", func() {
+			ipforwardValue := "1"
+			args = []string{"--name", id, "--rm", "--sysctl", "net.ipv4.ip_forward=" + ipforwardValue, Image, "cat", "/proc/sys/net/ipv4/ip_forward"}
+			stdout, _, exitCode = dockerRun(args...)
+			Expect(exitCode).To(Equal(0))
+			Expect(strings.Trim(stdout, " \n\t")).To(Equal(ipforwardValue))
 		})
 	})
 })


### PR DESCRIPTION
This adds a docker integration test for setting namespaced kernel
parameters to turn on IP forwarding in the containers network
namespace.

Fixes #1491

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>