### PR TITLE
ci: static tests: golangci: do not run golangci self tests

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -236,7 +236,10 @@ check_go()
 		local linter_version=$(get_test_version "externals.golangci-lint.version")
 
 		info "Forcing ${linter} version ${linter_version}"
-		build_version ${linter_url} "" ${linter_version}
+		build_version ${linter_url} "build" ${linter_version}
+		# golangci build only target does not install into ${GOPATH}/bin
+		# Hand install it...
+		go install -v "${linter_url}/..."
 	fi
 
 	local linter_args="run -c ${cidir}/.golangci.yml"


### PR DESCRIPTION
A default 'make' of golangci will run all its own testsuite after
it has done a build. That takes minutes, and we probably don't
need to test that the tester itself is OK. Skip the tests and
go directly to a 'build' build.

Fixes: #1683

Signed-off-by: Graham Whaley <graham.whaley@intel.com>