### PR TITLE
CI: add condition to be able to test experimental feature

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -114,3 +114,10 @@ if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	path="/usr/share/defaults/kata-containers"
 	sudo mv ${path}/configuration-fc.toml ${path}/configuration.toml
 fi
+
+# Enable experimental features if KATA_EXPERIMENTAL_FEATURES is set to true
+if [ "$KATA_EXPERIMENTAL_FEATURES" = true ]; then
+	echo "Enable runtime experimental features"
+	feature="newstore"
+	sudo sed -i -e "s|^experimental.*$|experimental=[ \"$feature\" ]|" "${runtime_config_path}"
+fi


### PR DESCRIPTION
Add an option in the `.ci/install_runtime.sh` to enable `newstore`
experimental feature in the runtime config file when
`KATA_EXPERIMENTAL_FEATURES` is set to `true`.

Fixes: #1500.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>