### PR TITLE
nemu: Enable static nemu for ci

### DIFF
--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -19,21 +19,22 @@ arch=$("${cidir}"/kata-arch.sh -d)
 install_nemu() {
 	local nemu_repo=$(get_version "assets.hypervisor.nemu.url")
 	local nemu_version=$(get_version "assets.hypervisor.nemu.version")
+	PACKAGING_REPO="github.com/kata-containers/packaging"
+	NEMU_TAR="kata-nemu-static.tar.gz"
 	case "$arch" in
 	x86_64)
-		local nemu_bin="qemu-system-${arch}_virt"
-		;;
-	aarch64)
-		local nemu_bin="qemu-system-${arch}"
+		local nemu_bin="nemu-system-${arch}"
 		;;
 	*)
 		die "Unsupported architecture: $arch"
 		;;
 	esac
 
-	curl -LO "${nemu_repo}/releases/download/${nemu_version}/${nemu_bin}"
-	sudo install -o root -g root -m 0755 "${nemu_bin}" "/usr/local/bin"
-	rm -rf "${nemu_bin}"
+	go get -d "${PACKAGING_REPO}" || true
+
+	prefix="${KATA_NEMU_DESTDIR}" ${GOPATH}/src/${PACKAGING_REPO}/static-build/nemu/build-static-nemu.sh
+	sudo tar -xvf ${NEMU_TAR} -C /
+	rm ${NEMU_TAR}
 }
 
 install_firmware() {
@@ -49,4 +50,5 @@ install_firmware() {
 }
 
 install_nemu
-install_firmware
+# NEMU static tar now also includes the OVMF.fd bios file.
+#install_firmware

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -86,14 +86,11 @@ if [ "$KATA_HYPERVISOR" == "qemu" ]; then
 	"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
 elif [ "$KATA_HYPERVISOR" == "nemu" ]; then
 	echo "Configure Nemu as Kata Hypervisor"
-	sudo sed -i -e 's|machine_type = "pc"|machine_type = "virt"|' "${runtime_config_path}"
-	sudo sed -i -e 's|firmware = ""|firmware = "/usr/share/nemu/firmware/OVMF.fd"|' "${runtime_config_path}"
+	sudo crudini --set "${runtime_config_path}" hypervisor.qemu machine_type \"virt\"
+	sudo crudini --set "${runtime_config_path}" hypervisor.qemu firmware \"${KATA_NEMU_DESTDIR}/share/kata-nemu/OVMF.fd\"
 	case "$arch" in
 	x86_64)
-		sudo sed -i -e "s|\"/usr/bin/qemu-lite-system-${arch}\"|\"/usr/local/bin/qemu-system-${arch}_virt\"|" "${runtime_config_path}"
-		;;
-	aarch64)
-		sudo sed -i -e "s|\"/usr/bin/qemu-lite-system-${arch}\"|\"/usr/local/bin/qemu-system-${arch}\"|" "${runtime_config_path}"
+		sudo crudini --set "${runtime_config_path}" hypervisor.qemu path \"${KATA_NEMU_DESTDIR}/bin/nemu-system-${arch}\"
 		;;
 	*)
 		die "Unsupported architecture: $arch"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -8,6 +8,7 @@
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
+export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr/local"}
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"


### PR DESCRIPTION
Build NEMU statically for every CI run to make sure we test a setup
similar to the one we are shipping with Kata.

Fixes: #1536
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>