### PR TITLE
static-checks: Exclude generated files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -405,6 +405,7 @@ static_check_license_headers()
 		--exclude="*.yaml" \
 		--exclude="*.pb.go" \
 		--exclude="*.gpl.c" \
+		--exclude="virtcontainers/pkg/firecracker/*" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
Exclude firecracker swagger generated files from static checks.

Fixes: #1754

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>