### PR TITLE
tracing: Increase `attempt` before exiting current iteration

### DIFF
--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -184,6 +184,7 @@ check_jaeger_status()
 		then
 			errors=$((errors+1))
 			warn "Found invalid parent span errors (attempt $attempt): $errors1"
+			attempt=$((attempt+1))
 			continue
 		else
 			errors=$((errors-1))
@@ -196,6 +197,7 @@ check_jaeger_status()
 		then
 			errors=$((errors+1))
 			warn "Found warnings (attempt $attempt): $errors2"
+			attempt=$((attempt+1))
 			continue
 		else
 			errors=$((errors-1))


### PR DESCRIPTION
increase the `attempt` value before running `continue` command
to prevent the script from getting hanged in a loop forever.

Fixes #1552.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>