### PR TITLE
make: add install- targets to run CI install scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
+INSTALL_FILES := $(wildcard .ci/install_*.sh)
+INSTALL_TARGETS := $(INSTALL_FILES:.ci/install_%.sh=install-%)
+
 # Load architecture-dependent settings
 ifneq ($(wildcard $(ARCH_FILE)),)
 include $(ARCH_FILE)
@@ -163,6 +166,12 @@ test: ${UNION}
 
 check: checkcommits log-parser
 
+$(INSTALL_TARGETS): install-%: .ci/install_%.sh
+	@bash -f $<
+
+list-install-targets:
+	@echo $(INSTALL_TARGETS) | tr " " "\n"
+
 # PHONY in alphabetical order
 .PHONY: \
 	check \
@@ -175,7 +184,9 @@ check: checkcommits log-parser
 	entropy \
 	functional \
 	ginkgo \
+	$(INSTALL_TARGETS) \
 	kubernetes \
+	list-install-targets \
 	log-parser \
 	oci \
 	openshift \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ The advantages of this approach are:
 
 - Assurance that all the code repositories are tested in this same way.
 
+CI scripts also provide a convenient way for other Kata repositories to
+install software. The preferred way to use these scripts is to invoke `make`
+with the corresponding `install-` target. For example, to install crio you
+would use:
+
+```
+$ make -C <path-to-this-repo> install-crio
+```
+
+Use `make list-install-targets` to retrieve all the available install targets.
+
 ### CI setup
 
 > **WARNING:**


### PR DESCRIPTION
Adding generic install- targets has the benefit of having a standardized way
of installing tools from the tests repository, hiding installation details
such as the paths to the actual install scripts.

Fixes: #1599

Signed-off-by: Marco Vedovati <mvedovati@suse.com>