### PR TITLE
optimise k8s images

### DIFF
--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -48,8 +48,10 @@ setup() {
 	# Verify persistent volume claim is bound
 	kubectl get pvc | grep "Bound"
 
+	# Add the e2fsprogs package to get mkfs.ext4 installed
+	kubectl exec "$pod_name" -- sh -c "apk add --no-cache e2fsprogs"
 	# make fs, mount device and write on it
-	kubectl exec "$pod_name" -- sh -c "mkfs -t ext4 $ctr_dev_path"
+	kubectl exec "$pod_name" -- sh -c "mkfs.ext4 $ctr_dev_path"
 	ctr_mount_path="/mnt"
 	ctr_message="Hello World"
 	ctr_file="${ctr_mount_path}/file.txt"

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -4,18 +4,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+#
+# Test that IP addresses/connections of PODS are routed/exposed correctly 
+# via a loadbalancer service.
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-
-# Saves the ip addresses
-declare -a IP_ADDRESSES
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
 	deployment="hello-world"
 	service="my-service"
-	port="8080"
 	get_pod_config_dir
 }
 
@@ -30,33 +29,26 @@ setup() {
 	cmd="kubectl wait --for=condition=Available deployment/${deployment}"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
-	# Get deployment
-	kubectl get deployments ${deployment}
-
-	# Describe deployment
-	kubectl describe deployments ${deployment}
-
-	# Display information about ReplicaSet objects
-	kubectl get replicasets
-	kubectl describe replicasets
-
-	# Expose deployment
-	kubectl expose deployment/${deployment} --type=LoadBalancer --name=${service}
-
-	# Get service
-	kubectl get services ${service}
-	kubectl describe services ${service}
-
 	# Check pods are running
 	cmd="kubectl get pods -o jsonpath='{.items[*].status.phase}' | grep Running"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
-	# Verify pods IP Addresses
-	IP_ADDRESSES=$(kubectl get pods -o jsonpath='{.items[*].status.podIP}')
+	# Expose deployment
+	kubectl expose deployment/${deployment} --type=LoadBalancer --name=${service}
 
-	for i in ${IP_ADDRESSES[@]}; do
-		curl http://$i:$port | grep "Hello Kubernetes"
-	done
+	# There appears to be no easy way to formally wait for a loadbalancer service
+	# to become 'ready' - there is no service.status.condition field to wait on.
+
+	# Now obtain the local IP:port pair of the loadbalancer service and ensure
+	# we can curl from it, and get the expected result
+	svcip=$(kubectl get service ${service} -o=json | jq '.spec.clusterIP' | sed 's/"//g')
+	svcport=$(kubectl get service ${service} -o=json | jq '.spec.ports[].port')
+	# And check we can curl the expected response from that IP address
+	curl http://$svcip:$svcport | grep "Hello, world!"
+
+	# NOTE - we do not test the 'public IP' address of the node balancer here as
+	# that may not be set up, as it may require an IP/DNS allocation and local
+	# routing and firewall rules to access.
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app: hello-world
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: hello-world
-        image: gcr.io/google-samples/node-hello:1.0
+        image: gcr.io/google-samples/hello-app:1.0
         ports:
         - containerPort: 8080

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -6,7 +6,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: my-container
-      image: debian
+      image: alpine
       command: ["tail", "-f", "/dev/null"]
       volumeDevices:
         - devicePath: DEVICE_PATH


### PR DESCRIPTION
Some of our k8s test container images were using some heavyweight items, that can be replaced by lighter ones. This saves us both time and space/cost in the CI.

- swap out debian for alpine
- swap out node-hello for hello-world

On my local tests this:
- trimmed the total image download size for the integration/k8s tests from 1.8g to 1.0g
- took the total time (including bringup and teardown lf the cluster) from 11m25s to 9m43s
