### PR TITLE
tests: Update nginx image for kubernetes test

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: handlers-container
-    image: nginx
+    image: "${nginx_version}"
     lifecycle:
       postStart:
         exec:

--- a/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -20,6 +20,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginx
-        image: nginx:1.14
+        image: "${nginx_version}"
         ports:
         - containerPort: 80

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -20,6 +20,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginxtest
-        image: nginx
+        image: "${nginx_version}"
         ports:
         - containerPort: 80

--- a/versions.yaml
+++ b/versions.yaml
@@ -33,7 +33,7 @@ docker_images:
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
-    version: "1.14"
+    version: "1.17.0-alpine"
 
 externals:
   description: "Third-party projects used specifically for testing"


### PR DESCRIPTION
This will update to unify all kubernetes tests to use the same nginx
image instead of different versions. This also updates to use
nginx:alpine-1.17.0 image which has a size of 23.6MB and will reduce the
current image download size.

Fixes #1693

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>