### PR TITLE
k8s: use Wave Net on AArch64 instead of flannel

### DIFF
--- a/.ci/aarch64/kubernetes/init.sh
+++ b/.ci/aarch64/kubernetes/init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+k8s_version=$(kubectl version | base64 | tr -d '\n')
+network_plugin_config="https://cloud.weave.works/k8s/net?k8s-version=${k8s_version}"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -65,10 +65,16 @@ export KUBECONFIG="$HOME/.kube/config"
 kubectl get nodes
 kubectl get pods
 
-# kube-flannel config file taken from k8s 1.12 documentation:
-flannel_config="https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml"
+arch=$("${SCRIPT_PATH}/../../.ci/kata-arch.sh")
+#Load arch-specific configure file
+if [ -f "${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/init.sh" ]; then
+        source "${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/init.sh"
+fi
 
-kubectl apply -f "$flannel_config"
+# default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation:
+network_plugin_config=${network_plugin_config:-https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml}
+
+kubectl apply -f "$network_plugin_config"
 
 # The kube-dns pod usually takes around 120 seconds to get ready
 # This instruction will wait until it is up and running, so we can


### PR DESCRIPTION
# Description of problem
flannel pod always got OOM killed on AArch64.
flannel pod has set memory limitation:
```
containers:
      - name: kube-flannel
        image: quay.io/coreos/flannel:v0.10.0-arm64
        command:
        - /opt/bin/flanneld
        args:
        - --ip-masq
        - --kube-subnet-mgr
        resources:
          requests:
            cpu: "100m"
            memory: "50Mi"
          limits:
            cpu: "100m"
            memory: "50Mi"
```
oom-killer logs in dmesg:
```
kernel: [429178.253663] conmon invoked oom-killer: gfp_mask=0x6000c0(GFP_KERNEL), order=0, oom_score_adj=-999
700]  oom_kill_process+0x330/0x370
kernel: [429178.253701]  out_of_memory+0x1b4/0x510
kernel: [429178.253708]  mem_cgroup_out_of_memory+0xc4/0xe0
kernel: [429178.253736] memory: uIsage 51200kB, limit 51200kB, failcnt 100154
kernel: [429178.264979] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=crio-conmon-095c9da0df6d2e4d867f3f757ae46adaa44860597e670f18ebb0268c91d04c65,mems_allowed=0-1,oom_memcg=/kubepods/podb70c2d7b-9241-11e9-a761-6805ca836f34,task_memcg=/kubepods/podb70c2d7b-9241-11e9-a761-6805ca836f34/crio-conmon-095c9da0df6d2e4d867f3f757ae46adaa44860597e670f18ebb0268c91d04c65,task=conmon,pid=158604,uid=0
kernel: [429178.264988] Memory cgroup out of memory: Kill process 158604 (conmon) score 0 or sacrifice child
```
This error look like arch-irrelevant, I have found similar issue [coreos/flannel/#963](https://github.com/coreos/flannel/issues/963
) here on x86-64. 
@grahamwhaley @chavafg Have you guys encountered the same error ever?
So I decided to switch to use Wave Net. ;)
