### PR TITLE
GitHub label changes

### DIFF
--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -361,6 +361,11 @@ labels:
     category: vendor
     color: DEFAULT_COLOUR
 
+  - name: needs-review
+    description: Needs to be assessed by the team.
+    category: team
+    color: 00ff00
+
   - name: needs-unit-tests
     description: Needs new unit tests to validate behaviour in this repository
     category: test

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -209,7 +209,7 @@ labels:
   - name: bug
     description: Incorrect behaviour
     category: type
-    color: DEFAULT_COLOUR
+    color: ff0000
 
   - name: cannot-reproduce
     description: Issue cannot be recreated


### PR DESCRIPTION
Added a new `needs-triage` label. The idea is that the new GitHub issue templates can all add this label when issues are created. The Triage Team will then review the new issues, add any missing labels and
*remove* the `needs-triage` label. The `needs-triage` label thus provides a simple way to identify issues
that have not been looked at yet.

Also changed the `bug` label to red.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>