### PR TITLE
check-markdown: Fix heading links

### DIFF
--- a/cmd/check-markdown/heading.go
+++ b/cmd/check-markdown/heading.go
@@ -6,12 +6,31 @@
 
 package main
 
+import "fmt"
+
 // newHeading creates a new Heading.
-func newHeading(name, mdName, linkName string, level int) Heading {
+func newHeading(name, mdName string, level int) (Heading, error) {
+	if name == "" {
+		return Heading{}, fmt.Errorf("heading name cannot be blank")
+	}
+
+	if mdName == "" {
+		return Heading{}, fmt.Errorf("heading markdown name cannot be blank")
+	}
+
+	linkName, err := createHeadingID(name)
+	if err != nil {
+		return Heading{}, err
+	}
+
+	if level < 1 {
+		return Heading{}, fmt.Errorf("level needs to be atleast 1")
+	}
+
 	return Heading{
 		Name:     name,
 		MDName:   mdName,
 		LinkName: linkName,
 		Level:    level,
-	}
+	}, nil
 }

--- a/cmd/check-markdown/heading_test.go
+++ b/cmd/check-markdown/heading_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHeading(t *testing.T) {
+	assert := assert.New(t)
+
+	type testData struct {
+		headingName      string
+		mdName           string
+		level            int
+		expectError      bool
+		expectedLinkName string
+	}
+
+	data := []testData{
+		{"", "", -1, true, ""},
+		{"a", "", -1, true, ""},
+		{"a", "a", -1, true, ""},
+		{"a", "a", 0, true, ""},
+		{"a", "", 1, true, ""},
+
+		{"a", "a", 1, false, "a"},
+		{"a-b", "`a-b`", 1, false, "a-b"},
+		{"a_b", "`a_b`", 1, false, "a_b"},
+		{"foo (json) bar", "foo `(json)` bar", 1, false, "foo-json-bar"},
+		{"func(json)", "`func(json)`", 1, false, "funcjson"},
+		{"?", "?", 1, false, ""},
+		{"a b", "a b", 1, false, "a-b"},
+		{"a - b", "a - b", 1, false, "a---b"},
+		{"a - b?", "a - b?", 1, false, "a---b"},
+		{"a - b.", "a - b.", 1, false, "a---b"},
+		{"a:b", "a:b", 1, false, "ab"},
+		{"a;b", "a;b", 1, false, "ab"},
+		{"a@b", "a@b", 1, false, "ab"},
+		{"a+b", "a+b", 1, false, "ab"},
+		{"a,b", "a,b", 1, false, "ab"},
+	}
+
+	for i, d := range data {
+		msg := fmt.Sprintf("test[%d]: %+v\n", i, d)
+
+		h, err := newHeading(d.headingName, d.mdName, d.level)
+		if d.expectError {
+			assert.Error(err, msg)
+			continue
+		}
+
+		assert.Equal(h.Name, d.headingName, msg)
+		assert.Equal(h.MDName, d.mdName, msg)
+		assert.Equal(h.Level, d.level, msg)
+		assert.Equal(h.LinkName, d.expectedLinkName, msg)
+	}
+}

--- a/cmd/check-markdown/main.go
+++ b/cmd/check-markdown/main.go
@@ -156,7 +156,7 @@ func handleDoc(c *cli.Context, createTOC bool) error {
 	}
 
 	if singleDocOnly && len(docs) > 1 {
-		doc.Logger.Debug("Not checking referenced files as user request")
+		doc.Logger.Debug("Not checking referenced files at user request")
 		return nil
 	}
 

--- a/cmd/check-markdown/node.go
+++ b/cmd/check-markdown/node.go
@@ -53,7 +53,10 @@ func (d *Doc) makeHeading(node *bf.Node) (Heading, error) {
 
 	data := node.HeadingData
 
-	heading := newHeading(name, mdName, data.HeadingID, data.Level)
+	heading, err := newHeading(name, mdName, data.Level)
+	if err != nil {
+		return Heading{}, err
+	}
 
 	return heading, nil
 }

--- a/cmd/check-markdown/parse.go
+++ b/cmd/check-markdown/parse.go
@@ -41,7 +41,7 @@ func (d *Doc) parseMarkdown() error {
 		return err
 	}
 
-	md := bf.New(bf.WithExtensions(bf.CommonExtensions | bf.AutoHeadingIDs))
+	md := bf.New(bf.WithExtensions(bf.CommonExtensions))
 
 	root := md.Parse(bytes)
 


### PR DESCRIPTION
Don't rely on the blackfriday package for generating heading IDs (used by the `toc` command) as although they are correct for generic markdown, they are not always correct when dealing with GFM [1].

Instead, use our own function which understands GitHub better.

Also added new tests.

[1] - https://github.github.com/gfm

Fixes: #1640.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>