### PR TITLE
test: Enable docker integration test for nonexistent command

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -215,7 +215,6 @@ var _ = Describe("run nonexistent command", func() {
 
 	Context("Running nonexistent command", func() {
 		It("container and its components should not exist", func() {
-			Skip("Issue: https://github.com/kata-containers/runtime/issues/366")
 			args = []string{"--rm", "--name", id, Image, "does-not-exist"}
 			_, _, exitCode = dockerRun(args...)
 			Expect(exitCode).NotTo(Equal(0))


### PR DESCRIPTION
Now that https://github.com/kata-containers/runtime/issues/366 has
been fixed, we can enable the docker run nonexistent command test.

Fixes #1606

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>