### PR TITLE
static-checks: recursively remove tmp files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -117,7 +117,7 @@ EOT
 }
 
 function remove_tmp_files() {
-	rm -f "${files_to_remove[@]}"
+	rm -rf "${files_to_remove[@]}"
 }
 
 # Convert a golang package to a full path


### PR DESCRIPTION
Some of the temporary files are directories, so we need
to use `rm -r` to delete them.

Fixes: #1652.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>