### PR TITLE
docs: Put command names in backticks

### DIFF
--- a/cmd/checkcommits/README.md
+++ b/cmd/checkcommits/README.md
@@ -1,4 +1,4 @@
-# checkcommits
+# `checkcommits`
 
 * [Overview](#overview)
 * [Handling long lines](#handling-long-lines)

--- a/cmd/checkmetrics/README.md
+++ b/cmd/checkmetrics/README.md
@@ -1,4 +1,4 @@
-# checkmetrics
+# `checkmetrics`
 
 * [Overview](#overview)
     * [JSON file format](#json-file-format)

--- a/cmd/kata-manager/README.md
+++ b/cmd/kata-manager/README.md
@@ -1,4 +1,4 @@
-# kata-manager
+# `kata-manager`
 
 * [Overview](#overview)
     * [For full details](#for-full-details)


### PR DESCRIPTION
All command names need to be in backticks.

Fixes: #1717.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>