### PR TITLE
ci: fix `install_runtime.sh` and add support for using acrn config file

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -39,10 +39,6 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
 build_and_install "github.com/kata-containers/runtime" "" "true"
 
-# Check system supports running Kata Containers
-kata_runtime_path=$(command -v kata-runtime)
-sudo -E PATH=$PATH "$kata_runtime_path" kata-check
-
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file
 	sudo rm -f "${runtime_config_path}"
@@ -60,6 +56,10 @@ if [ "$KATA_HYPERVISOR" = "nemu" ]; then
 	echo "Enable nemu configuration.toml"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-nemu.toml" "${PKGDEFAULTSDIR}/configuration.toml"
 fi
+
+# Check system supports running Kata Containers
+kata_runtime_path=$(command -v kata-runtime)
+sudo -E PATH=$PATH "$kata_runtime_path" kata-check
 
 if [ -z "${METRICS_CI}" ]; then
 	echo "Enabling all debug options in file ${runtime_config_path}"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -47,6 +47,11 @@ if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	runtime_config_path="${NEW_RUNTIME_CONFIG}"
 fi
 
+if [ "$KATA_HYPERVISOR" = "acrn" ]; then
+	echo "Enable acrn configuration.toml"
+	sudo mv "${PKGDEFAULTSDIR}/configuration-acrn.toml" "${PKGDEFAULTSDIR}/configuration.toml"
+fi
+
 if [ "$KATA_HYPERVISOR" = "firecracker" ]; then
 	echo "Enable firecracker configuration.toml"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-fc.toml" "${PKGDEFAULTSDIR}/configuration.toml"


### PR DESCRIPTION
Once kata-containers/runtime#1779 is merged, we will be able
to run CI using `acrn` hypervisor. Add support for running kata
with acrn using its dedicated configuration file.

In addition, `kata-runtime kata-check` will fail if the hypervisor
in the kata runtime config file is not found, so run kata-check 
after correct config file is in place.
