### PR TITLE
checkcommits: recognize jenkins CI environment

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -270,7 +270,7 @@ func getCommitRange(commit, branch string) ([]string, error) {
 	args = append(args, "rev-list")
 	args = append(args, "--no-merges")
 	args = append(args, "--reverse")
-	args = append(args, fmt.Sprintf("%s..%s", branch, commit))
+	args = append(args, fmt.Sprintf("origin/%s..%s", branch, commit))
 
 	return runCommand(args)
 }

--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -467,6 +467,13 @@ func detectCIEnvironment() (commit, dstBranch, srcBranch string) {
 			// contains that branch: master doesn't exist.
 			dstBranch = "origin"
 		}
+	} else if os.Getenv("ghprbPullId") != "" {
+		name = "JenkinsCI - github pull request builder"
+
+		commit = os.Getenv("ghprbActualCommit")
+
+		srcBranch = os.Getenv("ghprbSourceBranch")
+		dstBranch = os.Getenv("ghprbTargetBranch")
 	}
 
 	if verbose && name != "" {

--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -180,6 +180,11 @@ func clearCIVariables() {
 		"REVISION",
 		"BRANCH_NAME",
 		"PULL_REQUEST_NUMBER",
+
+		"ghprbPullId",
+		"ghprbActualCommit",
+		"ghprbSourceBranch",
+		"ghprbTargetBranch",
 	}
 
 	for _, envVar := range envVars {


### PR DESCRIPTION
Add jenkins github pull request builder env variables
to set commitID, source and dest branches.

Fixes: #1516

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>