### PR TITLE
ci: Add CentOS to run kubernetes

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -11,6 +11,7 @@ set -o pipefail
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 echo "Install Kubernetes components"
 
@@ -18,15 +19,59 @@ cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_version=$(get_version "externals.kubernetes.version")
 
-if [ "$ID" != "ubuntu" ]; then
-        echo "Currently this script only works for Ubuntu. Skipped Kubernetes Setup"
-        exit
+if [ "$ID" != "ubuntu" ] && [ "$ID" != "centos" ]; then
+        echo "Currently this script does not work on $ID. Skipped Kubernetes Setup"
+        exit 0
 fi
 
-sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
-EOF"
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-chronic sudo -E apt update
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	die "Kubernetes will not work with $KATA_HYPERVISOR"
+fi
 
-chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
+if [ "$ID" == "ubuntu" ]; then
+	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
+	EOF"
+
+	chronic sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list
+	chronic sudo -E sed -i '$ d' /etc/apt/sources.list.d/kubernetes.list
+	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+	chronic sudo -E apt update
+	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
+elif [ "$ID" == "centos" ]; then
+	sudo yum versionlock docker-ce
+
+	sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+	[kubernetes]
+	name=Kubernetes
+	baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+	enabled=1
+	gpgcheck=1
+	repo_gpgcheck=1
+	gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+	EOF"
+
+	chronic sudo -E sed -i 's/^[ \t]*//' /etc/yum.repos.d/kubernetes.repo
+	chronic sudo -E sed -i '$ d' /etc/yum.repos.d/kubernetes.repo
+	install_kubernetes_version=$(echo $kubernetes_version | cut -d'-' -f1)
+	chronic sudo -E yum -y update
+	chronic sudo -E yum install -y kubelet-"$install_kubernetes_version" kubeadm-"$install_kubernetes_version" kubectl-"$install_kubernetes_version" --disableexcludes=kubernetes
+
+	# Disable selinux
+	if  [ "$(getenforce)" != "Disabled" ]; then
+		chronic sudo -E setenforce 0
+		chronic sudo -E sed -i 's/^SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
+	fi
+
+	# Packets traversing the bridge should be sent to iptables for processing
+	echo br_netfilter | sudo -E tee /etc/modules-load.d/k8s.conf
+	sudo -E modprobe -i br_netfilter
+	sudo -E bash -c 'echo "net.bridge.bridge-nf-call-ip6tables = 1" > /etc/sysctl.d/k8s.conf'
+	sudo -E bash -c 'echo "net.bridge.bridge-nf-call-iptables = 1" >> /etc/sysctl.d/k8s.conf'
+	sudo -E bash -c 'echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/k8s.conf'
+	sudo -E sysctl --system
+
+	sudo -E systemctl enable kubelet
+else
+	die "Kubernetes configuration not done on $ID"
+fi

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -59,6 +59,7 @@ declare -A packages=( \
 	[gnu_parallel_dependencies]="perl bzip2 make" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
+	[versionlock]="yum-versionlock" \
 )
 
 main()

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -6,13 +6,18 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+source "/etc/os-release" || source "/usr/lib/os-release"
+
+issue="https://github.com/kata-containers/tests/issues/1731"
 
 setup() {
+	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Port forwarding" {
+	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
 	# Create deployment
@@ -61,6 +66,7 @@ setup() {
 }
 
 teardown() {
+	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
 	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
 }

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -8,14 +8,22 @@
 set -e
 
 source /etc/os-release || source /usr/lib/os-release
-kubernetes_dir=$(dirname $0)
+kubernetes_dir=$(dirname "$(readlink -f "$0")")
+cidir="${kubernetes_dir}/../../.ci/"
+source "${cidir}/lib.sh"
 
-# Currently, Kubernetes tests only work on Ubuntu.
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
+# Currently, Kubernetes tests only work on Ubuntu and Centos.
 # We should delete this condition, when it works for other Distros.
-if [ "$ID" != ubuntu  ]; then
+if [ "$ID" != "ubuntu" ] && [ "$ID" != "centos" ]; then
 	echo "Skip Kubernetes tests on $ID"
 	echo "kubernetes tests on $ID aren't supported yet"
-	exit
+	exit 0
+fi
+
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	die "Kubernetes tests will not run with $KATA_HYPERVISOR"
 fi
 
 # Docker is required to initialize kubeadm, even if we are


### PR DESCRIPTION
This will install and run kubernetes tests on CentOS with machinetype q35.

Fixes #1699

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>