### PR TITLE
ppc64le: run docker test serially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 ifeq ($(KATA_HYPERVISOR),firecracker)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x))
+else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x ppc64le))
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else ifneq (${FOCUS},)


### PR DESCRIPTION
Ginkgo doesn't skip the tests when they're run in parallel.

Fixes: #1572

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>