### PR TITLE
Soak tests: Do not assume hypervisors run with the full path

### DIFF
--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -106,9 +106,10 @@ check_all_running() {
 		fi
 
 		# check we have the right number of qemu's
-		how_many_qemus=$(pgrep -a -f ${HYPERVISOR_PATH} | wc -l)
-		if (( ${how_many_running} != ${how_many_qemus} )); then
-			echo "Wrong number of qemus running (${how_many_running} != ${how_many_qemus}) - stopping"
+		vmm_process=$(basename ${HYPERVISOR_PATH})
+		how_many_vmms=$(pgrep -a -f ${vmm_process} | wc -l)
+		if (( ${how_many_running} != ${how_many_vmms} )); then
+			echo "Wrong number of hypervisors running (${how_many_running} != ${how_many_vmms}) - stopping"
 			((goterror++))
 		fi
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -197,7 +197,7 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu"
+	local processes="kata-proxy kata-shim kata-runtime qemu firecracker"
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
Soak tests assume hypervisors run with the full path.

However when running a hypervisor with jailer the path is relative to
the jail and hence the check should only look for the process.

For example when running firecracker with jailer the process will be

 /firecracker
--id=5af26fcea8dbf413067e90026fd9845515d5a1f300d61f66427760a27ef114c2
--seccomp-level=2 --start-time-us=1562786230593253
--start-time-cpu-us=223 --api-sock=/api.socket�
where /firecracker is relative to the jailed location.

Fixes: #1802

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>