### PR TITLE
test: Fix pod quota test for kubernetes

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -35,3 +35,6 @@ sudo ip link del flannel.1
 
 # Check no kata processes are left behind after reseting kubernetes
 check_processes
+
+# Checks that pods were not left
+check_pods

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -15,8 +15,6 @@ setup() {
 @test "Pod quota" {
 	resource_name="pod-quota"
 	deployment_name="deploymenttest"
-	wait_time=10
-	sleep_time=2
 
 	# Create the resourcequota
 	kubectl create -f "${pod_config_dir}/resource-quota.yaml"
@@ -27,9 +25,8 @@ setup() {
 	# Create deployment
 	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
 
-	# View information about the deployment
-	cmd="kubectl get deployment \"$deployment_name\" --output=yaml | grep -q 'forbidden: exceeded quota'"
-	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+	# View deployment
+	kubectl wait --for=condition=Available deployment/${deployment_name}
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       purpose: quota-demo
-  replicas: 3
+  replicas: 2
   template:
     metadata:
       labels:

--- a/integration/kubernetes/untrusted_workloads/pod-quota-deployment.yaml
+++ b/integration/kubernetes/untrusted_workloads/pod-quota-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       purpose: quota-demo
-  replicas: 3
+  replicas: 2
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Fix pod quota test to avoid leaving pod information at /var/lib/vc/sbs (issue: https://github.com/kata-containers/runtime/issues/1611) and verify after running the tests that not pod information is left.

Fixes #1513

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>