### PR TITLE
release: 1.5.5 backport fixes

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -622,22 +622,26 @@ check_vendor()
 	# All vendor operations should modify this file
 	local vendor_ctl_file="Gopkg.lock"
 
+	[ -e "$vendor_ctl_file" ] || { info "No vendoring in this repository" && return; }
+
+	info "Checking vendored code is pristine"
+
 	files=$(get_pr_changed_file_details_full || true)
 
 	# Strip off status
 	files=$(echo "$files"|awk '{print $NF}')
 
-	# No files were changed
-	[ -z "$files" ] && info "No files found" && return
+	if [ -n "$files" ]
+	then
+		# PR changed files so check if it changed any vendored files
+		vendor_files=$(echo "$files" | grep "vendor/" || true)
 
-	vendor_files=$(echo "$files" | grep "vendor/" || true)
-
-	# No vendor files modified
-	[ -z "$vendor_files" ] && return
-
-	result=$(echo "$files" | egrep "\<${vendor_ctl_file}\>" || true)
-
-	[ -n "$result" ] || die "PR changes vendor files, but does not update ${vendor_ctl_file}"
+		if [ -n "$vendor_files" ]
+		then
+			result=$(echo "$files" | egrep "\<${vendor_ctl_file}\>" || true)
+			[ -n "$result" ] || die "PR changes vendor files, but does not update ${vendor_ctl_file}"
+		fi
+	fi
 }
 
 main()

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -608,11 +608,15 @@ check_files()
 	exit 1
 }
 
-# Ensure that changes to vendored code are accompanied by an update to the
-# vendor tooling config file. If not, the user simply hacked the vendor files
-# rather than following the correct process:
+# Perform vendor checks:
 #
-# - https://github.com/kata-containers/community/blob/master/VENDORING.md
+# - Ensure that changes to vendored code are accompanied by an update to the
+#   vendor tooling config file. If not, the user simply hacked the vendor files
+#   rather than following the correct process:
+#
+#   https://github.com/kata-containers/community/blob/master/VENDORING.md
+#
+# - Ensure vendor metadata is valid.
 check_vendor()
 {
 	local files
@@ -642,6 +646,14 @@ check_vendor()
 			[ -n "$result" ] || die "PR changes vendor files, but does not update ${vendor_ctl_file}"
 		fi
 	fi
+
+	info "Checking vendoring metadata"
+
+	# Get the vendoring tool
+	go get github.com/golang/dep/cmd/dep
+
+	# Check, but don't touch!
+	dep ensure -no-vendor -dry-run
 }
 
 main()

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -493,6 +493,12 @@ check_docs()
 		# Google APIs typically require an auth token.
 		echo "$url"|grep -q 'https://www.googleapis.com' && continue
 
+		# Git repo URL check
+		if echo "$url"|grep -q '^https.*git'
+		then
+			git ls-remote "$url" > /dev/null 2>&1 && continue
+		fi
+
 		# Check the URL, saving it if invalid
 		( curl -sLf -o /dev/null "$url" ||\
 				echo "$url" >> "$invalid_urls") &

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -263,8 +263,6 @@ get_git_repo()
 	local -r repo_url="https://${repo_path}"
 
 	if ! command -v git >/dev/null; then
-		info "getting repo $1 using http downloader"
-		detect_downloader
 		$downloader "${repo_url}/${tarball_suffix}" | tar xz -C "$local_dest" --strip-components=1
 		return
 	fi
@@ -389,6 +387,11 @@ setup()
 	kata_repos_base=$(go env GOPATH 2>/dev/null || true)
 	if [ -z "$kata_repos_base" ]; then
 		kata_repos_base="$HOME/go"
+	fi
+
+	if ! command -v git >/dev/null; then
+		info "git not installed - trying to use a downloader instead"
+		detect_downloader
 	fi
 }
 

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -60,9 +60,8 @@ done
 
 IFS=$OLD_IFS
 
-# run CRI-O tests using devicemapper on ubuntu 16.04
-MAJOR=$(echo "$VERSION_ID"|cut -d\. -f1)
-if [ "$ID" == "ubuntu" ] && [ "$MAJOR" -eq 16 ]; then
+# run CRI-O tests using devicemapper on ubuntu
+if [ "$ID" == "ubuntu" ]; then
 	# Block device attached to the VM where we run the CI
 	# If the block device has a partition, cri-o will not be able to use it.
 	export LVM_DEVICE
@@ -72,13 +71,9 @@ if [ "$ID" == "ubuntu" ] && [ "$MAJOR" -eq 16 ]; then
 	export STORAGE_OPTIONS="$DM_STORAGE_OPTIONS"
 fi
 
-# But if on ubuntu 17.10 or newer, test using overlay
+# On other distros or on ZUUL, use overlay.
 # This will allow us to run tests with at least 2 different
 # storage drivers.
-if [ "$ID" == "ubuntu" ] && [ "$MAJOR" -ge 17 ]; then
-	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
-fi
-
 if [ "$ID" == "fedora" ] || [ "$ID" == "centos" ]; then
 	export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
 fi

--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -113,6 +113,7 @@ var _ = Describe("memory constraints", func() {
 		useKmem       bool
 		err           error
 		defaultMemSz  int
+		hotMemSz      int
 	)
 
 	BeforeEach(func() {
@@ -143,8 +144,9 @@ var _ = Describe("memory constraints", func() {
 
 	Context("run container exceeding memory constraints", func() {
 		It("should ran out of memory", func() {
-			memSize = "256MB"
-			limSize = strconv.Itoa(260+defaultMemSz) + "M"
+			hotMemSz = 256
+			memSize = fmt.Sprintf("%dMB", hotMemSz)
+			limSize = fmt.Sprintf("%dM", (hotMemSz*2)+defaultMemSz)
 			args = []string{"--name", id, "--rm", "-m", memSize, StressImage, "-mem-total", limSize, "-mem-alloc-size", limSize}
 			_, stderr, exitCode = dockerRun(args...)
 			Expect(exitCode).NotTo(Equal(0))


### PR DESCRIPTION
Changes:

2a3cbb9 (James O. D. Hunt, 4 days ago)
   CI: Add explicit static check script vendor test

   Update the `check_vendor()` function in the static check script to run our
   current vendoring tool (`dep`) in check mode. This will ensure our 
   vendoring does not get silently broken [1].

   Fixes #1506.

   [1] - See for example https://github.com/kata-containers/runtime/pull/1442.

   Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
   (cherry picked from commit 830983f62b49703e4c052b38ab59947e98722a6f) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

23d8194 (James O. D. Hunt, 4 days ago)
   CI: Refactor static check vendor test

   Modify the `check_vendor()` function in the static check script. Rather 
   than exiting the function as early as possible, change the logic to allow
   follow on future checks to be added.

   Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
   (cherry picked from commit 50f3b035079e7c38b797edb11ac4c4df1afa58b9) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

bd82330 (Julio Montes, 6 days ago)
   integration/docker: improve memory test

   Consume twice the memory hot added to the container to guarantee the `out
   of memory` error.

   fixes #1504

   Signed-off-by: Julio Montes <julio.montes@intel.com>
   (cherry picked from commit bb49514364c5b46d594cf771ce315db546348686) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

3855dc8 (James O. D. Hunt, 6 days ago)
   kata-manager: Check for dependencies earlier

   The `kata-manager` script needs to download `git` repos. But if `git` isn't
   available, it can fall back to using `curl` or `wget`. However, if none of
   these tools are available, it should exit before any changes are made to
   the system.

   Note: The script _could_ install one of the tools of course. However, all
   known Linux distro "default installs" provide at least one of these tools,
   so this scenario should only be hit on very minimal systems. In that case,
   install one of the tools the error mentions and re-run
   `kata-manager`.

   Fixes #1502.

   Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
   (cherry picked from commit cfa9c821d873db8d8a662243e11e8cd098313211) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

3f0c8e7 (Salvador Fuentes, 10 days ago)
   cri-o: tests: use devicemapper on all ubuntu versions

   Do not restrict ubuntu version to run with devicemapper. We have now moved
   most of our jobs to ubuntu 18.04 and we were not testing with devicemapper. 
   With this change, we will test cri-o with devicemapper on all ubuntu
   versions.

   Fixes: #1493.

   Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>
   (cherry picked from commit 77a8cd531aa5b9889fb109d5f6f7d81c54c877ab) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

f1e79cc (Xu Wang, 2 weeks ago)
   CI: static check for openstack git URL

   Fixes: #1483

   Use git ls-remote instead of curl for git URL check

   Signed-off-by: Xu Wang <xu@hyper.sh>
   (cherry picked from commit 0d28f77dec116087f9eb9c2099177712f8de1d10) 
   Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>