### PR TITLE
test: Verify that docker is active before running shimv2 tests

### DIFF
--- a/integration/containerd/shimv2/shimv2-factory-tests.sh
+++ b/integration/containerd/shimv2/shimv2-factory-tests.sh
@@ -24,6 +24,12 @@ if [ -z $INITRD_PATH ]; then
         exit 0
 fi
 
+# Verify docker is running
+sudo systemctl is-active --quiet docker
+if [ $? -ne 0 ]; then
+	sudo systemctl start docker
+fi
+
 echo "========================================"
 echo "   start shimv2 with factory testing"
 echo "========================================"

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -15,6 +15,12 @@ ${SCRIPT_PATH}/../../../.ci/install_cni_plugins.sh
 
 export SHIMV2_TEST=true
 
+# Verify docker is running
+sudo systemctl is-active --quiet docker
+if [ $? -ne 0 ]; then
+	sudo systemctl start docker
+fi
+
 echo "========================================"
 echo "         start shimv2 testing"
 echo "========================================"


### PR DESCRIPTION
This will verify that docker is running before running the shimv2
tests.

Fixes #1749

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>