### PR TITLE
clean-up: do extra clean up for k8s integration on bare-metal CI

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -282,6 +282,9 @@ gen_clean_arch() {
 		GOCACHE=${GOCACHE:-$HOME/.cache/go-build}
 	fi
 	[ -d "$GOCACHE" ] && sudo rm -rf ${GOCACHE}/*
+
+	info "Clean transient test data and logs which has been stored under ${KATA_TESTS_BASEDIR}"
+	[ -d "${KATA_TESTS_BASEDIR}" ] && sudo rm -rf ${KATA_TESTS_BASEDIR}/*
 }
 
 build_install_parallel() {

--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -9,13 +9,14 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
-iptables_cache="${SCRIPT_PATH}/iptables_cache"
+source "${SCRIPT_PATH}/../../lib/common.bash"
+
+iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 
 # The kubeadm reset process does not reset or clean up iptables rules
 # you must do it manually
 # Here, we restore the iptables based on the previously cached file.
 sudo iptables-restore < "$iptables_cache"
-sudo rm -rf "$iptables_cache"
 
 # The kubeadm reset process does not clean your kubeconfig files.
 # you must remove them manually.

--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+iptables_cache="${SCRIPT_PATH}/iptables_cache"
+
+# The kubeadm reset process does not reset or clean up iptables rules
+# you must do it manually
+# Here, we restore the iptables based on the previously cached file.
+sudo iptables-restore < "$iptables_cache"
+sudo rm -rf "$iptables_cache"
+
+# The kubeadm reset process does not clean your kubeconfig files.
+# you must remove them manually.
+sudo -E rm -rf "$HOME/.kube"
+
+# Remove existing CNI configurations and binaries.
+sudo rm -rf /var/lib/cni/networks/*
+sudo rm -rf /opt/cni/bin/*

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -33,6 +33,12 @@ sudo ip link set dev flannel.1 down
 sudo ip link del cni0
 sudo ip link del flannel.1
 
+# if CI run in bare-metal, we need a set of extra clean
+BAREMETAL="${BAREMETAL:-false}"
+if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ];  then
+	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
+fi
+
 # Check no kata processes are left behind after reseting kubernetes
 check_processes
 

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -20,8 +20,11 @@ kubernetes_version=$(get_version "externals.kubernetes.version")
 
 # store iptables if CI running on bare-metal
 BAREMETAL="${BAREMETAL:-false}"
-iptables_cache="${SCRIPT_PATH}/iptables_cache"
-[ "${BAREMETAL}" == true ] && iptables-save > "$iptables_cache"
+iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
+if [ "${BAREMETAL}" == true ]; then
+	[ -d "${KATA_TESTS_DATADIR}" ] || sudo mkdir -p "${KATA_TESTS_DATADIR}"
+	iptables-save > "$iptables_cache"
+fi
 
 [ "$ID" == "fedora" ] && bash "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
 

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -18,6 +18,11 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 cri_runtime="${CRI_RUNTIME:-crio}"
 kubernetes_version=$(get_version "externals.kubernetes.version")
 
+# store iptables if CI running on bare-metal
+BAREMETAL="${BAREMETAL:-false}"
+iptables_cache="${SCRIPT_PATH}/iptables_cache"
+[ "${BAREMETAL}" == true ] && iptables-save > "$iptables_cache"
+
 [ "$ID" == "fedora" ] && bash "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
 
 case "${cri_runtime}" in
@@ -54,7 +59,6 @@ kubeadm_config_file="$(mktemp --tmpdir kubeadm_config.XXXXXX.yaml)"
 sed -e "s|CRI_RUNTIME_SOCKET|${cri_runtime_socket}|" "${kubeadm_config_template}" > "${kubeadm_config_file}"
 sed -i "s|KUBERNETES_VERSION|v${kubernetes_version/-*}|" "${kubeadm_config_file}"
 
-BAREMETAL="${BAREMETAL:-false}"
 if [ "${BAREMETAL}" == true ] && [[ $(wc -l /proc/swaps | awk '{print $1}') -gt 1 ]]; then
 	sudo swapoff -a || true
 fi

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -13,8 +13,14 @@ VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
 # Sandbox runtime directory
 RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"
 
+# Kata tests directory used for storing various test-related artifacts.
+KATA_TESTS_BASEDIR="${KATA_TESTS_LOGDIR:-/var/log/kata-tests}"
+
 # Directory that can be used for storing test logs.
-KATA_TESTS_LOGDIR="${KATA_TESTS_LOGDIR:-/var/log/kata-tests}"
+KATA_TESTS_LOGDIR="${KATA_TESTS_LOGDIR:-${KATA_TESTS_BASEDIR}/logs}"
+
+# Directory that can be used for storing test data.
+KATA_TESTS_DATADIR="${KATA_TESTS_DATADIR:-${KATA_TESTS_BASEDIR}/data}"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 


### PR DESCRIPTION
When running `kubeadm reset` to delete stale resource derived from k8s integration tests, we often get following suggestion:
```
The reset process does not reset or clean up iptables rules or IPVS tables.
If you wish to reset iptables, you must do so manually.
For example:
iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X

If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)
to reset your system's IPVS tables.

The reset process does not clean your kubeconfig files and you must remove them manually.
Please, check the contents of the $HOME/.kube/config file.
```
Especially for cleaning up iptables, if you don't clean it up, it may lead to `cni0` interface not being set up in master node next time.
They all exist in bare-metal environment. ;)