### PR TITLE
Update GitHub labels

### DIFF
--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -55,6 +55,10 @@ categories:
       How the issue affect the operation of the system. A more precise version
       of regression.
 
+  - name: block
+    description: |
+      Stop a PR from being merged.
+
   - name: cleanup
     description: Refactoring, restructuring or general tidy-up needed.
 
@@ -240,6 +244,11 @@ labels:
     description: Highlight a feature that will soon be removed
     category: cleanup
     color: DEFAULT_COLOUR
+
+  - name: do-not-merge
+    description: PR has problems or depends on another
+    category: block
+    color: ff0000
 
   - name: duplicate
     description: Same issue as one already reported
@@ -529,6 +538,11 @@ labels:
     description: Part of the system is not stable
     category: behaviour
     color: DEFAULT_COLOUR
+
+  - name: wip
+    description: Work in Progress (PR incomplete - needs more work or rework)
+    category: block
+    color: ff0000
 
   - name: wont-fix
     description: Issue will not be fixed (not a good use of limited resources)

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -270,7 +270,6 @@ labels:
     description: Very urgent issue (resolve quickly)
     category: priority
     color: ff7f00
-    from: P2
 
   - name: high-severity
     description: Very important issue
@@ -281,7 +280,6 @@ labels:
     description: Critically urgent issue (must be resolved as soon as possible)
     category: priority
     color: ff0000
-    from: P1
 
   - name: highest-severity
     description: Extremely important issue
@@ -302,7 +300,6 @@ labels:
     description: Urgent issue (resolve before unprioritised issues)
     category: priority
     color: ffff00
-    from: P3
 
   - name: medium-severity
     description: Important issue


### PR DESCRIPTION
Add the missing labels `wip` and `do-not-merge` which got dropped from the new set of GitHub labels.

Also removed the old `from:` entries which no longer apply since we've now moved to the new set of labels.

Fixes: #1669.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>