### PR TITLE
tests: Fix kubernetes test job

### DIFF
--- a/integration/kubernetes/k8s-job.bats
+++ b/integration/kubernetes/k8s-job.bats
@@ -7,16 +7,13 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/1746"
 
 setup() {
-	skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Run a job to completion" {
-	skip "test not working see: ${issue}"
 	job_name="job-pi-test"
 	wait_time=60
 	sleep_time=2
@@ -40,7 +37,6 @@ setup() {
 }
 
 teardown() {
-	skip "test not working see: ${issue}"
 	kubectl delete pod "$pod_name"
 	# Verify that pod is not running
 	run kubectl get pods

--- a/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -8,6 +8,7 @@ kind: Job
 metadata:
   name: job-pi-test
 spec:
+  activeDeadlineSeconds: 100
   template:
     spec:
       runtimeClassName: kata


### PR DESCRIPTION
In order to ensure that we are not leaving pod information, we use a
TTL mechanism provided by a TTL controller for finished resources. This
will clean up the job as well as all the dependent objects.

Fixes #1746

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>