### PR TITLE
ci: Do not add ppa:alexlarsson/flatpak repo for ppc64le

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -45,12 +45,12 @@ chronic sudo -E apt install -y build-essential python pkg-config zlib1g-dev
 echo -e "Install CRI-O dependencies available for Ubuntu $VERSION_ID"
 chronic sudo -E apt install -y libdevmapper-dev btrfs-tools util-linux
 
-if [ "$VERSION_ID" == "16.04" ]; then
-	echo "Install os-tree"
+if [ "$VERSION_ID" == "16.04" ] && [ "$(arch)" != "ppc64le" ]; then
 	chronic sudo -E add-apt-repository ppa:alexlarsson/flatpak -y
 	chronic sudo -E apt update
 fi
 
+echo "Install os-tree"
 chronic sudo -E apt install -y libostree-dev
 
 echo "Install YAML validator"


### PR DESCRIPTION
Do not add ppa:alexlarsson/flatpak repo for ppc64le
arch as it fails to add key resulting in CI failure.

Fixes: #1533

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com