### PR TITLE
dictionary: Add "crypto"

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -16,6 +16,7 @@ checkbox/A
 codebase
 commandline
 config/AB
+crypto		# Cryptography
 DaemonSet/AB
 devicemapper/B
 dialer


### PR DESCRIPTION
Add the common contraction "crypto" for cryptography to the custom dictionary.

Fixes: #1769.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>