### PR TITLE
ci: Add kubernetes in Fedora

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -32,6 +32,13 @@ crio_repo=$(get_version "externals.crio.url")
 crio_repo="${crio_repo#*//}"
 crio_config_file="/etc/crio/crio.conf"
 
+# Remove CRI-O repository if already exists on Fedora
+if [ "$ID" == "fedora" ]; then
+	if [ -d "${GOPATH}/src/${crio_repo}" ]; then
+		sudo rm -r "${GOPATH}/src/${crio_repo}"
+	fi
+fi
+
 go get -d "$crio_repo" || true
 pushd "${GOPATH}/src/${crio_repo}"
 
@@ -43,7 +50,11 @@ then
 	# the kubernetes version that we support (usually latest stable).
 	# Sometimes these versions differ.
 	if [ "$ID" == "fedora" ]; then
-		crio_version=$(get_version "externals.crio.meta.openshift")
+		if [ "$KUBERNETES" == "yes" ]; then
+			crio_version=$(get_version "externals.crio.version")
+		else
+			crio_version=$(get_version "externals.crio.meta.openshift")
+		fi
 	else
 		crio_version=$(get_version "externals.crio.version")
 	fi

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -102,6 +102,15 @@ install_extra_tools() {
 		source "${cidir}/${arch}/lib_setup_${arch}.sh"
 	fi
 
+	# Do not install immediately kubernetes on Fedora as
+	# first we will run Openshift with its correspondent CRI-O
+	# version and then we will install kubernetes with its
+	# correspondent CRI-O version in order to not break the
+	# compatibility matrix
+	if [ "$ID" == "fedora" ]; then
+		export KUBERNETES="no"
+	fi
+
 	[ "${CRIO}" = "yes" ] &&
 		echo "Install CRI-O" &&
 		bash -f "${cidir}/install_crio.sh" &&

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -36,6 +36,7 @@ declare -A packages=( \
 	[gnu_parallel]="parallel" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
+	[versionlock]="python3-dnf-plugin-versionlock" \
 )
 
 main()

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ ifeq (${CI}, true)
 endif
 
 # union for 'make test'
-UNION := functional debug-console $(DOCKER_DEPENDENCY) crio docker-compose network netmon \
-	docker-stability oci openshift kubernetes swarm vm-factory \
+UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
+	docker-stability oci netmon kubernetes swarm vm-factory \
 	entropy ramdisk shimv2 tracing
 
 # filter scheme script for docker integration test suites

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -13,9 +13,12 @@ set -o pipefail
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 cri_runtime="${CRI_RUNTIME:-crio}"
 kubernetes_version=$(get_version "externals.kubernetes.version")
+
+[ "$ID" == "fedora" ] && bash "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
 
 case "${cri_runtime}" in
 containerd)

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -11,13 +11,13 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 issue="https://github.com/kata-containers/tests/issues/1731"
 
 setup() {
-	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
+	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Port forwarding" {
-	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
+	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
 	# Create deployment
@@ -66,7 +66,7 @@ setup() {
 }
 
 teardown() {
-	[ "$ID" == "centos" ] && skip "test not working see: ${issue}"
+	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
 }

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -14,9 +14,9 @@ source "${cidir}/lib.sh"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-# Currently, Kubernetes tests only work on Ubuntu and Centos.
+# Currently, Kubernetes tests only work on Ubuntu, Centos and Fedora.
 # We should delete this condition, when it works for other Distros.
-if [ "$ID" != "ubuntu" ] && [ "$ID" != "centos" ]; then
+if [ "$ID" != "ubuntu" ] && [ "$ID" != "centos" ] && [ "$ID" != "fedora" ]; then
 	echo "Skip Kubernetes tests on $ID"
 	echo "kubernetes tests on $ID aren't supported yet"
 	exit 0


### PR DESCRIPTION
This will enable and run kubernetes on Fedora in order to increase
the number of distros where k8s tests are being run.

Fixes #1761

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>