### PR TITLE
arch: install tests repo brfore using script kata-arch.sh

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -45,11 +45,11 @@ export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
 kata_repo_dir="${GOPATH}/src/${kata_repo}"
 tests_repo_dir="${GOPATH}/src/${tests_repo}"
 
-arch=$("${tests_repo_dir}/.ci/kata-arch.sh")
-
 # Get the tests repository
 mkdir -p $(dirname "${tests_repo_dir}")
 [ -d "${tests_repo_dir}" ] || git clone "https://${tests_repo}.git" "${tests_repo_dir}"
+
+arch=$("${tests_repo_dir}/.ci/kata-arch.sh)
 
 # Get the repository of the PR to be tested
 mkdir -p $(dirname "${kata_repo_dir}")


### PR DESCRIPTION
# Description of problem
```
17:41:04 .ci/jenkins_job_build.sh: line 48: /home/jenkins/workspace/kata-containers-runtime-ARM-18.04-PR/go/src/github.com/kata-containers/tests/.ci/kata-arch.sh: No such file or directory
```
Let's install `tests/` repo brfore using script `kata-arch.sh`, which lives in `tests/` repo.
I'm confused why it only occurred in ARM CI node???? ☹
@chavafg @grahamwhaley 