### PR TITLE
tests: Add k8s test for port forwarding to access redis application

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -55,6 +55,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[gnu_parallel_dependencies]="perl bzip2 make" \
 	[libsystemd]="systemd-devel" \
+	[redis]="redis" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -34,6 +34,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[gnu_parallel]="parallel" \
 	[libsystemd]="libsystemd-dev"\
+	[redis]="redis-server" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -31,6 +31,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[gnu_parallel]="parallel" \
 	[libsystemd]="systemd-devel" \
+	[redis]="redis" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -30,6 +30,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[gnu_parallel]="gnu_parallel" \
 	[libsystemd]="systemd-devel" \
+	[redis]="redis" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -39,6 +39,7 @@ declare -A packages=(
 	[haveged]="haveged" \
 	[gnu_parallel_dependencies]="perl bzip2 make" \
         [libsystemd]="systemd-devel" \
+	[redis]="redis" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -42,6 +42,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
  	[gnu_parallel]="gnu_parallel" \
 	[libsystemd]="systemd-devel" \
+	[redis]="redis" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -35,6 +35,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[gnu_parallel]="parallel" \
 	[libsystemd]="libsystemd-dev" \
+	[redis]="redis-server" \
 )
 
 pkgs_to_install=${packages[@]}

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	get_pod_config_dir
+}
+
+@test "Port forwarding" {
+	deployment_name="redis-master"
+
+	# Create deployment
+	kubectl apply -f "${pod_config_dir}/redis-master-deployment.yaml"
+
+	# Check deployment
+	kubectl wait --for=condition=Available deployment/"$deployment_name"
+	kubectl expose deployment/"$deployment_name"
+
+	# Get pod name
+	pod_name=$(kubectl get pods --output=jsonpath={.items..metadata.name})
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# View replicaset
+	kubectl get rs
+
+	# Create service
+	kubectl apply -f "${pod_config_dir}/redis-master-service.yaml"
+
+	# Check service
+	kubectl get svc | grep redis
+
+	# Check redis service
+	port_redis=$(kubectl get pods $pod_name --template='{{(index (index .spec.containers 0).ports 0).containerPort}}{{"\n"}}')
+
+	# Verify that redis is running in the pod and listening on port
+	port=6379
+	[ "$port_redis" -eq "$port" ]
+
+	# Forward a local port to a port on the pod
+	(2&>1 kubectl port-forward "$pod_name" 7000:"$port"> /dev/null) &
+
+	# Run redis-cli
+	retries="10"
+	ok="0"
+
+	for _ in $(seq 1 "$retries"); do
+		if sudo -E redis-cli ping | grep -q "PONG" ; then
+			ok="1"
+			break;
+		fi
+		sleep 1
+	done
+
+	[ "$ok" -eq "1" ]
+}
+
+teardown() {
+	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
+	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -27,6 +27,7 @@ pushd "$kubernetes_dir"
 bats nginx.bats
 bats k8s-uts+ipc-ns.bats
 bats k8s-env.bats
+bats k8s-port-forward.bats
 bats k8s-empty-dirs.bats
 bats k8s-limit-range.bats
 bats k8s-credentials-secrets.bats

--- a/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      runtimeClassName: kata
+      containers:
+      - name: master
+        image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/integration/kubernetes/runtimeclass_workloads/redis-master-service.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/redis-master-service.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    role: master
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend


### PR DESCRIPTION
This test kubectl port-forward to connect to a Redis server
running in a Kubernetes cluster.

Fixes #1625

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>