### PR TITLE
ci: fix manage-ctr-mgr.sh to handle docker 18.09

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -117,7 +117,8 @@ install_docker(){
 			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"
 			sudo yum-config-manager --add-repo "$repo_url"
 			sudo yum makecache
-			docker_version_full=$(yum --showduplicate list "$pkg_name" | grep "$docker_version" | awk '{print $2}' | tail -1)
+			docker_version_full=$(yum --showduplicate list "$pkg_name" | \
+				grep "$docker_version" | awk '{print $2}' | tail -1 | cut -d':' -f2)
 			sudo -E yum -y install "${pkg_name}-${docker_version_full}"
 		elif [ "$ID" == "debian" ]; then
 			sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common


### PR DESCRIPTION
Fix `manage-ctr-mgr.sh` to be able to correctly parse
the full version of docker 18.09.

Fixes: #1622.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>