### PR TITLE
integration/docker: drop postgres image

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -29,9 +29,6 @@ const (
 	// Image used to run containers
 	Image = "busybox"
 
-	// PostgresImage is the postgres image
-	PostgresImage = "postgres"
-
 	// DebianImage is the debian image
 	DebianImage = "debian"
 
@@ -104,7 +101,6 @@ func init() {
 	images = []string{
 		Image,
 		AlpineImage,
-		PostgresImage,
 		DebianImage,
 		FedoraImage,
 		CentosImage,


### PR DESCRIPTION
The postgres image was only used to do user/group id checks. It is a big image, and we can do the same checks using a much smaller image such as busybox.
This will reduce our download and storage time.
Drop postgres, move the user tests to busybox.