### PR TITLE
ci: do not run docker/cri-o tests if TEST_DOCKER/TEST_CRIO are not true 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,15 @@
 # The time limit in seconds for each test
 TIMEOUT := 120
 
+DOCKER_DEPENDENCY = docker
+ifeq (${CI}, true)
+	ifneq (${TEST_DOCKER}, true)
+		DOCKER_DEPENDENCY =
+	endif
+endif
+
 # union for 'make test'
-UNION := functional debug-console docker crio docker-compose network netmon \
+UNION := functional debug-console $(DOCKER_DEPENDENCY) crio docker-compose network netmon \
 	docker-stability oci openshift kubernetes swarm vm-factory \
 	entropy ramdisk shimv2 tracing
 

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -13,6 +13,15 @@ source "${SCRIPT_PATH}/crio_skip_tests.sh"
 source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
+# Skip the cri-o tests if TEST_CRIO is not true
+# and we are on a CI job.
+# For non CI execution, run the cri-o tests always.
+if [ "$CI" = true ] && [ "$TEST_CRIO" != true ]
+then
+	echo "Skipping cri-o tests as TEST_CRIO is not true"
+	exit
+fi
+
 crio_repository="github.com/cri-o/cri-o"
 crio_repository_path="$GOPATH/src/${crio_repository}"
 


### PR DESCRIPTION
do not run `cri-o` tests if `TEST_CRIO` is not true
do not run `docker` tests if `TEST_DOCKER` is not true

This behavior will only be valid when running under CI.
When running `make test` without `CI=true`, docker and
cri-o will always run.

Fixes: #1686.