### PR TITLE
CI: Add shell script and JSON checks to static analysis script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -945,15 +945,17 @@ main()
 
 	local long_option_names="${!long_options[@]}"
 
-	local args=$(getopt \
+	local args
+
+	args=$(getopt \
 		-n "$script_name" \
 		-a \
 		--options="h" \
 		--longoptions="$long_option_names" \
 		-- "$@")
+	[ $? -eq 0 ] || { usage >&2; exit 1; }
 
 	eval set -- "$args"
-	[ $? -ne 0 ] && { usage >&2; exit 1; }
 
 	local func=
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -76,6 +76,12 @@ long_options=(
 yamllint_cmd="yamllint"
 have_yamllint_cmd=$(command -v "$yamllint_cmd" || true)
 
+chronic=chronic
+
+# Disable chronic on OSX to avoid having to update the Travis config files
+# for additional packages on that platform.
+[ "$(uname -s)" == "Darwin" ] && chronic=
+
 usage()
 {
 	cat <<EOT
@@ -887,7 +893,7 @@ static_check_xml()
 
 		local ret
 
-		{ chronic xmllint -format - <<< "$contents"; ret=$?; } || true
+		{ $chronic xmllint -format - <<< "$contents"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "failed to check XML file '$file'"
 	done
@@ -924,7 +930,7 @@ static_check_shell()
 
 		local ret
 
-		{ chronic bash -n "$script"; ret=$?; } || true
+		{ $chronic bash -n "$script"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "check for script '$script' failed"
 	done
@@ -961,7 +967,7 @@ static_check_json()
 
 		local ret
 
-		{ chronic jq -S . "$json"; ret=$?; } || true
+		{ $chronic jq -S . "$json"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "failed to check JSON file '$json'"
 	done


### PR DESCRIPTION
- CI: Add shell script static analysis check

  Add a basic CI shell checker test to catch basic syntax errors.

  Fixes: #1787.

- Add a CI check on JSON files.

  Fixes: #1788.

- Correct the handling of an incorrect CLI option in the static checks script. This is a nasty issue where the `local` keyword means that the return value of `getopt(1)` is *always* zero, even when an incorrect
option is specified.

  See: https://github.com/koalaman/shellcheck/wiki/SC2155

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>