### PR TITLE
tracing: Fix tracing test script.

### DIFF
--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -76,7 +76,7 @@ get_jaeger_status()
 
 		[ "$ret" -eq 0 ] && [ -n "$status" ] && break
 
-		attempt=$((attempt++))
+		attempt=$((attempt+1))
 		sleep 1
 	done
 
@@ -202,7 +202,7 @@ check_jaeger_status()
 			[ "$errors" -lt 0 ] && errors=0
 		fi
 
-		attempt=$((attempt++))
+		attempt=$((attempt+1))
 
 		[ "$errors" -eq 0 ] && break
 	done


### PR DESCRIPTION
We use an `$attempt` variable to have a maximum
of 3 attempts to validate tracing spans, but
the variable increment was not correct, leading
to having the script getting hanged.

Fixes: #1552.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>