### PR TITLE
ci: Remove installation from OBS

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -88,15 +88,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/CentOS_${VERSION_ID}/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
-		repo_file="/etc/yum.repos.d/home\:katacontainers\:releases\:$(arch)\:master.repo"
-		sudo bash -c "echo timeout=10 >> $repo_file"
-		sudo bash -c "echo retries=2 >> $repo_file"
-	fi
-
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -66,14 +66,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/Debian_${VERSION_ID}"
-		sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
-		curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
-		chronic sudo -E apt-get update
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -67,12 +67,6 @@ main()
 	echo "Install kata containers dependencies"
 	chronic sudo -E dnf -y groupinstall "Development tools"
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/Fedora_$VERSION_ID/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo "$obs_url"
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -64,14 +64,6 @@ main()
 	echo "Install YAML validator"
 	chronic sudo -E easy_install pip
 	chronic sudo -E pip install yamllint
-
-	[ "$setup_type" = "minimal" ] && exit 0
-
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/openSUSE_Leap_${VERSION_ID}"
-		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -70,16 +70,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		VERSION_ID="7"
-		echo "Install Kata Containers OBS repository for CentOS (see https://github.com/kata-containers/packaging/pull/555)"
-		obs_url="${KATA_OBS_REPO_BASE}/CentOS_${VERSION_ID}/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
-		repo_file="/etc/yum.repos.d/home\:katacontainers\:releases\:$(arch)\:master.repo"
-		sudo bash -c "echo timeout=10 >> $repo_file"
-		sudo bash -c "echo retries=2 >> $repo_file"
-	fi
-
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -81,12 +81,6 @@ main()
 	echo "Install Build Tools"
 	chronic sudo -E zypper -n install -t pattern "Basis-Devel"
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/SLE_${VERSION//-/_}/"
-		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-	fi
-
 	echo "Add crudini repo"
 	VERSIONID="12_SP1"
 	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -75,14 +75,6 @@ main()
 	echo "Install os-tree"
 	chronic sudo -E apt install -y libostree-dev
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="$KATA_OBS_REPO_BASE/xUbuntu_$(lsb_release -rs)/"
-		sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
-		curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
-		chronic sudo -E apt-get update
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}


### PR DESCRIPTION
We are not longer using the installation from the OBS repository,
this will remove the unnecesary steps.

Fixes #1790

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>