### PR TITLE
check-markdown: Fix bug that made checker impotent

### DIFF
--- a/cmd/check-markdown/main.go
+++ b/cmd/check-markdown/main.go
@@ -295,16 +295,14 @@ func realMain() error {
 			Usage:       "perform tests on the specified document",
 			Description: "Exit code denotes success",
 			Action: func(c *cli.Context) error {
-				handleDoc(c, false)
-				return nil
+				return handleDoc(c, false)
 			},
 		},
 		{
 			Name:  "toc",
 			Usage: "display a markdown Table of Contents",
 			Action: func(c *cli.Context) error {
-				handleDoc(c, true)
-				return nil
+				return handleDoc(c, true)
 			},
 		},
 		{


### PR DESCRIPTION
Remove the original stub code and actually return the result of `handleDoc()` to unbreak the `check` command. Previously, `check` would display any error and then return successfully! However, the `list` command would (and still does) successfully detect invalid markdown.

Fixes: #1721.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>