### PR TITLE
Allow Travis to call CI setup

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017-2018 Intel Corporation
+# Copyright (c) 2017-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -147,4 +147,5 @@ main() {
 		sudo -E PATH=$PATH bash -c "echo 1 > /proc/sys/fs/may_detach_mounts"
 	fi
 }
+
 main $*

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -24,25 +24,20 @@ KUBERNETES="${KUBERNETES:-yes}"
 OPENSHIFT="${OPENSHIFT:-yes}"
 
 setup_distro_env() {
+	local script
+
 	echo "Set up environment"
-	if [ "$ID" == centos ]; then
-		bash -f "${cidir}/setup_env_centos.sh"
-	elif [ "$ID" == fedora ]; then
-		bash -f "${cidir}/setup_env_fedora.sh"
-	elif [ "$ID" == ubuntu ]; then
-		bash -f "${cidir}/setup_env_ubuntu.sh"
-	elif [ "$ID" == debian ]; then
-		bash -f "${cidir}/setup_env_debian.sh"
-	elif [[ "$ID" =~ ^opensuse.*$ ]]; then
-		bash -f "${cidir}/setup_env_opensuse.sh"
-	elif [ "$ID" == sles ]; then
-		bash -f "${cidir}/setup_env_sles.sh"
-	elif [ "$ID" == rhel ]; then
-		bash -f "${cidir}/setup_env_rhel.sh"
+
+	if [[ "$ID" =~ ^opensuse.*$ ]]; then
+		script="${cidir}/setup_env_opensuse.sh"
 	else
-		die "ERROR: Unrecognised distribution: ${ID}."
-		exit 1
+		script="${cidir}/setup_env_${ID}.sh"
 	fi
+
+	[ -n "$script" ] || die "Failed to determine distro setup script"
+	[ -e "$script" ] || die "Unrecognised distribution: ${ID}"
+
+	bash -f "${script}"
 
 	sudo systemctl start haveged
 }

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -58,13 +58,13 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E yum -y install $pkgs_to_install
 
 if [ "$(arch)" == "x86_64" ]; then

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -15,6 +15,10 @@ export DEBIAN_FRONTEND=noninteractive
 echo "Install chronic"
 sudo -E apt -y install moreutils
 
+declare -A minimal_packages=( \
+	[yaml_validator]="yamllint" \
+)
+
 declare -A packages=( \
 	[general_dependencies]="curl git" \
 	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc alien libpixman-1-dev coreutils parted" \
@@ -26,7 +30,6 @@ declare -A packages=( \
 	[build_tools]="build-essential python pkg-config zlib1g-dev" \
 	[crio_dependencies_for_debian]="libdevmapper-dev btrfs-tools util-linux" \
 	[os_tree]="libostree-dev" \
-	[yaml_validator]="yamllint" \
 	[metrics_dependencies]="smem jq" \
 	[cri-containerd_dependencies]="libseccomp-dev libapparmor-dev btrfs-tools  make gcc pkg-config" \
 	[crudini]="crudini" \
@@ -37,40 +40,58 @@ declare -A packages=( \
 	[redis]="redis-server" \
 )
 
-pkgs_to_install=
+main()
+{
+	local setup_type="$1"
+	[ -z "$setup_type" ] && die "need setup type"
 
-for pkgs in "${packages[@]}"; do
-	info "The following package will be installed: $pkgs"
-	pkgs_to_install+=" $pkgs"
-done
+	local pkgs_to_install
+	local pkgs
 
-chronic sudo -E apt -y install $pkgs_to_install
+	for pkgs in "${minimal_packages[@]}"; do
+		info "The following package will be installed: $pkgs"
+		pkgs_to_install+=" $pkgs"
+	done
 
-echo "Enable librbd1 repository"
-sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/unstable.list
-deb http://deb.debian.org/debian unstable main contrib non-free
-deb-src http://deb.debian.org/debian unstable main contrib non-free
-EOF"
+	if [ "$setup_type" = "default" ]; then
+		for pkgs in "${packages[@]}"; do
+			info "The following package will be installed: $pkgs"
+			pkgs_to_install+=" $pkgs"
+		done
+	fi
 
-echo "Lower priority than stable"
-sudo bash -c "cat <<EOF > /etc/apt/preferences.d/unstable
-Package: *
-Pin: release a=unstable
-Pin-Priority: 10
-EOF"
+	chronic sudo -E apt -y install $pkgs_to_install
 
-echo "Install librbd1"
-chronic sudo -E apt update && sudo -E apt install -y -t unstable librbd1
+	[ "$setup_type" = "minimal" ] && exit 0
 
-if [ "$(arch)" == "x86_64" ]; then
-	echo "Install Kata Containers OBS repository"
-	obs_url="${KATA_OBS_REPO_BASE}/Debian_${VERSION_ID}"
-	sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
-	curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
-	chronic sudo -E apt-get update
-fi
+	echo "Enable librbd1 repository"
+	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/unstable.list
+	deb http://deb.debian.org/debian unstable main contrib non-free
+	deb-src http://deb.debian.org/debian unstable main contrib non-free
+	EOF"
 
-if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-	echo "Install ${KATA_KSM_THROTTLER_JOB}"
-	chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
-fi
+	echo "Lower priority than stable"
+	sudo bash -c "cat <<EOF > /etc/apt/preferences.d/unstable
+	Package: *
+	Pin: release a=unstable
+	Pin-Priority: 10
+	EOF"
+
+	echo "Install librbd1"
+	chronic sudo -E apt update && sudo -E apt install -y -t unstable librbd1
+
+	if [ "$(arch)" == "x86_64" ]; then
+		echo "Install Kata Containers OBS repository"
+		obs_url="${KATA_OBS_REPO_BASE}/Debian_${VERSION_ID}"
+		sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
+		curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
+		chronic sudo -E apt-get update
+	fi
+
+	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+		echo "Install ${KATA_KSM_THROTTLER_JOB}"
+		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
+	fi
+}
+
+main "$@"

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -37,13 +37,13 @@ declare -A packages=( \
 	[redis]="redis-server" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E apt -y install $pkgs_to_install
 
 echo "Enable librbd1 repository"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -14,6 +14,10 @@ source "${cidir}/lib.sh"
 echo "Install chronic"
 sudo -E dnf -y install moreutils
 
+declare -A minimal_packages=( \
+	[yaml_validator]="yamllint" \
+)
+
 declare -A packages=( \
 	[general_dependencies]="dnf-plugins-core python pkgconfig util-linux libgpg-error-devel" \
 	[kata_containers_dependencies]="libtool automake autoconf bc pixman numactl-libs" \
@@ -23,7 +27,6 @@ declare -A packages=( \
 	[crio_dependencies]="btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libseccomp-devel libselinux-devel" \
 	[bison_binary]="bison" \
 	[os_tree]="ostree-devel" \
-	[yaml_validator]="yamllint" \
 	[metrics_dependencies]="smem jq" \
 	[cri-containerd_dependencies]="libseccomp-devel btrfs-progs-devel libseccomp-static" \
 	[crudini]="crudini" \
@@ -34,25 +37,43 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=
+main()
+{
+	local setup_type="$1"
+	[ -z "$setup_type" ] && die "need setup type"
 
-for pkgs in "${packages[@]}"; do
-	info "The following package will be installed: $pkgs"
-	pkgs_to_install+=" $pkgs"
-done
+	local pkgs_to_install
+	local pkgs
 
-chronic sudo -E dnf -y install $pkgs_to_install
+	for pkgs in "${minimal_packages[@]}"; do
+		info "The following package will be installed: $pkgs"
+		pkgs_to_install+=" $pkgs"
+	done
 
-echo "Install kata containers dependencies"
-chronic sudo -E dnf -y groupinstall "Development tools"
+	if [ "$setup_type" = "default" ]; then
+		for pkgs in "${packages[@]}"; do
+			info "The following package will be installed: $pkgs"
+			pkgs_to_install+=" $pkgs"
+		done
+	fi
 
-if [ "$(arch)" == "x86_64" ]; then
-	echo "Install Kata Containers OBS repository"
-	obs_url="${KATA_OBS_REPO_BASE}/Fedora_$VERSION_ID/home:katacontainers:releases:$(arch):master.repo"
-	sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo "$obs_url"
-fi
+	chronic sudo -E dnf -y install $pkgs_to_install
 
-if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-	echo "Install ${KATA_KSM_THROTTLER_JOB}"
-	chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
-fi
+	[ "$setup_type" = "minimal" ] && exit 0
+
+	echo "Install kata containers dependencies"
+	chronic sudo -E dnf -y groupinstall "Development tools"
+
+	if [ "$(arch)" == "x86_64" ]; then
+		echo "Install Kata Containers OBS repository"
+		obs_url="${KATA_OBS_REPO_BASE}/Fedora_$VERSION_ID/home:katacontainers:releases:$(arch):master.repo"
+		sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo "$obs_url"
+	fi
+
+	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
+		echo "Install ${KATA_KSM_THROTTLER_JOB}"
+		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
+	fi
+}
+
+main "$@"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -34,13 +34,13 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E dnf -y install $pkgs_to_install
 
 echo "Install kata containers dependencies"

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -33,13 +33,13 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E zypper -n install $pkgs_to_install
 
 echo "Install YAML validator"

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -14,8 +14,12 @@ source "${cidir}/lib.sh"
 echo "Install chronic"
 sudo -E zypper -n install moreutils
 
+declare -A minimal_packages=( \
+	[yaml_validator_dependencies]="python-setuptools" \
+)
+
 declare -A packages=( \
-	[general_dependencies]="curl python-setuptools git libcontainers-common libdevmapper1_03 util-linux" \
+	[general_dependencies]="curl git libcontainers-common libdevmapper1_03 util-linux" \
 	[kata_containers_dependencies]="libtool automake autoconf bc perl-Alien-SDL libpixman-1-0-devel coreutils python2-pkgconfig" \
 	[qemu_dependencies]="libcap-devel libattr1 libcap-ng-devel librbd-devel" \
 	[kernel_dependencies]="libelf-devel flex glibc-devel-static thin-provisioning-tools" \
@@ -33,21 +37,39 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=
+main()
+{
+	local setup_type="$1"
+	[ -z "$setup_type" ] && die "need setup type"
 
-for pkgs in "${packages[@]}"; do
-	info "The following package will be installed: $pkgs"
-	pkgs_to_install+=" $pkgs"
-done
+	local pkgs_to_install
+	local pkgs
 
-chronic sudo -E zypper -n install $pkgs_to_install
+	for pkgs in "${minimal_packages[@]}"; do
+		info "The following package will be installed: $pkgs"
+		pkgs_to_install+=" $pkgs"
+	done
 
-echo "Install YAML validator"
-chronic sudo -E easy_install pip
-chronic sudo -E pip install yamllint
+	if [ "$setup_type" = "default" ]; then
+		for pkgs in "${packages[@]}"; do
+			info "The following package will be installed: $pkgs"
+			pkgs_to_install+=" $pkgs"
+		done
+	fi
 
-if [ "$(arch)" == "x86_64" ]; then
-	echo "Install Kata Containers OBS repository"
-	obs_url="${KATA_OBS_REPO_BASE}/openSUSE_Leap_${VERSION_ID}"
-	chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-fi
+	chronic sudo -E zypper -n install $pkgs_to_install
+
+	echo "Install YAML validator"
+	chronic sudo -E easy_install pip
+	chronic sudo -E pip install yamllint
+
+	[ "$setup_type" = "minimal" ] && exit 0
+
+	if [ "$(arch)" == "x86_64" ]; then
+		echo "Install Kata Containers OBS repository"
+		obs_url="${KATA_OBS_REPO_BASE}/openSUSE_Leap_${VERSION_ID}"
+		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
+	fi
+}
+
+main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -42,13 +42,13 @@ declare -A packages=(
 	[redis]="redis" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E yum -y install $pkgs_to_install
 
 if [ "$(arch)" == "x86_64" ]; then

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -45,13 +45,13 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E zypper -n install $pkgs_to_install
 
 echo "Install Build Tools"

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -27,6 +27,10 @@ sudo -E zypper refresh
 echo "Install chronic"
 sudo -E zypper -n install moreutils
 
+declare -A minimal_packages=( \
+	[yaml_validator_dependencies]="python-setuptools" \
+)
+
 declare -A packages=( \
 	[general_dependencies]="curl git patch"
 	[kata_containers_dependencies]="libtool automake autoconf bc libpixman-1-0-devel coreutils" \
@@ -36,7 +40,6 @@ declare -A packages=( \
 	[bison_binary]="bison" \
 	[libudev-dev]="libudev-devel" \
 	[build_tools]="python zlib-devel" \
-	[yaml_validator_dependencies]="python-setuptools" \
 	[metrics_dependencies]="jq" \
 	[cri-containerd_dependencies]="libseccomp-devel libapparmor-devel make pkg-config" \
 	[haveged]="haveged" \
@@ -45,30 +48,48 @@ declare -A packages=( \
 	[redis]="redis" \
 )
 
-pkgs_to_install=
+main() 
+{
+	local setup_type="$1"
+	[ -z "$setup_type" ] && die "need setup type"
 
-for pkgs in "${packages[@]}"; do
-	info "The following package will be installed: $pkgs"
-	pkgs_to_install+=" $pkgs"
-done
+	local pkgs_to_install
+	local pkgs
 
-chronic sudo -E zypper -n install $pkgs_to_install
+	for pkgs in "${minimal_packages[@]}"; do
+		info "The following package will be installed: $pkgs"
+		pkgs_to_install+=" $pkgs"
+	done
 
-echo "Install Build Tools"
-chronic sudo -E zypper -n install -t pattern "Basis-Devel"
+	if [ "$setup_type" = "default" ]; then
+		for pkgs in "${packages[@]}"; do
+			info "The following package will be installed: $pkgs"
+			pkgs_to_install+=" $pkgs"
+		done
+	fi
 
-echo "Install YAML validator"
-chronic sudo -E easy_install pip
-chronic sudo -E pip install yamllint
+	chronic sudo -E zypper -n install $pkgs_to_install
 
-if [ "$(arch)" == "x86_64" ]; then
-	echo "Install Kata Containers OBS repository"
-	obs_url="${KATA_OBS_REPO_BASE}/SLE_${VERSION//-/_}/"
-	chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-fi
+	echo "Install YAML validator"
+	chronic sudo -E easy_install pip
+	chronic sudo -E pip install yamllint
 
-echo "Add crudini repo"
-VERSIONID="12_SP1"
-crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
-chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
-chronic sudo -E zypper refresh
+	[ "$setup_type" = "minimal" ] && exit 0
+
+	echo "Install Build Tools"
+	chronic sudo -E zypper -n install -t pattern "Basis-Devel"
+
+	if [ "$(arch)" == "x86_64" ]; then
+		echo "Install Kata Containers OBS repository"
+		obs_url="${KATA_OBS_REPO_BASE}/SLE_${VERSION//-/_}/"
+		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
+	fi
+
+	echo "Add crudini repo"
+	VERSIONID="12_SP1"
+	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
+	chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
+	chronic sudo -E zypper refresh
+}
+
+main "$@"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2017-2018 Intel Corporation
+# Copyright (c) 2017-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -38,13 +38,13 @@ declare -A packages=( \
 	[redis]="redis-server" \
 )
 
-pkgs_to_install=${packages[@]}
+pkgs_to_install=
 
-for j in ${packages[@]}; do
-	pkgs=$(echo "$j")
+for pkgs in "${packages[@]}"; do
 	info "The following package will be installed: $pkgs"
 	pkgs_to_install+=" $pkgs"
 done
+
 chronic sudo -E apt -y install $pkgs_to_install
 
 if [ "$VERSION_ID" == "16.04" ] && [ "$(arch)" != "ppc64le" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+dist: xenial
+
 os:
   - linux
   - osx
@@ -13,7 +15,6 @@ matrix:
   include:
     - os: linux
       sudo: required
-      dist: trusty
 
 language: go
 go_import_path: github.com/kata-containers/tests
@@ -26,9 +27,7 @@ env:
   - target_branch=$TRAVIS_BRANCH
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install --user yamllint          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then .ci/setup.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint gnu-getopt; fi
 
 script:


### PR DESCRIPTION
Refactored the setup scripts to allow them to be called from the `.travis.yml` configuration file.
    
Now, the main setup script detects when it is running under Travis and passes a `minimal` flag to the distro-specific setup script. The latter script will then perform the minimal setup and exit.

Also:

- Simplified the existing setup scripts a little.
- Updated the Travis distro to Xenial to install `yamllint` without having to use `pip`.
    
Fixes: #1724.
    
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>