### PR TITLE
ci: Remove KSM installation

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -7,7 +7,6 @@
 #
 
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
-export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -91,11 +91,6 @@ main()
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel
-
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -65,11 +65,6 @@ main()
 	chronic sudo -E apt -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
-
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -66,11 +66,6 @@ main()
 
 	echo "Install kata containers dependencies"
 	chronic sudo -E dnf -y groupinstall "Development tools"
-
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -73,11 +73,6 @@ main()
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel
-
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -74,11 +74,6 @@ main()
 
 	echo "Install os-tree"
 	chronic sudo -E apt install -y libostree-dev
-
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
-	fi
 }
 
 main "$@"

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -11,7 +11,6 @@ RESULT_DIR="${LIB_DIR}/../results"
 source ${LIB_DIR}/../../lib/common.bash
 source ${LIB_DIR}/json.bash
 source /etc/os-release || source /usr/lib/os-release
-KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-no}"
 
 # Set variables to reasonable defaults if unset or empty
 DOCKER_EXE="${DOCKER_EXE:-docker}"
@@ -203,14 +202,6 @@ show_system_state() {
 		echo " --pgrep ${p}--"
 		pgrep -a ${p}
 	done
-
-	# Verify kata-ksm-throttler
-	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
-		process="kata-ksm-throttler"
-		process_path=$(whereis ${process} | tr -d '[:space:]'| cut -d ':' -f2)
-		echo " --pgrep ${process}--"
-		pgrep -f ${process_path} > /dev/null
-	fi
 }
 
 common_init(){


### PR DESCRIPTION
Currently in our CI, we are not using the variable of KATA_KSM_THROTTLER
in any of the jobs that we have so we can remove the unnecessary steps
like the installation.

Fixes #1741

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>