### PR TITLE
tests: Add k8s test for a replicationcontroller

### DIFF
--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	get_pod_config_dir
+}
+
+@test "Replication controller" {
+	replication_name="replicationtest"
+	number_of_replicas="1"
+	wait_time=20
+	sleep_time=2
+
+	# Create replication controller
+	kubectl create -f "${pod_config_dir}/replication-controller.yaml"
+
+	# Check replication controller
+	kubectl describe replicationcontrollers/"$replication_name" | grep "replication-controller"
+
+	# Check pod creation
+	pod_name=$(kubectl get pods --output=jsonpath={.items..metadata.name})
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+	# Check number of pods created for the
+	# replication controller is equal to the
+	# number of replicas that we defined
+	launched_pods=$(echo $pod_name | wc -l)
+
+	[ "$launched_pods" -eq "$number_of_replicas" ]
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+	kubectl delete rc "$replication_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -24,6 +24,7 @@ systemctl is-active --quiet docker || sudo systemctl start docker
 
 pushd "$kubernetes_dir"
 ./init.sh
+bats k8s-replication.bats
 bats nginx.bats
 bats k8s-uts+ipc-ns.bats
 bats k8s-env.bats

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: replicationtest
+spec:
+  replicas: 1
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: nginxtest
+        image: nginx
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This tests uses a kubernetes replicationcontroller that ensures
that a specified number of pod replicas are launched.

Fixes #1618

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>