### PR TITLE
metrics: Adjust check values for memory footprint ksm

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 56088.5
+midval = 56366.5
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
We need to increase the check values for memory footprint ksm as
we have recent failures in the metrics CI. With the data
gathered at http://jenkins.katacontainers.io/job/kata-metrics-tests-ubuntu-16-04-PR/,
we can see that we need to set the bound values to:
ksm 56366.5m

Fixes #1704

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>