### PR TITLE
kata-manager: Check for dependencies earlier

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -269,8 +269,6 @@ get_git_repo()
 	local -r repo_url="https://${repo_path}"
 
 	if ! command -v git >/dev/null; then
-		info "getting repo $1 using http downloader"
-		detect_downloader
 		$downloader "${repo_url}/${tarball_suffix}" | tar xz -C "$local_dest" --strip-components=1
 		return
 	fi
@@ -436,6 +434,11 @@ setup()
 	kata_repos_base=$(go env GOPATH 2>/dev/null || true)
 	if [ -z "$kata_repos_base" ]; then
 		kata_repos_base="$HOME/go"
+	fi
+
+	if ! command -v git >/dev/null; then
+		info "git not installed - trying to use a downloader instead"
+		detect_downloader
 	fi
 }
 


### PR DESCRIPTION
The `kata-manager` script needs to download `git` repos. But if `git` isn't available, it can fall back to using `curl` or `wget`. However, if none of these tools are available, it should exit before any changes are
made to the system.

Note: The script _could_ install one of the tools of course. However, all known Linux distro "default installs" provide at least one of these tools, so this scenario should only be hit on very minimal systems. In that case, install one of the tools the error mentions and re-run `kata-manager`.

Fixes #1502.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>