### PR TITLE
cri-o: Skip "aditional devices permissions" test

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -12,4 +12,5 @@ declare -a skipCRIOTests=(
 'test "ctr stats output"'
 'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
 'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
+'test "additional devices permissions"'
 );


### PR DESCRIPTION
Skip test as we do not have support for device cgroups.

Fixes: #1627.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>