### PR TITLE
ci: Add virtio-fs support

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -51,6 +51,16 @@ if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	runtime_config_path="${NEW_RUNTIME_CONFIG}"
 fi
 
+if [ "$KATA_HYPERVISOR" = "firecracker" ]; then
+	echo "Enable firecracker configuration.toml"
+	sudo mv "${PKGDEFAULTSDIR}/configuration-fc.toml" "${PKGDEFAULTSDIR}/configuration.toml"
+fi
+
+if [ "$KATA_HYPERVISOR" = "nemu" ]; then
+	echo "Enable nemu configuration.toml"
+	sudo mv "${PKGDEFAULTSDIR}/configuration-nemu.toml" "${PKGDEFAULTSDIR}/configuration.toml"
+fi
+
 if [ -z "${METRICS_CI}" ]; then
 	echo "Enabling all debug options in file ${runtime_config_path}"
 	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
@@ -104,12 +114,6 @@ fi
 if [ "$MACHINETYPE" == "q35" ]; then
 	echo "Use machine_type q35"
 	sudo sed -i -e 's|machine_type = "pc"|machine_type = "q35"|' "${runtime_config_path}"
-fi
-
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	echo "Enable firecracker configuration.toml"
-	path="/usr/share/defaults/kata-containers"
-	sudo mv ${path}/configuration-fc.toml ${path}/configuration.toml
 fi
 
 # Enable experimental features if KATA_EXPERIMENTAL_FEATURES is set to true

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -8,7 +8,7 @@
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
-export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr/local"}
+export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,7 +22,7 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
-	"FIRECRACKER")
+	"FIRECRACKER"|"NEMU")
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
 		echo "INFO: Running soak test"

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type hypervisor struct {
 	DisableNestingChecks  bool   `toml:"disable_nesting_checks"`
 	EnableIOThreads       bool   `toml:"enable_iothreads"`
 	Vsock                 bool   `toml:"use_vsock"`
+	SharedFS              string `toml:"shared_fs"`
 }
 
 type proxy struct {

--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -69,6 +69,9 @@ var _ = Describe("Hotplug memory when create containers", func() {
 
 	DescribeTable("Hotplug memory when create containers",
 		func(dockerMem int64) {
+			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+				Skip("Skip issue: https://github.com/kata-containers/runtime/issues/1745")
+			}
 			args = []string{"--name", id, "-tid", "--rm", "-m", fmt.Sprintf("%d", dockerMem), Image}
 			_, _, exitCode = dockerRun(args...)
 			Expect(exitCode).To(BeZero())
@@ -117,6 +120,9 @@ var _ = Describe("memory constraints", func() {
 	)
 
 	BeforeEach(func() {
+		if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+			Skip("Skip issue: https://github.com/kata-containers/runtime/issues/1745")
+		}
 		useSwappiness = true
 		useSwap = true
 		useKmem = true
@@ -242,6 +248,9 @@ var _ = Describe("run container and update its memory constraints", func() {
 
 	DescribeTable("should have applied the memory constraints",
 		func(dockerMem int64, updateMem int64, fail bool) {
+			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+				Skip("Skip issue: https://github.com/kata-containers/runtime/issues/1745")
+			}
 			memSize = fmt.Sprintf("%d", dockerMem)
 			args = []string{"--name", id, "-dti", "--rm", "-m", memSize, Image}
 


### PR DESCRIPTION
Add configuration option to use virtio-fs.
We will currently use nemu for testing the
virtio-fs support.

Depends-on: github.com/kata-containers/runtime#1639

Fixes: #1536.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>