### PR TITLE
CI: Ignore XML (and *.yml) files in license check

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -414,6 +414,7 @@ static_check_license_headers()
 		--exclude="vendor/*" \
 		--exclude="VERSION" \
 		--exclude="virtcontainers/pkg/firecracker/*" \
+		--exclude="*.xml" \
 		--exclude="*.yaml" \
 		-EL "\<${pattern}\>" \
 		$files || true)

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -416,6 +416,7 @@ static_check_license_headers()
 		--exclude="virtcontainers/pkg/firecracker/*" \
 		--exclude="*.xml" \
 		--exclude="*.yaml" \
+		--exclude="*.yml" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -399,22 +399,22 @@ static_check_license_headers()
 		--exclude=".git/*" \
 		--exclude=".gitignore" \
 		--exclude="Gopkg.lock" \
-		--exclude="LICENSE" \
-		--exclude="vendor/*" \
-		--exclude="VERSION" \
+		--exclude="*.gpl.c" \
 		--exclude="*.jpg" \
 		--exclude="*.json" \
+		--exclude="LICENSE" \
 		--exclude="*.md" \
+		--exclude="*.pb.go" \
 		--exclude="*.png" \
 		--exclude="*.pub" \
 		--exclude="*.service" \
 		--exclude="*.svg" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \
-		--exclude="*.yaml" \
-		--exclude="*.pb.go" \
-		--exclude="*.gpl.c" \
+		--exclude="vendor/*" \
+		--exclude="VERSION" \
 		--exclude="virtcontainers/pkg/firecracker/*" \
+		--exclude="*.yaml" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
Update static check script to ignore XML files when considering whether files need a license header.

Fixes: #1800.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
