### PR TITLE
ci: Fix libsystemd installation on RHEL

### DIFF
--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -81,7 +81,7 @@ chronic sudo -E yum -y install perl bzip2 make
 build_install_parallel
 
 echo "Install libsystemd"
-chronic sudo -E dnf -y install systemd-devel
+chronic sudo -E yum -y install systemd-devel
 
 if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 	echo "Install ${KATA_KSM_THROTTLER_JOB}"


### PR DESCRIPTION
dnf does not exist on RHEL so the installation of libsystemd is
failing on RHEL. This needs to be replaced by yum.

Fixes #1562

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>