### PR TITLE
Log Jaeger traces

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -13,6 +13,9 @@ VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
 # Sandbox runtime directory
 RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"
 
+# Directory that can be used for storing test logs.
+KATA_TESTS_LOGDIR="${KATA_TESTS_LOGDIR:-/var/log/kata-tests}"
+
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 die() {


### PR DESCRIPTION
Defined `KATA_TESTS_LOGDIR` in the common bash library so that tests can write log information to a known location.

Save the trace spans logged with Jaeger to a directory below KATA_TESTS_LOGDIR` so that if the test fails, the spans can be analysed. This will allow the saved trace spans to be attached to a failing PR as artifacts. If the test passes, the cached spans are deleted.

Fixes: #1593.
    
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>