### PR TITLE
dictionary: Add "chipset" word

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -13,6 +13,7 @@ backtick/AB
 backtrace
 bootloader/AB
 checkbox/A
+chipset/AB
 codebase
 commandline
 config/AB


### PR DESCRIPTION
Add the word "chipset" to the custom dictionary.

Fixes: #1773.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>