### PR TITLE
ci: move install_yq function in lib.sh a dedicate script

### DIFF
--- a/.ci/filter/filter_docker_test.sh
+++ b/.ci/filter/filter_docker_test.sh
@@ -36,7 +36,7 @@ filter_and_build()
 main()
 {
 	# install yq if not exist
-	[ -z "$(command -v yq)" ] && install_yq
+	${ci_dir}/install_yq.sh
 	# build skip option based on Describe block
 	filter_and_build "${describe_skip_flag}"
 

--- a/.ci/filter/filter_docker_test.sh
+++ b/.ci/filter/filter_docker_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 ARM Limited
 #

--- a/.ci/filter/filter_test_union.sh
+++ b/.ci/filter/filter_test_union.sh
@@ -22,7 +22,7 @@ source "${ci_dir}/lib.sh"
 main()
 {
 	# install yq if not exist
-	[ -z "$(command -v yq)" ] && install_yq
+	${ci_dir}/install_yq.sh
 	local array_test=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${test_filter_flag}")
 	[ "${array_test}" = "null" ] && return
 	mapfile -t _array_test <<< "${array_test}"

--- a/.ci/install_yq.sh
+++ b/.ci/install_yq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2019 SUSE LLC
 #

--- a/.ci/install_yq.sh
+++ b/.ci/install_yq.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -eu
+
+function install_yq() {
+	local cidir=$(dirname "${BASH_SOURCE[0]}")
+	# source lib.sh to make sure GOPATH is set
+	source ${cidir}/lib.sh
+	[ -x  "${GOPATH}/bin/yq" ] && return
+
+	local yq_path="${GOPATH}/bin/yq"
+	local yq_pkg="github.com/mikefarah/yq"
+	local goos="$(uname -s)"
+	local goarch="$(${cidir}/kata-arch.sh --golang)"
+
+	mkdir -p "${GOPATH}/bin"
+
+	# Workaround to get latest release from github (to not use github token).
+	# Get the redirection to latest release on github.
+	yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
+	# The redirected url should include the latest release version
+	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
+	yq_version=$(basename "${yq_latest_url}")
+
+	## NOTE: ${var,,} => gives lowercase value of var
+	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"
+	curl -o "${yq_path}" -LSsf ${yq_url}
+	chmod +x ${yq_path}
+
+	if ! command -v "${yq_path}" >/dev/null; then
+		die "Cannot not get ${yq_path} executable"
+	fi
+}
+
+install_yq

--- a/.ci/kata-arch.sh
+++ b/.ci/kata-arch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Intel Corporation
 #

--- a/.ci/kata-arch.sh
+++ b/.ci/kata-arch.sh
@@ -61,7 +61,12 @@ main()
 {
 	local type="default"
 
-	local args=$(getopt \
+	local getopt_cmd="getopt"
+
+	# macOS default getopt does not recognize GNU options
+	[ "$(uname -s)" == "Darwin" ] && getopt_cmd="/usr/local/opt/gnu-getopt/bin/${getopt_cmd}"
+
+	local args=$("$getopt_cmd" \
 		-n "$script_name" \
 		-a \
 		--options="dghk" \

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -104,65 +104,16 @@ function build_and_install() {
 	popd
 }
 
-function install_yq() {
-	local yq_path="${GOPATH}/bin/yq"
-	local yq_pkg="github.com/mikefarah/yq"
-	[ -x  "${GOPATH}/bin/yq" ] && return
-
-	read -r -a sysInfo <<< "$(uname -sm)"
-
-	case "${sysInfo[0]}" in
-	"Linux" | "Darwin")
-		goos="${sysInfo[0],}"
-		;;
-	"*")
-		die "OS ${sysInfo[0]} not supported"
-		;;
-	esac
-
-	case "${sysInfo[1]}" in
-	"aarch64")
-		goarch=arm64
-		;;
-	"ppc64le")
-		goarch=ppc64le
-		;;
-	"x86_64")
-		goarch=amd64
-		;;
-	"s390x")
-		goarch=s390x
-		;;
-	"*")
-		die "Arch ${sysInfo[1]} not supported"
-		;;
-	esac
-
-	mkdir -p "${GOPATH}/bin"
-
-	# Workaround to get latest release from github (to not use github token).
-	# Get the redirection to latest release on github.
-	yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
-	# The redirected url should include the latest release version
-	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
-	yq_version=$(basename "${yq_latest_url}")
-
-	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-	curl -o "${yq_path}" -LSs ${yq_url}
-	chmod +x ${yq_path}
-
-	if ! command -v "${yq_path}" >/dev/null; then
-		die "Cannot not get ${yq_path} executable"
-	fi
-}
-
 function get_dep_from_yaml_db(){
 	local versions_file="$1"
 	local dependency="$2"
 
 	[ ! -f "$versions_file" ] && die "cannot find $versions_file"
 
-	install_yq >&2
+	# directory of this script, not the caller
+	local cidir=$(dirname "${BASH_SOURCE[0]}")
+
+	${cidir}/install_yq.sh >&2
 
 	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017-2018 Intel Corporation
 # Copyright (c) 2018 ARM Limited

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install --user yamllint          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint gnu-getopt; fi
 
 script:
   - bash .ci/static-checks.sh github.com/kata-containers/tests

--- a/cmd/github-labels/github-labels.sh
+++ b/cmd/github-labels/github-labels.sh
@@ -38,7 +38,8 @@ merge_yaml()
 	[ -n "$file2" ] || die "need 2nd file"
 	[ -n "$out" ] || die "need output file"
 
-	[ -z "$(command -v yq)" ] && install_yq
+	# install yq if not exist
+	${cidir}/install_yq.sh
 
 	yq merge "$file1" --append "$file2" > "$out"
 }

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018-2019 Intel Corporation
 #


### PR DESCRIPTION
Moving install_yq in a dedicated script allows other repositories to reuse it.
Also, this complements the set of scripts in .ci/ used to install software.

Fixes: #1604

Signed-off-by: Marco Vedovati <mvedovati@suse.com>