### PR TITLE
Firecracker: Upgrade firecracker to 0.17.0

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -42,7 +42,8 @@ go get -d ${firecracker_repo} || true
 pushd "${GOPATH}/src/${firecracker_repo}"
 git checkout tags/${firecracker_version}
 ./tools/devtool --unattended build --release -- --features vsock
-sudo install ${GOPATH}/src/${firecracker_repo}/build/release/firecracker /usr/bin/
+sudo install ${GOPATH}/src/${firecracker_repo}/build/release-musl/firecracker /usr/bin/
+sudo install ${GOPATH}/src/${firecracker_repo}/build/release-musl/jailer /usr/bin/
 popd
 
 echo "Install and configure docker"


### PR DESCRIPTION
Upgrade firecracker to 0.17.0. The binary locations have changed.

Depends-on: github.com/kata-containers/runtime#1813

Fixes #1756

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>