### PR TITLE
tests: Add K8s test for health checks

### DIFF
--- a/integration/kubernetes/k8s-health-checks.sh
+++ b/integration/kubernetes/k8s-health-checks.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	get_pod_config_dir
+}
+
+@test "Health checks" {
+	pod_name="hctest"
+	bad_pod_name="badhctest"
+	wait_time=120
+	sleep_time=2
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-health.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout="$wait_time"s pod "$pod_name"
+
+	# Check pod status
+	cmd="kubectl describe pod $pod_name | grep 'Started container'"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+	# Create a bad pod
+	kubectl create -f "${pod_config_dir}/pod-bad-health.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout="$wait_time"s pod "$pod_name"
+
+	# Check bad pod status
+	cmd="kubectl describe pod $bad_pod_name | grep Unhealthy"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+}
+
+teardown() {
+	kubectl delete pod "$pod_name" "$bad_pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -44,6 +44,7 @@ bats k8s-qos-pods.bats
 bats k8s-pod-quota.bats
 bats k8s-sysctls.bats
 bats k8s-volume.bats
+bats k8s-health-checks.sh
 bats k8s-projected-volume.bats
 bats k8s-memory.bats
 bats k8s-block-volume.bats

--- a/integration/kubernetes/runtimeclass_workloads/pod-bad-health.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-bad-health.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badhctest
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: test
+    image: mhausenblas/simpleservice:0.5.0
+    ports:
+    - containerPort: 9876
+# Here the container in the time range 1 to
+# 4 sec does not return a healthy code
+    env:
+    - name: HEALTH_MIN
+      value: "1000"
+    - name: HEALTH_MAX
+      value: "4000"
+    livenessProbe:
+      initialDelaySeconds: 2
+      periodSeconds: 5
+      httpGet:
+        path: /health
+        port: 9876

--- a/integration/kubernetes/runtimeclass_workloads/pod-health.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-health.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hctest
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: test
+    image: mhausenblas/simpleservice:0.5.0
+    ports:
+    - containerPort: 9876
+    livenessProbe:
+      initialDelaySeconds: 2
+      periodSeconds: 5
+      httpGet:
+        path: /health
+        port: 9876


### PR DESCRIPTION
This adds a kubernetes test to verify a container in a pod is healthy by
using the health checking mechanisms.

Fixes #1663

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>