### PR TITLE
CI: Sort files for comm(1)

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -197,11 +197,11 @@ check_go()
 	# repositories, we assume they are tested independently in their
 	# repository so do not need to be re-tested here.
 	submodule_packages=$(mktemp)
-	git submodule -q foreach "go list ./..." > "$submodule_packages" || true
+	git submodule -q foreach "go list ./..." | sort > "$submodule_packages" || true
 
 	# all packages
 	all_packages=$(mktemp)
-	go list ./... > "$all_packages" || true
+	go list ./... | sort > "$all_packages" || true
 
 	# List of packages to consider which is defined as:
 	#


### PR DESCRIPTION
Files passed to `comm(1)` must be sorted.

Fixes: #1614.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>