### PR TITLE
CI: Add network timeout

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -20,6 +20,9 @@ KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
 # more formats).
 export KATA_DOCKER_TIMEOUT=30
 
+# Number of seconds to wait for a general network operation to complete.
+export KATA_NET_TIMEOUT=30
+
 # Ensure GOPATH set
 if command -v go > /dev/null; then
 	export GOPATH=${GOPATH:-$(go env GOPATH)}

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -600,7 +600,7 @@ static_check_docs()
 		# Git repo URL check
 		if echo "$url"|grep -q '^https.*git'
 		then
-			git ls-remote "$url" > /dev/null 2>&1 && continue
+			timeout "${KATA_NET_TIMEOUT}" git ls-remote "$url" > /dev/null 2>&1 && continue
 		fi
 
 		info "Checking URL $url"


### PR DESCRIPTION
Add a timeout in the static checks script for `git ls-remote`. This hits the network and can cause a hang (and subsequent job timeout).

Fixes: #1711.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>