### PR TITLE
lib: common: do not bork if no runtime found for env

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -76,7 +76,7 @@ extract_kata_env(){
 	local toml
 	local rpath=$(get_docker_kata_path "$RUNTIME")
 	if [ -n "$rpath" ]; then
-		rpath=$(command -v "$rpath")
+		rpath=$(command -v "$rpath" || true)
 	fi
 
 	# If we can execute the path handed back to us


### PR DESCRIPTION
When extracting the `kata env`, do not fail/abort if a runtime
cannot be found - fall through to take the defaults.

Fixes: #1751

Signed-off-by: Graham Whaley <graham.whaley@intel.com>