### PR TITLE
CI: Add unreferenced doc check

### DIFF
--- a/cmd/check-markdown/README.md
+++ b/cmd/check-markdown/README.md
@@ -30,7 +30,7 @@ some errors it finds. It can also generate a TOC (table of contents).
 ## Basic
 
 ```sh
-$ kata-check-markdown README.md
+$ kata-check-markdown check README.md
 ```
 
 ## Generate a TOC

--- a/cmd/check-markdown/README.md
+++ b/cmd/check-markdown/README.md
@@ -3,6 +3,8 @@
 * [Usage](#usage)
     * [Basic](#basic)
     * [Generate a TOC](#generate-a-toc)
+    * [List headings](#list-headings)
+    * [List links](#list-links)
     * [Full details](#full-details)
 
 # Overview
@@ -37,6 +39,22 @@ $ kata-check-markdown check README.md
 
 ```sh
 $ kata-check-markdown toc README.md
+```
+
+## List headings
+
+To list the document headings in the default `text` format:
+
+```sh
+$ kata-check-markdown list headings README.md
+```
+
+## List links
+
+To list the links in a document in tab-separated format:
+
+```sh
+$ kata-check-markdown list links --format tsv README.md
 ```
 
 ## Full details

--- a/cmd/check-markdown/README.md
+++ b/cmd/check-markdown/README.md
@@ -36,7 +36,7 @@ $ kata-check-markdown check README.md
 ## Generate a TOC
 
 ```sh
-$ kata-check-markdown --create-toc README.md
+$ kata-check-markdown toc README.md
 ```
 
 ## Full details

--- a/cmd/check-markdown/add.go
+++ b/cmd/check-markdown/add.go
@@ -84,15 +84,20 @@ func (d *Doc) addLink(link Link) error {
 		"link": fmt.Sprintf("%+v", link),
 	}
 
-	if _, ok := d.Links[addr]; ok {
-		d.Logger.WithFields(fields).Debug("not adding duplicate link")
+	links := d.Links[addr]
 
-		return nil
+	for _, l := range links {
+		if l.Type == link.Type {
+			d.Logger.WithFields(fields).Debug("not adding duplicate link")
+
+			return nil
+		}
 	}
 
 	d.Logger.WithFields(fields).Debug("adding link")
 
-	d.Links[addr] = link
+	links = append(links, link)
+	d.Links[addr] = links
 
 	return nil
 }

--- a/cmd/check-markdown/add.go
+++ b/cmd/check-markdown/add.go
@@ -69,6 +69,10 @@ func (d *Doc) addLink(link Link) error {
 		return d.Errorf("link address cannot be blank: %+v", link)
 	}
 
+	if link.Type == unknownLink {
+		return d.Errorf("BUG: link type invalid: %+v", link)
+	}
+
 	// Not checked by default as magic "build status" / go report / godoc
 	// links don't have a description - they have a image only.
 	if strict && link.Description == "" {

--- a/cmd/check-markdown/add_test.go
+++ b/cmd/check-markdown/add_test.go
@@ -1,0 +1,192 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testFileMode = os.FileMode(0640)
+	testDirMode  = os.FileMode(0750)
+	readmeName   = "README.md"
+)
+
+func createFile(file, contents string) error {
+	return ioutil.WriteFile(file, []byte(contents), testFileMode)
+}
+
+// makeDirs creates two directories below the specified base directory: one is
+// an empty director named emptyDirName and the other is named readmeDirName
+// and contains a markdown file called "README.md".
+func makeDirs(assert *assert.Assertions, baseDir string, readmeDirName, emptyDirName string) {
+	readmeDir := filepath.Join(baseDir, readmeDirName)
+	err := os.MkdirAll(readmeDir, testDirMode)
+	assert.NoError(err)
+
+	readme := filepath.Join(readmeDir, "README.md")
+
+	err = createFile(readme, "# hello")
+	assert.NoError(err)
+
+	emptyDir := filepath.Join(baseDir, emptyDirName)
+	err = os.MkdirAll(emptyDir, testDirMode)
+	assert.NoError(err)
+}
+
+func TestDocAddHeading(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		heading     Heading
+		expectError bool
+	}
+
+	data := []testData{
+		{Heading{"", "", "", -1}, true},
+		{Heading{"Foo", "", "", -1}, true},
+		{Heading{"Foo", "", "", 0}, true},
+		{Heading{"Foo", "", "", 1}, true},
+		{Heading{"Foo", "", "foo", -1}, true},
+		{Heading{"Foo", "", "foo", 0}, true},
+
+		{Heading{"Foo", "", "foo", 1}, false},
+		{Heading{"`Foo`", "`Foo`", "foo", 1}, false},
+	}
+
+	logger := logrus.WithField("test", "true")
+
+	for i, d := range data {
+		doc := newDoc("foo", logger)
+
+		assert.Empty(doc.Headings)
+
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		err := doc.addHeading(d.heading)
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.NotEmpty(doc.Headings, msg)
+
+		name := d.heading.Name
+
+		result, ok := doc.Headings[name]
+		assert.True(ok, msg)
+
+		assert.Equal(d.heading, result, msg)
+	}
+}
+
+func TestDocAddLink(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		link        Link
+		expectError bool
+	}
+
+	data := []testData{
+		{Link{nil, "", "", "", -1}, true},
+		{Link{nil, "foo", "", "", unknownLink}, true},
+
+		{Link{nil, "foo", "", "", internalLink}, false},
+		{Link{nil, "http://google.com", "", "", urlLink}, false},
+		{Link{nil, "https://google.com", "", "", urlLink}, false},
+		{Link{nil, "mailto:me@somewhere.com", "", "", mailLink}, false},
+	}
+
+	logger := logrus.WithField("test", "true")
+
+	for i, d := range data {
+		doc := newDoc("foo", logger)
+
+		assert.Empty(doc.Links)
+
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		err := doc.addLink(d.link)
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.NotEmpty(doc.Links, msg)
+		addr := d.link.Address
+
+		result := doc.Links[addr][0]
+		assert.Equal(result, d.link)
+	}
+}
+
+func TestDocLinkAddrToPath(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+
+	cwd, err := os.Getwd()
+	assert.NoError(err)
+	defer os.Chdir(cwd)
+
+	err = os.Chdir(dir)
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	savedDocRoot := docRoot
+	docRoot = dir
+
+	defer func() {
+		docRoot = savedDocRoot
+
+	}()
+
+	mdFile := "bar.md"
+	mdPath := filepath.Join("/", mdFile)
+	actualMDPath := filepath.Join(dir, mdFile)
+
+	type testData struct {
+		linkAddr     string
+		expectedPath string
+		expectError  bool
+	}
+
+	data := []testData{
+		{"", "", true},
+		{"bar", "bar", false},
+		{"bar.md", "bar.md", false},
+		{mdPath, actualMDPath, false},
+	}
+
+	logger := logrus.WithField("test", "true")
+	doc := newDoc("foo", logger)
+
+	for i, d := range data {
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		result, err := doc.linkAddrToPath(d.linkAddr)
+
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.Equal(d.expectedPath, result)
+	}
+}

--- a/cmd/check-markdown/check.go
+++ b/cmd/check-markdown/check.go
@@ -112,10 +112,12 @@ func (d *Doc) checkLink(address string, link Link, checkOtherDoc bool) error {
 
 // check performs all checks on the document.
 func (d *Doc) check() error {
-	for name, link := range d.Links {
-		err := d.checkLink(name, link, false)
-		if err != nil {
-			return err
+	for name, linkList := range d.Links {
+		for _, link := range linkList {
+			err := d.checkLink(name, link, false)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/check-markdown/display.go
+++ b/cmd/check-markdown/display.go
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/Sirupsen/logrus"
+)
+
+var outputFile = os.Stdout
+
+// displayHandler is an interface that all output display handlers
+// (formatters) must implement.
+type DisplayHandler interface {
+	DisplayHeadings(d *Doc) error
+	DisplayLinks(d *Doc) error
+}
+
+// DisplayHandlers encapsulates the list of available display handlers.
+type DisplayHandlers struct {
+	handlers map[string]DisplayHandler
+}
+
+// handlers is a map of the available output format display handling
+// implementations.
+var handlers map[string]DisplayHandler
+
+// NewDisplayHandlers create a new DisplayHandler.
+func NewDisplayHandlers(tsvSeparator string, disableHeader bool) *DisplayHandlers {
+	separator := rune('\t')
+
+	if tsvSeparator != "" {
+		separator = rune(tsvSeparator[0])
+	}
+
+	if handlers == nil {
+		handlers = make(map[string]DisplayHandler)
+
+		handlers[textFormat] = NewDisplayText(outputFile)
+		handlers[tsvFormat] = NewDisplayTSV(outputFile, separator, disableHeader)
+	}
+
+	h := &DisplayHandlers{
+		handlers: handlers,
+	}
+
+	return h
+}
+
+// find looks for a display handler corresponding to the specified format
+func (d *DisplayHandlers) find(format string) DisplayHandler {
+	for f, handler := range d.handlers {
+		if f == format {
+			return handler
+		}
+	}
+
+	return nil
+}
+
+// Get returns a list of the available formatters (display handler names).
+func (d *DisplayHandlers) Get() []string {
+	var formats []string
+
+	for f := range d.handlers {
+		formats = append(formats, f)
+	}
+
+	sort.Strings(formats)
+
+	return formats
+}
+
+func show(inputFilename string, logger *logrus.Entry, handler DisplayHandler, what DataToShow) error {
+	var fn func(*Doc) error
+
+	switch what {
+	case showHeadings:
+		fn = handler.DisplayHeadings
+	case showLinks:
+		fn = handler.DisplayLinks
+	default:
+		return fmt.Errorf("unknown show option: %v", what)
+	}
+
+	doc := newDoc(inputFilename, logger)
+	doc.ListMode = true
+
+	err := doc.parse()
+	if err != nil {
+		return err
+	}
+
+	return fn(doc)
+}

--- a/cmd/check-markdown/display_text.go
+++ b/cmd/check-markdown/display_text.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+type displayText struct {
+	file *os.File
+}
+
+func NewDisplayText(file *os.File) DisplayHandler {
+	return &displayText{
+		file: file,
+	}
+}
+
+func (d *displayText) DisplayLinks(doc *Doc) error {
+	for _, linkList := range doc.Links {
+		for _, link := range linkList {
+			err := d.displayLink(link)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *displayText) displayLink(l Link) error {
+	_, err := fmt.Fprintf(d.file, "%+v\n", l)
+
+	return err
+}
+
+func (d *displayText) DisplayHeadings(doc *Doc) error {
+	for _, h := range doc.Headings {
+		err := d.displayHeading(h)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *displayText) displayHeading(h Heading) error {
+	_, err := fmt.Fprintf(d.file, "%+v\n", h)
+
+	return err
+}

--- a/cmd/check-markdown/display_tsv.go
+++ b/cmd/check-markdown/display_tsv.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"encoding/csv"
+	"os"
+)
+
+type displayTSV struct {
+	writer        *csv.Writer
+	disableHeader bool
+}
+
+func NewDisplayTSV(file *os.File, separator rune, disableHeader bool) DisplayHandler {
+	tsv := &displayTSV{
+		disableHeader: disableHeader,
+	}
+
+	tsv.writer = csv.NewWriter(file)
+
+	tsv.writer.Comma = separator
+
+	return tsv
+}
+
+func (d *displayTSV) DisplayLinks(doc *Doc) error {
+	if !d.disableHeader {
+		record := linkHeaderRecord()
+		if err := d.writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	for _, linkList := range doc.Links {
+		for _, link := range linkList {
+			record := linkToRecord(link)
+
+			if err := d.writer.Write(record); err != nil {
+				return err
+			}
+		}
+	}
+
+	d.writer.Flush()
+
+	return d.writer.Error()
+}
+
+func (d *displayTSV) DisplayHeadings(doc *Doc) error {
+	if !d.disableHeader {
+		record := headingHeaderRecord()
+		if err := d.writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	for _, l := range doc.Headings {
+		record := headingToRecord(l)
+
+		if err := d.writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	d.writer.Flush()
+
+	return d.writer.Error()
+}

--- a/cmd/check-markdown/doc.go
+++ b/cmd/check-markdown/doc.go
@@ -67,3 +67,10 @@ func (d *Doc) Errorf(format string, args ...interface{}) error {
 
 	return fmt.Errorf("file=%q: %s", d.Name, s)
 }
+
+// String "pretty-prints" the specified document
+//
+// Just display the name as that is enough in text output.
+func (d *Doc) String() string {
+	return d.Name
+}

--- a/cmd/check-markdown/doc.go
+++ b/cmd/check-markdown/doc.go
@@ -26,7 +26,7 @@ func newDoc(name string, logger *logrus.Entry) *Doc {
 	d := &Doc{
 		Name:     name,
 		Headings: make(map[string]Heading),
-		Links:    make(map[string]Link),
+		Links:    make(map[string][]Link),
 		Parsed:   false,
 		ShowTOC:  false,
 		Logger:   logger,

--- a/cmd/check-markdown/extract.go
+++ b/cmd/check-markdown/extract.go
@@ -7,6 +7,8 @@
 package main
 
 import (
+	"fmt"
+
 	bf "gopkg.in/russross/blackfriday.v2"
 )
 
@@ -42,32 +44,40 @@ func linkDescription(l *bf.Node) (string, error) {
 	return text, nil
 }
 
-// headingName extracts the heading name from the specified Heading node.
-func headingName(h *bf.Node) (string, error) {
-	if err := checkNode(h, bf.Heading); err != nil {
-		return "", err
+// headingName extracts the heading name from the specified Heading node in
+// plain text, and markdown. The latter is used for creating TOC's which need
+// to include the original markdown value.
+func headingName(h *bf.Node) (name, mdName string, err error) {
+	if err = checkNode(h, bf.Heading); err != nil {
+		return "", "", err
 	}
 
 	// A heading can be comprised of various elements so scan
 	// through them to build up the final value.
 
-	text := ""
 	node := h.FirstChild
 
 	for node != nil {
 		switch node.Type {
 		case bf.Code:
-			text += string(node.Literal)
+			value := string(node.Literal)
+
+			name += value
+			mdName += fmt.Sprintf("`%s`", value)
 		case bf.Text:
-			text += string(node.Literal)
+			value := string(node.Literal)
+
+			name += value
+			mdName += value
 		case bf.Link:
 			// yep, people do crazy things like adding links into titles!
 			descr, err := linkDescription(node)
 			if err != nil {
-				return "", err
+				return "", "", err
 			}
 
-			text += descr
+			name += descr
+			mdName += descr
 		default:
 			logger.WithField("node", node).Debug("ignoring node")
 		}
@@ -79,5 +89,5 @@ func headingName(h *bf.Node) (string, error) {
 		node = node.Next
 	}
 
-	return text, nil
+	return name, mdName, nil
 }

--- a/cmd/check-markdown/heading.go
+++ b/cmd/check-markdown/heading.go
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+// newHeading creates a new Heading.
+func newHeading(name, mdName, linkName string, level int) Heading {
+	return Heading{
+		Name:     name,
+		MDName:   mdName,
+		LinkName: linkName,
+		Level:    level,
+	}
+}

--- a/cmd/check-markdown/link.go
+++ b/cmd/check-markdown/link.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// newLink creates a new Link.
+func newLink(doc *Doc, address, description string) (Link, error) {
+	l := Link{
+		Doc:         doc,
+		Address:     address,
+		Description: description,
+	}
+
+	err := l.categorise()
+	if err != nil {
+		return Link{}, err
+	}
+
+	return l, nil
+}
+
+// categorise determines the type of Link.
+func (l *Link) categorise() error {
+	address := l.Address
+
+	// markdown file extension with optional link name ("#...")
+	const re = `\.md#*.*$`
+
+	pattern := regexp.MustCompile(re)
+
+	matched := pattern.MatchString(address)
+
+	if strings.HasPrefix(address, "http:") {
+		l.Type = urlLink
+	} else if strings.HasPrefix(address, "https:") {
+		l.Type = urlLink
+	} else if strings.HasPrefix(address, "mailto:") {
+		l.Type = mailLink
+	} else if strings.HasPrefix(address, anchorPrefix) {
+		l.Type = internalLink
+
+		// Remove the prefix to make a valid link address
+		address = strings.TrimPrefix(address, anchorPrefix)
+		l.Address = address
+	} else if matched {
+		l.Type = externalLink
+	} else {
+		// Link must be an external file, but not a markdown file.
+		l.Type = externalFile
+	}
+
+	return nil
+}

--- a/cmd/check-markdown/link.go
+++ b/cmd/check-markdown/link.go
@@ -7,6 +7,9 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -52,10 +55,68 @@ func (l *Link) categorise() error {
 		l.Address = address
 	} else if matched {
 		l.Type = externalLink
+
+		file, _, err := splitLink(address)
+		if err != nil {
+			return err
+		}
+
+		file, err = l.Doc.linkAddrToPath(file)
+		if err != nil {
+			return err
+		}
+
+		l.ResolvedPath = file
 	} else {
-		// Link must be an external file, but not a markdown file.
-		l.Type = externalFile
+		isREADME, err := l.handleImplicitREADME()
+		if err != nil {
+			return err
+		}
+
+		if !isREADME {
+			// Link must be an external file, but not a markdown file.
+			l.Type = externalFile
+		}
 	}
 
 	return nil
+}
+
+// handleImplicitREADME determines if the specified link is an implicit link
+// to a README document.
+func (l *Link) handleImplicitREADME() (isREADME bool, err error) {
+	const readme = "README.md"
+
+	address := l.Address
+	if address == "" {
+		return false, errors.New("need link address")
+	}
+
+	file, err := l.Doc.linkAddrToPath(address)
+	if err != nil {
+		return false, err
+	}
+
+	// The resolved path should exist as this is a local file.
+	st, err := os.Stat(file)
+	if err != nil {
+		return false, err
+	}
+
+	if !st.IsDir() {
+		return false, nil
+	}
+
+	// The file is a directory so try appending the implicit README file
+	// and see if that exists.
+	resolvedPath := filepath.Join(file, readme)
+
+	success := fileExists(resolvedPath)
+
+	if success {
+		l.Type = externalLink
+		l.ResolvedPath = resolvedPath
+	}
+
+	return success, nil
 }

--- a/cmd/check-markdown/link_test.go
+++ b/cmd/check-markdown/link_test.go
@@ -1,0 +1,210 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// createLinkAndCategorise will create a link and categorise it. If
+// createLinkManually is set, the link will be created "manually" (without the
+// constructor) and categorise() called. If not set, the constructor will be
+// used.
+func createLinkAndCategorise(assert *assert.Assertions, createLinkManually bool) {
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+
+	cwd, err := os.Getwd()
+	assert.NoError(err)
+	defer os.Chdir(cwd)
+
+	err = os.Chdir(dir)
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	readmeDirName := "dir-with-readme"
+	emptyDirName := "empty"
+	makeDirs(assert, dir, readmeDirName, emptyDirName)
+
+	readmeDirPath := filepath.Join(readmeDirName, readmeName)
+
+	topLevelReadmeName := "top-level.md"
+	topLevelReadmeLink := filepath.Join("/", topLevelReadmeName)
+
+	topLevelReadmePath := filepath.Join(dir, topLevelReadmeName)
+
+	type testData struct {
+		linkAddress string
+
+		expectedPath string
+
+		expectedType LinkType
+		expectError  bool
+
+		// Set if expectedPath should be checked
+		checkPath bool
+	}
+
+	docRoot = dir
+
+	data := []testData{
+		{"", "", -1, true, false},
+		{"a", "", -1, true, false},
+		{"a.b", "", -1, true, false},
+		{"a#b", "", -1, true, false},
+
+		{"htt://foo", "", -1, true, false},
+		{"HTTP://foo", "", -1, true, false},
+		{"moohttp://foo", "", -1, true, false},
+		{"mailto", "", -1, true, false},
+		{"http", "", -1, true, false},
+		{"https", "", -1, true, false},
+
+		{"http://foo", "", urlLink, false, false},
+		{"https://foo/", "", urlLink, false, false},
+		{"https://foo/bar", "", urlLink, false, false},
+		{"mailto:me", "", mailLink, false, false},
+
+		{".", "", externalFile, false, false},
+		{"/", "", externalFile, false, false},
+		{emptyDirName, "", externalFile, false, false},
+
+		{readmeDirName, readmeDirPath, externalLink, false, true},
+		{"foo.md", "foo.md", externalLink, false, true},
+		{"foo.md#bar", "foo.md", externalLink, false, true},
+		{topLevelReadmeLink, topLevelReadmePath, externalLink, false, true},
+	}
+
+	logger := logrus.WithField("test", "true")
+	description := ""
+
+	for i, d := range data {
+		var link Link
+		var err error
+
+		doc := newDoc("foo", logger)
+
+		if createLinkManually {
+			link = Link{
+				Doc:         doc,
+				Address:     d.linkAddress,
+				Description: description,
+			}
+
+			err = link.categorise()
+		} else {
+			link, err = newLink(doc, d.linkAddress, description)
+		}
+
+		msg := fmt.Sprintf("test[%d] manual-link: %v: %+v, link: %+v\n", i, createLinkManually, d, link)
+
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.NoError(err, msg)
+
+		assert.Equal(link.Doc, doc)
+		assert.Equal(link.Address, d.linkAddress)
+		assert.Equal(link.Description, description)
+		assert.Equal(link.Type, d.expectedType)
+
+		if d.checkPath {
+			assert.Equal(d.expectedPath, link.ResolvedPath)
+		}
+	}
+}
+
+func TestNewLink(t *testing.T) {
+	assert := assert.New(t)
+
+	createLinkAndCategorise(assert, false)
+}
+
+func TestLinkCategorise(t *testing.T) {
+	assert := assert.New(t)
+
+	createLinkAndCategorise(assert, true)
+}
+
+func TestLinkHandleImplicitREADME(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	cwd, err := os.Getwd()
+	assert.NoError(err)
+	defer os.Chdir(cwd)
+
+	err = os.Chdir(dir)
+	assert.NoError(err)
+	defer os.RemoveAll(dir)
+
+	readmeDirName := "dir-with-readme"
+	emptyDirName := "empty"
+	makeDirs(assert, dir, readmeDirName, emptyDirName)
+
+	readmePath := filepath.Join(readmeDirName, readmeName)
+
+	emptyFileName := "empty-file"
+
+	err = createFile(emptyFileName, "")
+	assert.NoError(err)
+
+	type testData struct {
+		linkAddr     string
+		isREADME     bool
+		expectError  bool
+		expectedType LinkType
+		expectedPath string
+	}
+
+	data := []testData{
+		{"", false, true, unknownLink, ""},
+		{"foo", false, true, unknownLink, ""},
+		{emptyFileName, false, false, unknownLink, ""},
+		{emptyDirName, false, false, unknownLink, ""},
+		{readmeDirName, true, false, externalLink, readmePath},
+	}
+
+	logger := logrus.WithField("test", "true")
+
+	for i, d := range data {
+		doc := newDoc("foo", logger)
+
+		link := Link{
+			Doc:     doc,
+			Address: d.linkAddr,
+		}
+
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		isREADME, err := link.handleImplicitREADME()
+
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.NoError(err, msg)
+		assert.Equal(isREADME, d.isREADME)
+		assert.Equal(isREADME, d.isREADME)
+		assert.Equal(link.Address, d.linkAddr)
+		assert.Equal(link.Type, d.expectedType)
+		assert.Equal(link.ResolvedPath, d.expectedPath)
+	}
+}

--- a/cmd/check-markdown/main.go
+++ b/cmd/check-markdown/main.go
@@ -112,8 +112,8 @@ func handleDoc(c *cli.Context) error {
 		return errNeedFile
 	}
 
-	createTOC := c.Bool("create-toc")
-	singleDocOnly := c.Bool("single-doc-only")
+	createTOC := c.GlobalBool("create-toc")
+	singleDocOnly := c.GlobalBool("single-doc-only")
 
 	doc := newDoc(fileName, logger)
 	doc.ShowTOC = createTOC
@@ -212,7 +212,6 @@ func realMain() error {
 	app.Description = "Tool to check GitHub-Flavoured Markdown (GFM) format documents"
 	app.Usage = app.Description
 	app.UsageText = fmt.Sprintf("%s [options] file ...", app.Name)
-	app.Action = handleDoc
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "create-toc, t",
@@ -234,6 +233,15 @@ func realMain() error {
 		cli.BoolFlag{
 			Name:  "strict, s",
 			Usage: "enable strict mode",
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:        "check",
+			Usage:       "Perform tests on the specified document",
+			Description: "Exit code denotes success",
+			Action:      handleDoc,
 		},
 	}
 

--- a/cmd/check-markdown/main.go
+++ b/cmd/check-markdown/main.go
@@ -37,6 +37,8 @@ var (
 	listPrefix = "*"
 
 	logger *logrus.Entry
+
+	errNeedFile = errors.New("need markdown file")
 )
 
 // Black Friday sometimes chokes on markdown (I know!!), so record how many
@@ -102,12 +104,12 @@ func handleDoc(c *cli.Context) error {
 	handleLogging(c)
 
 	if c.NArg() == 0 {
-		return errors.New("need markdown file")
+		return errNeedFile
 	}
 
 	fileName := c.Args().First()
 	if fileName == "" {
-		return errors.New("invalid markdown file")
+		return errNeedFile
 	}
 
 	createTOC := c.Bool("create-toc")

--- a/cmd/check-markdown/main.go
+++ b/cmd/check-markdown/main.go
@@ -100,7 +100,7 @@ func handleLogging(c *cli.Context) {
 	logger.Logger.SetLevel(logLevel)
 }
 
-func handleDoc(c *cli.Context) error {
+func handleDoc(c *cli.Context, createTOC bool) error {
 	handleLogging(c)
 
 	if c.NArg() == 0 {
@@ -112,7 +112,6 @@ func handleDoc(c *cli.Context) error {
 		return errNeedFile
 	}
 
-	createTOC := c.GlobalBool("create-toc")
 	singleDocOnly := c.GlobalBool("single-doc-only")
 
 	doc := newDoc(fileName, logger)
@@ -214,10 +213,6 @@ func realMain() error {
 	app.UsageText = fmt.Sprintf("%s [options] file ...", app.Name)
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "create-toc, t",
-			Usage: "display a markdown Table of Contents for the document",
-		},
-		cli.BoolFlag{
 			Name:  "debug, d",
 			Usage: "display debug information",
 		},
@@ -239,9 +234,20 @@ func realMain() error {
 	app.Commands = []cli.Command{
 		{
 			Name:        "check",
-			Usage:       "Perform tests on the specified document",
+			Usage:       "perform tests on the specified document",
 			Description: "Exit code denotes success",
-			Action:      handleDoc,
+			Action: func(c *cli.Context) error {
+				handleDoc(c, false)
+				return nil
+			},
+		},
+		{
+			Name:  "toc",
+			Usage: "display a markdown Table of Contents",
+			Action: func(c *cli.Context) error {
+				handleDoc(c, true)
+				return nil
+			},
 		},
 	}
 

--- a/cmd/check-markdown/node.go
+++ b/cmd/check-markdown/node.go
@@ -129,10 +129,12 @@ func (d *Doc) handleLink(node *bf.Node) error {
 // will ensure that "section-bar" exists in external file "foo.md".
 func handleIntraDocLinks() error {
 	for _, doc := range docs {
-		for addr, link := range doc.Links {
-			err := doc.checkLink(addr, link, true)
-			if err != nil {
-				return doc.Errorf("intra-doc link invalid: %v", err)
+		for addr, linkList := range doc.Links {
+			for _, link := range linkList {
+				err := doc.checkLink(addr, link, true)
+				if err != nil {
+					return doc.Errorf("intra-doc link invalid: %v", err)
+				}
 			}
 		}
 	}

--- a/cmd/check-markdown/node.go
+++ b/cmd/check-markdown/node.go
@@ -49,7 +49,7 @@ func (d *Doc) makeHeading(node *bf.Node) (Heading, error) {
 		return Heading{}, err
 	}
 
-	name, err := headingName(node)
+	name, mdName, err := headingName(node)
 	if err != nil {
 		return Heading{}, d.Errorf("failed to get heading name: %v", err)
 	}
@@ -58,6 +58,7 @@ func (d *Doc) makeHeading(node *bf.Node) (Heading, error) {
 
 	heading := Heading{
 		Name:     name,
+		MDName:   mdName,
 		LinkName: data.HeadingID,
 		Level:    data.Level,
 	}

--- a/cmd/check-markdown/parse.go
+++ b/cmd/check-markdown/parse.go
@@ -19,7 +19,7 @@ import (
 var errorList []error
 
 func (d *Doc) parse() error {
-	if !d.ShowTOC {
+	if !d.ShowTOC && !d.ListMode {
 		d.Logger.Info("Checking file")
 	}
 

--- a/cmd/check-markdown/record.go
+++ b/cmd/check-markdown/record.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import "fmt"
+
+func linkHeaderRecord() []string {
+	return []string{
+		"Document",
+		"Address",
+		"Path",
+		"Description",
+		"Type",
+	}
+}
+
+func linkToRecord(l Link) (record []string) {
+	record = append(record, l.Doc.Name)
+	record = append(record, l.Address)
+	record = append(record, l.ResolvedPath)
+	record = append(record, l.Description)
+	record = append(record, l.Type.String())
+
+	return record
+}
+
+func headingHeaderRecord() []string {
+	return []string{
+		"Name",
+		"Link",
+		"Level",
+	}
+}
+func headingToRecord(h Heading) (record []string) {
+	record = append(record, h.Name)
+	record = append(record, h.LinkName)
+	record = append(record, fmt.Sprintf("%d", h.Level))
+
+	return record
+}

--- a/cmd/check-markdown/stats.go
+++ b/cmd/check-markdown/stats.go
@@ -17,9 +17,11 @@ func (d *Doc) showStats() {
 
 	linkCount := 0
 
-	for _, link := range d.Links {
-		counters[link.Type]++
-		linkCount++
+	for _, linkList := range d.Links {
+		for _, link := range linkList {
+			counters[link.Type]++
+			linkCount++
+		}
 	}
 
 	fields := logrus.Fields{

--- a/cmd/check-markdown/toc.go
+++ b/cmd/check-markdown/toc.go
@@ -52,7 +52,7 @@ func (d *Doc) displayTOCEntryFromHeading(heading Heading) error {
 		prefix = strings.Repeat(" ", level*indentSpaces)
 	}
 
-	entry := fmt.Sprintf("[%s](%s%s)", heading.Name, anchorPrefix, heading.LinkName)
+	entry := fmt.Sprintf("[%s](%s%s)", heading.MDName, anchorPrefix, heading.LinkName)
 
 	fmt.Printf("%s%s %s\n", prefix, listPrefix, entry)
 

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -109,8 +109,9 @@ type Doc struct {
 	Headings map[string]Heading
 
 	// Key: link address
-	// Value: Link
-	Links map[string]Link
+	// Value: *list* of links. Required since you can have multiple links with
+	// the same _address_, but of a different type.
+	Links map[string][]Link
 
 	// true when this document has been fully parsed
 	Parsed bool

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -47,14 +47,15 @@ func (t LinkType) String() string {
 //
 // Example: A heading like this:
 //
-//    ### This is a heading
+//    ### This is a `verbatim` heading
 //
 // ... would be described as:
 //
 // ```go
 // Heading{
-//   Name:     "This is a heading",
-//   LinkName: "this-is-a-heading",
+//   Name:     "This is a verbatim heading",
+//   MDName    "This is a `verbatim` heading",
+//   LinkName: "this-is-a-verbatim-heading",
 //   Level:    3,
 // }
 // ```
@@ -62,6 +63,9 @@ type Heading struct {
 	// Not strictly necessary since the name is used as a hash key.
 	// However, storing here too makes the code simpler ;)
 	Name string
+
+	// Name including any markdown syntax
+	MDName string
 
 	// The encoded value of Name.
 	LinkName string

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -12,6 +12,7 @@ import "github.com/Sirupsen/logrus"
 type LinkType int
 
 const (
+	unknownLink   LinkType = iota
 	internalLink  LinkType = iota
 	externalLink  LinkType = iota // External ".md" file
 	externalFile  LinkType = iota // External non-".md" file
@@ -21,9 +22,11 @@ const (
 )
 
 func (t LinkType) String() string {
-	name := "unknown"
+	var name string
 
 	switch t {
+	case unknownLink:
+		name = "unknown"
 	case internalLink:
 		name = "internal-link"
 	case externalLink:

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -91,6 +91,11 @@ type Heading struct {
 // }
 // ```
 type Link struct {
+	// Document this link refers to.
+	Doc *Doc
+
+	// Original address from document.
+	//
 	// Must be a valid Heading.LinkName.
 	//
 	// Not strictly necessary since the address is used as a hash key.

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -148,5 +148,7 @@ type Doc struct {
 	// if true, only show the Table Of Contents
 	ShowTOC bool
 
+	ListMode bool
+
 	Logger *logrus.Entry
 }

--- a/cmd/check-markdown/types.go
+++ b/cmd/check-markdown/types.go
@@ -85,9 +85,24 @@ type Heading struct {
 //
 // ```go
 // Link{
-//   Address:     "internal-section-name",
-//   Description: "internal link",
-//   Type:        internalLink,
+//   Address:      "internal-section-name",
+//   ResolvedPath: "",
+//   Description:  "internal link",
+//   Type:         internalLink,
+// }
+//
+// And a link like this:
+//
+//     [external link](/foo.md#section-name)
+//
+// ... would be described as:
+//
+// ```go
+// Link{
+//   Address:      "foo.md#section-name",
+//   ResolvedPath: "/docroot/foo.md",
+//   Description:  "external link",
+//   Type:         externalLink,
 // }
 // ```
 type Link struct {
@@ -101,6 +116,11 @@ type Link struct {
 	// Not strictly necessary since the address is used as a hash key.
 	// However, storing here too makes the code simpler ;)
 	Address string
+
+	// The fully expanded address, without any anchor and heading suffix.
+	//
+	// Only applies to certain link types.
+	ResolvedPath string
 
 	// The text the user sees for the hyperlink address
 	Description string


### PR DESCRIPTION
Add a new test to the CI static check script to look for markdown documents that are not referenced by any other. With a small number of exceptions, most markdown files should be linked to from other markdown documents in the same repository to allow all in-repository documentation to be discovered by link navigation.

This check necessitated updating the markdown check tool to dump all links - see the updated `README` for details.

Fixes: #1588.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>