### PR TITLE
tests: Modify vsock test to not use `journalctl -g`

### DIFF
--- a/integration/docker/vsock_test.go
+++ b/integration/docker/vsock_test.go
@@ -57,11 +57,11 @@ var _ = Describe("vsock test", func() {
 			Expect(exitCode).To(BeZero())
 
 			cmd := NewCommand("journalctl", "-e", "-q", "-b", "-n", "10",
-				"-t", DefaultShim+"-shim", "-g", "source=agent")
+				"-t", DefaultShim+"-shim")
 			stdout, stderr, exitCode = cmd.Run()
 			Expect(exitCode).To(BeZero())
 			Expect(stderr).To(BeEmpty())
-			Expect(stdout).NotTo(BeEmpty())
+			Expect(stdout).To(ContainSubstring("source=agent"))
 		})
 	})
 })


### PR DESCRIPTION
`journalctl -g` does not work properly on some linux distributions,
like ubuntu or centos.

Modify the test to search for `source=agent` using gomega matcher.

Fixes: #1671.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>