### PR TITLE
metrics: update slave bounds check values for memory footprint ksm

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 55879.5
+midval = 56088.5
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
Once that https://github.com/kata-containers/tests/pull/1646 lands, we
need to update the current values for the memory footprint ksm to work
with QEMU 4.

Based on the results of jenkins builds for QEMU 4 the test
repo: https://github.com/kata-containers/tests/issues/1646

Set new bound values:
ksm 56088.5m

Fixes #1676

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>