### PR TITLE
network_plugin: delete memory limitation of flannel on AArch64

### DIFF
--- a/.ci/aarch64/kubernetes/init.sh
+++ b/.ci/aarch64/kubernetes/init.sh
@@ -8,5 +8,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-k8s_version=$(kubectl version | base64 | tr -d '\n')
-network_plugin_config="https://cloud.weave.works/k8s/net?k8s-version=${k8s_version}"
+network_plugin_config_file="${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/kube-flannel.yml"
+
+curl -fsL $flannel_url -o $network_plugin_config_file
+
+memory_resource="spec.template.spec.containers[*].resources.*.memory"
+# install yq if not exist
+${SCRIPT_PATH}/../../.ci/install_yq.sh
+# original flannel has limitation and request for memory, it may cause OOM on AArch64
+# so we delete related config on AArch64
+sudo -E ${GOPATH}/bin/yq d -i -d5 $network_plugin_config_file $memory_resource  > /dev/null
+
+network_plugin_config="$network_plugin_config_file"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -68,14 +68,17 @@ export KUBECONFIG="$HOME/.kube/config"
 kubectl get nodes
 kubectl get pods
 
+# default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation
+flannel_version="bc79dd1505b0c8681ece4de4c0d86c5cd2643275"
+flannel_url="https://raw.githubusercontent.com/coreos/flannel/${flannel_version}/Documentation/kube-flannel.yml"
+
 arch=$("${SCRIPT_PATH}/../../.ci/kata-arch.sh")
 #Load arch-specific configure file
 if [ -f "${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/init.sh" ]; then
         source "${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/init.sh"
 fi
 
-# default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation:
-network_plugin_config=${network_plugin_config:-https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml}
+network_plugin_config=${network_plugin_config:-$flannel_url}
 
 kubectl apply -f "$network_plugin_config"
 


### PR DESCRIPTION
Sorry for the trouble, I have decided to switch back to use flannel. It is small work load. And It is easy to be cleaned up on bare-metal. ;)
I know, A few days ago, I just replaced it with `weave`. But in recent days, I found that it costs too much work to clean up on bare-metal, and it requires more useless extra work load than flannel,
e.g.
```
root@entos-thunderx2-desktop:~/go/src/github.com/kata-containers/tests/integration/kubernetes# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp9s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 68:05:ca:83:6f:34 brd ff:ff:ff:ff:ff:ff
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default
    link/ether 02:42:33:4a:28:49 brd ff:ff:ff:ff:ff:ff
4: virbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
5: virbr0-nic: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master virbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
6: datapath: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether de:ea:2d:17:a5:3b brd ff:ff:ff:ff:ff:ff
8: weave: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 9a:22:ea:13:b3:9e brd ff:ff:ff:ff:ff:ff
10: vethwe-datapath@vethwe-bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue master datapath state UP mode DEFAULT group default
    link/ether ba:1c:56:b3:70:4e brd ff:ff:ff:ff:ff:ff
11: vethwe-bridge@vethwe-datapath: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue master weave state UP mode DEFAULT group default
    link/ether f2:fb:9a:5f:2c:fd brd ff:ff:ff:ff:ff:ff
12: vxlan-6784: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 65535 qdisc noqueue master datapath state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 0a:d5:c4:4b:52:fd brd ff:ff:ff:ff:ff:ff
14: vethwepl419181a@if13: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue master weave state UP mode DEFAULT group default
    link/ether 42:3c:81:0d:e3:b4 brd ff:ff:ff:ff:ff:ff link-netnsid 0
16: vethwepl47fd84f@if15: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1376 qdisc noqueue master weave state UP mode DEFAULT group default
    link/ether 5e:79:1a:17:db:0b brd ff:ff:ff:ff:ff:ff link-netnsid 1
```
It brought up a lot new interfaces to be cleaned up.
The original reason I firstly stopped using flannel on AArch64 is that it will be OOM killed for memory being limited of 50M. I have tried on different threshold, and found out different machines may need different threshold on AArch64.
So I just decided to delete the limitation on AArch64, related PR is on the way. ;) 