### PR TITLE
kata-manager: improve openSUSE install support

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -358,7 +358,7 @@ cmd_remove_packages()
 	info "removing packages"
 
 	case "$distro" in
-		centos|fedora|opensuse*|rhel|sles)
+		centos|fedora|opensuse|rhel|sles)
 			packages=$(rpm -qa|egrep "${packages_regex}" || true)
 			;;
 
@@ -389,7 +389,7 @@ cmd_remove_packages()
 				centos|rhel) sudo yum versionlock delete "$pkg" &>/dev/null || true ;;
 				debian|ubuntu) sudo apt-mark unhold "$pkg" &>/dev/null || true ;;
 				fedora) sudo dnf versionlock delete "$pkg" &>/dev/null || true ;;
-				opensuse*|sles) sudo zypper removelock "$pkg" &>/dev/null || true ;;
+				opensuse|sles) sudo zypper removelock "$pkg" &>/dev/null || true ;;
 			esac
 		done
 	fi
@@ -398,7 +398,7 @@ cmd_remove_packages()
 		centos|rhel) sudo yum -y remove $packages ;;
 		debian|ubuntu) sudo apt-get -y remove $packages ;;
 		fedora) sudo dnf -y remove $packages ;;
-		opensuse*|sles) sudo zypper remove -y $packages ;;
+		opensuse|sles) sudo zypper remove -y $packages ;;
 	esac
 }
 
@@ -429,7 +429,11 @@ cmd_reset_config()
 setup()
 {
 	source /etc/os-release || source /usr/lib/os-release
-	distro=$ID
+
+	case "$ID" in
+		opensuse*) distro="opensuse" ;;
+		*)         distro="$ID" ;;
+	esac
 
 	kata_repos_base=$(go env GOPATH 2>/dev/null || true)
 	if [ -z "$kata_repos_base" ]; then


### PR DESCRIPTION
Improve kata-manager support for openSUSE, so that installation of Kata
& Docker packages can be done on different openSUSE versions.

Fixes: #1630

Signed-off-by: Marco Vedovati <mvedovati@suse.com>