### PR TITLE
 tests: fix oci_call test for docker 18.09 or later

### DIFF
--- a/integration/oci_calls/oci_call_test.sh
+++ b/integration/oci_calls/oci_call_test.sh
@@ -22,7 +22,7 @@ PAYLOAD="tail -f /dev/null"
 NAME="testoci"
 
 function remove_tmp_file {
-	rm -rf $TMP_FILE
+	rm "$TMP_FILE"
 }
 
 trap remove_tmp_file EXIT
@@ -34,12 +34,12 @@ function get_time() {
 
 # Get log for a specific time
 function get_debug_logs() {
-	sudo journalctl -q --since "$start_time" -o cat -a -t ${RUNTIME} > ${TMP_FILE}
+	sudo journalctl -q --since "$start_time" -o cat -a -t "${RUNTIME}" > "${TMP_FILE}"
 }
 
 # Find the arguments or oci calls for a specific command
 function check_arguments() {
-	list_arguments=$(grep -o "arguments=[^ ]*" ${TMP_FILE} --color|cut -d= -f2-|tr -d '"'|tr -d "\\\\")
+	list_arguments=$(grep -o "arguments=[^ ]*" "${TMP_FILE}" --color|cut -d= -f2-|tr -d '"'|tr -d "\\\\")
 
 	[ -n "$list_arguments" ] || die "List of arguments missing"
 
@@ -54,10 +54,11 @@ function order_arguments() {
 	# Remove all duplicated arguments, remove `state` argument (as it is
 	# not defined with a specific order and we already checked that is part
 	# of the oci arguments) and remove an empty space.
-	local -a final_arguments=$(echo ${list_arguments//state/} | \
+	local -a final_arguments
+	final_arguments=$(echo "${list_arguments//state/}" | \
 		awk '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}' | \
 		sed 's/ *$//')
-	final_oci=$(echo ${oci_call[@]//state/})
+	final_oci="$(echo ${oci_call[*]//state/})"
 
 	[[ "${final_oci}" == "${final_arguments}" ]]
 }
@@ -70,7 +71,7 @@ function setup() {
 	extract_kata_env
 
 	# Enable full debug
-	sudo sed -i 's/#enable_debug = true/enable_debug = true/g' ${RUNTIME_CONFIG_PATH}
+	sudo sed -i 's/#enable_debug = true/enable_debug = true/g' "${RUNTIME_CONFIG_PATH}"
 }
 
 function run_oci_call() {
@@ -82,7 +83,7 @@ function run_oci_call() {
 	get_time
 
 	# Start a container
-	docker run -d --runtime=${RUNTIME} --name=${NAME} ${IMAGE} ${PAYLOAD}
+	docker run -d --runtime="${RUNTIME}" --name="${NAME}" "${IMAGE}" sh -c "${PAYLOAD}"
 
 	get_debug_logs
 
@@ -115,7 +116,7 @@ function run_oci_call_true() {
 	# Find docker version
 	version=$(docker version --format '{{.Server.Version}}' | cut -d '.' -f1-2)
 	result=$(echo "$version>18.06" | bc)
-	if [ ${result} -eq 1 ]; then
+	if [ "${result}" -eq 1 ]; then
 		local -a oci_call=( "create" "start" "delete" "state" )
 	else
 		local -a oci_call=( "create" "start" "kill" "delete" "state" )
@@ -127,7 +128,7 @@ function run_oci_call_true() {
 	get_time
 
 	# Run a container with true
-	docker run --rm --runtime=${RUNTIME} ${IMAGE} true
+	docker run --rm --runtime="${RUNTIME}" "${IMAGE}" true
 
 	get_debug_logs
 
@@ -144,7 +145,7 @@ function teardown() {
 	extract_kata_env
 
 	# Disable full debug
-	sudo sed -i 's/enable_debug = true/#enable_debug = true/g' ${RUNTIME_CONFIG_PATH}
+	sudo sed -i 's/enable_debug = true/#enable_debug = true/g' "${RUNTIME_CONFIG_PATH}"
 }
 
 echo "Running setup"

--- a/integration/oci_calls/oci_call_test.sh
+++ b/integration/oci_calls/oci_call_test.sh
@@ -114,8 +114,8 @@ function stop_oci_call() {
 function run_oci_call_true() {
 	# Find docker version
 	version=$(docker version --format '{{.Server.Version}}' | cut -d '.' -f1-2)
-	result=$(echo "$version>=18.06" | bc)
-	if [ ${result} -ne 1 ]; then
+	result=$(echo "$version>18.06" | bc)
+	if [ ${result} -eq 1 ]; then
 		local -a oci_call=( "create" "start" "delete" "state" )
 	else
 		local -a oci_call=( "create" "start" "kill" "delete" "state" )


### PR DESCRIPTION
Fix the comparison that is used to know which docker
version we are using.

Fixes: #1608.

In addition, fixes issues reported by shellcheck.