### PR TITLE
ci: fix possible unbound variable in install_crio.sh

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -39,6 +39,10 @@ if [ "$ID" == "fedora" ]; then
 	fi
 fi
 
+crio_version=$(get_version "externals.crio.version")
+crictl_version=$(get_test_version "externals.critools.version")
+crictl_tag_prefix="v"
+
 if [ "$ghprbGhRepository" != "${crio_repo/github.com\/}" ]
 then
 	# For Fedora, we use CRI-O version that is compatible with the
@@ -54,10 +58,6 @@ then
 		fi
 		crictl_version=$(get_version "externals.crio.meta.crictl")
 		crictl_tag_prefix=""
-	else
-		crio_version=$(get_version "externals.crio.version")
-		crictl_version=$(get_test_version "externals.critools.version")
-		crictl_tag_prefix="v"
 	fi
 fi
 


### PR DESCRIPTION
The latest merge of the cri tools PR seems to beak upstream tests with the error:
```
.ci/install_crio.sh: line 65: crictl_version: unbound variable
```

I'm unsure why we did not cover this failure on the CI, but that the variable is unbound would mean that this statement is false, right:
```
if [ "$ghprbGhRepository" != "${crio_repo/github.com\/}" ]
```

Reference: http://jenkins.katacontainers.io/job/kata-containers-crio-PR/3883/console

Closes #1815