### PR TITLE
git: check if git is capable of shallow cloning

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -297,3 +297,25 @@ build_install_parallel() {
 
 	rm -rf "$gnu_parallel_dir" "$gnu_parallel_tar_pkg"
 }
+
+check_git_version() {
+	result="true"
+
+        local required_version_major=$(echo "$1" | cut -d. -f1)
+        local required_version_medium=$(echo "$1" | cut -d. -f2)
+        local required_version_minor=$(echo "$1" | cut -d. -f3)
+
+        local git_version=$(git version | cut -d' ' -f3)
+        [ -n "${git_version}" ] || die "cannot determine git version, please ensure it is installed"
+
+        local current_version_major=$(echo "${git_version}" | cut -d. -f1)
+        local current_version_medium=$(echo "${git_version}" | cut -d. -f2)
+        local current_version_minor=$(echo "${git_version}" | cut -d. -f3)
+
+        [[ ${current_version_major} -lt ${required_version_major} ]] || \
+        [[ ( ${current_version_major} -eq ${required_version_major} ) && ( ${current_version_medium} -lt ${required_version_medium} ) ]] || \
+        [[ ( ${current_version_major} -eq ${required_version_major} ) && ( ${current_version_medium} -eq ${required_version_medium} ) && ( ${current_version_minor} -lt ${required_version_minor} ) ]] && \
+        result="false"
+
+	echo "${result}"
+}


### PR DESCRIPTION
This PR is following #1555, we hit a [issue](https://github.com/kata-containers/tests/pull/1555#issuecomment-492595005) there, git v2.7.4 is the latest on Ubuntu 16.04, and option `--shallow-submodules` was introduced in git v2.9.0, which means that for now, shallow clone will not be working well on Ubuntu 16.04.
So we need to check git version firstly before using the shallow clone.

Fixes: #1638

Signed-off-by: Penny Zheng <penny.zheng@arm.com>