### PR TITLE
ci: Use virtio-block as block storage driver

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -118,3 +118,10 @@ if [ "$KATA_EXPERIMENTAL_FEATURES" = true ]; then
 	feature="newstore"
 	sudo sed -i -e "s|^experimental.*$|experimental=[ \"$feature\" ]|" "${runtime_config_path}"
 fi
+
+# Enable virtio-blk device driver only for ubuntu with initrd for this moment
+# see https://github.com/kata-containers/tests/issues/1603
+if [ "$ID" == ubuntu ] && [ x"${TEST_INITRD}" == x"yes" ] && [ "$VERSION_ID" != "16.04" ]; then
+	echo "Set virtio-blk as the block device driver on $ID"
+	sudo sed -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
+fi


### PR DESCRIPTION
This will enable virtio-blk as a block storage driver in
ubuntu 18.04 with INITRD.

Fixes #1603

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>