### PR TITLE
test: reback the shimv2 test on centos

### DIFF
--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -25,9 +25,4 @@ if [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == sles ] || [ "$ID" == rhel ]; then
 	exit
 fi
 
-if [ "$ID" != "centos" ]; then
-	${SCRIPT_PATH}/../cri/integration-tests.sh
-else
-	issue="https://github.com/kata-containers/tests/issues/1047"
-	echo "Skip shimv2 on $ID, see: $issue"
-fi
+${SCRIPT_PATH}/../cri/integration-tests.sh


### PR DESCRIPTION
Seems the shimv2 test can work well on centos recently,
so reback the shimv2 test on centos.

Fixes:#1047

Signed-off-by: lifupan <lifupan@gmail.com>