### PR TITLE
tests: Enable k8s port forwarding tests

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -104,6 +104,9 @@ main()
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -77,6 +77,9 @@ main()
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -76,6 +76,9 @@ main()
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -71,6 +71,9 @@ main()
 		obs_url="${KATA_OBS_REPO_BASE}/openSUSE_Leap_${VERSION_ID}"
 		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -87,6 +87,9 @@ main()
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -91,6 +91,9 @@ main()
 	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
 	chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
 	chronic sudo -E zypper refresh
+
+	echo "Start redis server"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -86,6 +86,9 @@ main()
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
 	fi
+
+	echo "Start redis service"
+	sudo systemctl start redis
 }
 
 main "$@"

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -8,16 +8,12 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-issue="https://github.com/kata-containers/tests/issues/1731"
-
 setup() {
-	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Port forwarding" {
-	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
 	# Create deployment
@@ -66,7 +62,6 @@ setup() {
 }
 
 teardown() {
-	[ "$ID" == "centos" ] || [ "$ID" == "fedora" ] && skip "test not working see: ${issue}"
 	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
 }


### PR DESCRIPTION
In order to run the k8s port forwarding test, we need to start the
redis server.

Fixes #1731

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>