### PR TITLE
ci: lib.sh: set PATH for sudo even in no-go case

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -96,7 +96,7 @@ function build_and_install() {
 	pushd "${GOPATH}/src/${github_project}"
 	if [ "$test_not_gopath_set" = "true" ]; then
 		info "Installing ${github_project} in No GO command or GOPATH not set mode"
-		sudo -E KATA_RUNTIME="${KATA_RUNTIME}" make install
+		sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
 		[ $? -ne 0 ] && die "Fail to install ${github_project} in No GO command or GOPATH not set mode"
 	fi
 	info "Installing ${github_project}"


### PR DESCRIPTION
If the scripts failed to find go or a GOPATH they would follow a different
path and invoke `sudo -E`, but not with the PATH=$PATH argument. This
normally works on oru CIs, but on Zuul, where the old distro go version
will be in the sudo path first, it fails with a 'go too old' error.
Pass the CI env/user PATH into the `sudo` to ensure we pick up
the correct golang.

Fixes: #1479

Signed-off-by: Graham Whaley <graham.whaley@intel.com>