### PR TITLE
tests: Fix soak tests

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -25,6 +25,8 @@ case "${CI_JOB}" in
 	"FIRECRACKER"|"NEMU")
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
+		echo "INFO: Running soak test"
+		sudo -E PATH="$PATH" bash -c "make docker-stability"
 		echo "INFO: Running oci call test"
 		sudo -E PATH="$PATH" bash -c "make oci"
 		echo "INFO: Running networking tests"

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -46,11 +46,6 @@ if [ "$ID" == "debian" ]; then
 	exit
 fi
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	echo "Skip soak test (see https://github.com/kata-containers/tests/issues/1804)"
-	exit
-fi
-
 check_vsock_active() {
 	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
 	vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')
@@ -110,10 +105,10 @@ check_all_running() {
 			((goterror++))
 		fi
 
-		# check we have the right number of qemu's
-		how_many_qemus=$(pgrep -a -f ${HYPERVISOR_PATH} | wc -l)
-		if (( ${how_many_running} != ${how_many_qemus} )); then
-			echo "Wrong number of qemus running (${how_many_running} != ${how_many_qemus}) - stopping"
+		# check we have the right number of vm's
+		how_many_vms=$(pgrep -a $(basename ${HYPERVISOR_PATH} | cut -d '-' -f1) | wc -l)
+		if (( ${how_many_running} != ${how_many_vms} )); then
+			echo "Wrong number of $KATA_HYPERVISOR running (${how_many_running} != ${how_many_vms}) - stopping"
 			((goterror++))
 		fi
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -197,7 +197,7 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu"
+	local processes="kata-proxy kata-shim kata-runtime $(basename ${HYPERVISOR_PATH} | cut -d '-' -f1)"
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
Instead of taking the full path name of the hypervisors, we need to change
to use only the name of the process as this will change once that we enable
jailer on firecracker.
Fixes #1804

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>