### PR TITLE
kubernetes: assure swap=off when running kubernetes integration tests

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -51,6 +51,10 @@ kubeadm_config_file="$(mktemp --tmpdir kubeadm_config.XXXXXX.yaml)"
 sed -e "s|CRI_RUNTIME_SOCKET|${cri_runtime_socket}|" "${kubeadm_config_template}" > "${kubeadm_config_file}"
 sed -i "s|KUBERNETES_VERSION|v${kubernetes_version/-*}|" "${kubeadm_config_file}"
 
+BAREMETAL="${BAREMETAL:-false}"
+if [ "${BAREMETAL}" == true ] && [[ $(wc -l /proc/swaps | awk '{print $1}') -gt 1 ]]; then
+	sudo swapoff -a || true
+fi
 sudo -E kubeadm init --config "${kubeadm_config_file}"
 
 mkdir -p "$HOME/.kube"


### PR DESCRIPTION
When setting up kubernetes on bare metal, it may occur `swap=on` error during preflight checks. 
```
[preflight] Running pre-flight checks
error execution phase preflight: [preflight] Some fatal errors occurred:
        [ERROR Swap]: running with swap on is not supported. Please disable swa                            p
[preflight] If you know what you are doing, you can make a check non-fatal with                               `--ignore-preflight-errors=...`
Failed at 54: sudo -E kubeadm init --config "${kubeadm_config_file}"
```
Since running kubernetes with `swap=on` is not supported. we need to assure swap file/partition turned off before kubeinit preflight checks.