### PR TITLE
Backport tests 1.8

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Description: Perform CI 'fast path return' checks.
+# Returns: 0 for 'fast return OK', 1 for 'do not fastpath'.
+#
+# Checks for:
+#  - file name patterns from the YAML that will force the CI to run
+#  - file name patterns from the YAML to see if we can skip all files in the PR
+#  - If potentially skipping, looks for a 'force' label on the PR to force the CI
+#    to run anyway
+
+set -e
+
+[ -n "$DEBUG" ] && set -x
+
+script_name="${0##*/}"
+script_dir_base=".ci"
+script_gitname="${script_dir_base}/${script_name}"
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+# If no branch specified, compare against the master.
+# The 'branch' var is required by the get_pr() lib functions.
+branch=${branch:-master}
+
+# The YAML file containing our filename match patterns.
+yqfile_rootname="ci-fast-return.yaml"
+yqfile="${cidir}/${yqfile_rootname}"
+yqfile_gitname="${script_dir_base}/${yqfile_rootname}"
+
+# The YAML file containing our unit test patterns
+unit_yamlfile_rootname="ci-fast-return/test.yaml"
+unit_yamlfile="${cidir}/${unit_yamlfile_rootname}"
+unit_yamlfile_gitname="${script_dir_base}/${unit_yamlfile_rootname}"
+
+# Name of the label, that if set on a PR, will force the CI to be run anyway.
+force_label="force-ci"
+
+# The list of files to check is held in a global, to make writing the unit test
+# code easier - otherwise we would have to pass two multi-entry lists (the list
+# of expressions and the list of filenames) to a single test function, which is
+# tricky.
+filenames=""
+
+# We have a local info func, as many of our funcs return their answers via stdout,
+# and we don't want to either open code a redirect all over the code nor send to
+# the standard stdout (would corrupt our return strings) or stderr (some CIs would
+# take that as a failure case). So, use another file descriptor, mapped back to
+# stdout, that we set up previously.
+local_info() {
+	msg="$*"
+	info "$msg" >&5
+}
+
+# Read our patterns from the YAML file.
+# Arguments:
+# $1 - the yaml file path
+# $2 - the yaml (yq) path to the patterns
+#
+# Returns on stdout
+#  the patterns found, or "" if no patterns (it will translate the yq 'null' return
+#  to the empty string)
+#
+read_yaml() {
+	res=$(yq read "$1" "$2")
+	[ "$res" == "null" ] && res=""
+	echo $res
+	return 0
+}
+
+# Check if any files in ${filenames} match the egrep command line expressions
+# passed in as arguments. Note, the arguments must be formatted *as passed*
+# to egrep. Thus, a single expression can just be passed on its own, but multiple
+# expressions must individually be prefixed with '-e' or '--regexp='.
+# Returns on stdout any files that match the patterns.
+check_matches() {
+	egrep $@ <<< "$filenames" || true
+}
+
+# Check if any files in ${filenames} *DO NOT* match the egrep command line expressions
+# passed in as arguments. Note, the arguments must be formatted *as passed*
+# to egrep. Thus, a single expression can just be passed on its own, but multiple
+# expressions must individually be prefixed with '-e' or '--regexp='.
+# Returns on stdout any files that *DO NOT* match the patterns.
+check_not_matches() {
+	egrep -v $@ <<< "$filenames" || true
+}
+
+# Check if any files changed by the PR either force the CI to run or if
+# we can skip all the files in the PR.
+#
+# Returns stdout string:
+#  0 - all files are fastpath - yes, we can skip.
+#  1 - at least one non-fastpath file found - cannot skip
+can_we_skip() {
+	# The branch is the baseline - ignore it.
+	if [ "$specific_branch" = "true" ]; then
+		local_info "Skip baseline branch"
+		echo "0"
+		return 0
+	fi
+
+	filenames=$(get_pr_changed_file_details || true)
+	# Strip off the leading status - just grab last column.
+	filenames=$(echo "$filenames"|awk '{print $NF}')
+
+	# no files were changed - I guess we can skip the CI then?
+	if [ -z "$filenames" ]; then
+		local_info "No files found"
+		echo "0"
+		return 0
+	fi
+
+	# Check to see if this file or any of its deps changed, as then we should
+	# run our own internal unit tests.
+	check_for_self_test
+
+	# Get our common patterns we check against all repos.
+	local common_skip=$(read_yaml ${yqfile} common.skip_patterns)
+	local common_check=$(read_yaml ${yqfile} common.check_patterns)
+
+	# Use just the repo name itself. The YAML does not like having the full
+	# repo path in it.
+	local repo="${kata_repo##*/}"
+
+	if [ -n "$repo" ]; then
+		# Get our repo specific patterns
+		local repo_skip=$(read_yaml ${yqfile} ${repo}.skip_patterns)
+		local repo_check=$(read_yaml ${yqfile} ${repo}.check_patterns)
+	else
+		local_info "No repo set, skipping repo specific patterns"
+	fi
+
+	local canskip_exprs=""
+	for x in $common_skip $repo_skip; do
+		# Build up the string of "-e exp1 -e exp2" arguments to later pass
+		# to the egrep based search.
+		canskip_exprs+=$(echo "-e $x ")
+	done
+
+	local mustcheck_exprs=""
+	for x in $common_check $repo_check; do
+		# Build up the string of "-e exp1 -e exp2" arguments to later pass
+		# to the egrep based search.
+		mustcheck_exprs+=$(echo "-e $x ")
+	done
+
+	local_info "Skip patterns: [$canskip_exprs]"
+	local_info "Check patterns: [$mustcheck_exprs]"
+
+	# do we have any patterns to check?
+	if [ -n "$mustcheck_exprs" ]; then
+		local need_checking=$(check_matches ${mustcheck_exprs[@]})
+	else
+		local_info "No force CI check patterns"
+		local need_checking=""
+	fi
+
+	# If we have any files that *must* be checked, then immediately return
+	if [ -n "$need_checking" ]; then
+		# stderr, so it does not get in our return value...
+		cat >&2 <<-EOT
+		INFO: Cannot fastpath skip CI.
+		INFO: Some files present must be CI checked.
+		INFO: Files to check are:
+
+		$need_checking
+
+EOT
+		echo "1"
+		return 0
+	else
+		local_info "No force check files found"
+	fi
+
+	# Now we have checked there are no 'must check' files, we can check to see
+	# if all files fall into the 'can skip' patterns.
+	# first, do we have any skip patterns to search for?
+	if [ -n "$canskip_exprs" ]; then
+		local non_skippable=$(check_not_matches ${canskip_exprs[@]} <<< "$filenames")
+	else
+		local_info "No skip CI check patterns"
+		# No patterns, set non-skippable list to all files then...
+		local non_skippable="$filenames"
+	fi
+
+	if [ -z "$non_skippable" ]; then
+		# stderr, so it does not get in our return value...
+		cat >&2 <<-EOT
+		INFO: No files to check in CI.
+		INFO: Fastpath short circuit returning from CI.
+		INFO: Files skipped are:
+
+		$filenames
+
+EOT
+		echo "0"
+		return 0
+	else
+		cat >&2 <<-EOT
+		INFO: Not all files skippable
+
+		$non_skippable
+
+EOT
+		echo "1"
+		return 0
+	fi
+}
+
+# Check if we have the 'magic label' that forces a CI run set on the PR
+# Returns on stdout as string:
+#  0 - No label found, could skip the CI
+#  1 - Label found - should run the CI
+check_force_label() {
+	if [ -z "$ghprbGhRepository" ]; then
+		local_info "No ghprbGhRepository set, skip label check"
+		echo "0"
+		return 0
+	fi
+
+	if [ -z "$ghprbPullId" ]; then
+		local_info "No ghprbPullId set, skip label check"
+		echo "0"
+		return 0
+	fi
+
+	local_info "Checking labels for PR ${ghprbGhRepository}/${ghprbPullId}"
+
+	# Pull the label list for the PR
+	# Ideally we'd use a github auth token here so we don't get rate limited, but to do that we would
+	# have to expose the token into the CI scripts, which is then potentially a security hole.
+	local json=$(curl -sL https://api.github.com/repos/${ghprbGhRepository}/issues/${ghprbPullId}/labels)
+
+	# Pull the label list out
+	local labels=$(jq .[].name <<< $json)
+
+	# Check if we have the forcing label set
+	for x in $labels; do
+		# Strip off any surrounding '"'s
+		y=$(sed 's/"//g' <<< $x)
+
+		if [ "$y" == "$force_label" ]; then
+			local_info "label found, forcing CI"
+			echo "1"
+			return 0
+		fi
+	done
+
+	local_info "No forcing label found"
+	echo "0"
+	return 0
+}
+
+# Unit tests. Check the YAML file reader functions work as expected.
+testYAMLreader() {
+	repos=()
+	patterns=()
+	results=()
+
+	# Check we can read 'common' patterns, and they act as we expect.
+	repos+=("common")
+	patterns+=("skip_patterns")
+	results+=("^CODEOWNERS$ .*\.md")
+
+	repos+=("common")
+	patterns+=("check_patterns")
+	results+=("check1 .*check2$")
+
+	# Check a pattern with no list does not fault.
+	repos+=("common")
+	patterns+=("empty_patterns")
+	results+=("")
+
+	# Check we do not fault looking for a pattern that is not defined.
+	repos+=("common")
+	patterns+=("undefined_patterns")
+	results+=("")
+
+	# Check we can read a named repo.
+	# Check single line expression entries work.
+	repos+=("documentation")
+	patterns+=("doc_single_entry")
+	results+=("single_pattern")
+
+	# Check we can handle multiple complex regexps.
+	repos+=("documentation")
+	patterns+=("doc_complex_patterns")
+	results+=("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$ ^#?([a-f0-9]{6}|[a-f0-9]{3})$")
+
+	# Check we do not fail if trying to assess a repo that is not defined.
+	repos+=("nonrepo")
+	patterns+=("nonrepo_pattern")
+	results+=("")
+
+	count=0
+	for x in ${repos[@]}; do
+		echo " $count: Testing $x:${patterns[$count]} == '${results[$count]}'"
+
+		res=$(read_yaml "$unit_yamlfile" "${x}.${patterns[$count]}")
+		assertEquals "${results[$count]}" "$res"
+
+		count=$(( count+1 ))
+	done
+}
+
+# Unit test: Check the pattern matcher functions work as expected.
+testPatternMatcher() {
+	filenames="fred
+john
+mark
+doc.md"
+
+	matches=$(check_matches '.*\.md')
+	assertEquals "doc.md" "$matches"
+
+	# Check it also works with `-e` multiple expressions
+	matches=$(check_matches '-e notaname -e .*\.md')
+	assertEquals "doc.md" "$matches"
+
+	matches=$(check_matches 'mark')
+	assertEquals "mark" "$matches"
+
+	matches=$(check_matches '^.*$')
+	assertEquals "$filenames" "$matches"
+
+	matches=$(check_not_matches '.*\.md')
+	assertEquals "fred
+john
+mark" "$matches"
+
+	# check with multi patterns
+	matches=$(check_not_matches '-e .*\.md -e john')
+	assertEquals "fred
+mark" "$matches"
+
+
+	matches=$(check_not_matches 'mark')
+	assertEquals "fred
+john
+doc.md" "$matches"
+
+	matches=$(check_not_matches '^.*$')
+	assertEquals "" "$matches"
+
+}
+
+# Check if any of our own files have changed in this PR, and if so, run our own
+# unit tests...
+check_for_self_test() {
+	local ourfiles=""
+
+	ourfiles+="-e ^${script_gitname}$ "
+	ourfiles+="-e ^${yqfile_gitname}$ "
+	ourfiles+="-e ^${unit_yamlfile_gitname}$ "
+
+	res=$(check_matches $ourfiles)
+
+	if [ -n "$res" ]; then
+		local_info "file(s) [$res] modified - self running unit tests"
+		# Need to push the unit test output via the stdout mapped file descriptor
+		# so we don't corrupt our actual test function return values.
+		${cidir}/${script_name} test >&5
+	fi
+}
+
+# Run our self tests. Tests are written using the
+# github.com/kward/shunit2 library, and are encoded into functions starting
+# with the string 'test'.
+self_test() {
+	local shunit2_path="github.com/kward/shunit2"
+	local_info "Running self tests"
+
+	local_info "Go get unit test framework from ${shunit2_path}"
+	go get -d "${shunit2_path}" || true
+	local_info "Run the unit tests"
+	# Sourcing the `shunit2` file automatically runs the unit tests in this file.
+	. "${GOPATH}/src/${shunit2_path}/shunit2"
+	# shunit2 call does not return - it exits with its return code.
+}
+
+help()
+{
+	cat <<EOT
+Usage: ${script_name} [test]
+
+This script will check if the CI system needs to be run, according
+to the egrep patterns found in the file ${yqfile}
+
+Passing the argument 'test' to this script will cause it to only
+run its self tests.
+EOT
+
+	exit 0
+}
+
+main() {
+
+	# Some of our sub-funcs return their results on stdout, but we also want them to be
+	# able to log INFO messages. But, we don't want those going to stderr, as that may
+	# be seen by some CIs as an actual error. Create another file descriptor, mapped
+	# back to stdout, for us to send INFO messages to...
+	exec 5>&1
+
+	if [ "$1" == "test" ]; then
+		self_test
+		# self_test func does not return
+	fi
+
+	[ $# -gt 0 ] && help
+
+	info "Checking for any changed files that will prevent CI fastpath return"
+	res=$(can_we_skip)
+
+	# If the file check says we can skip, check the labels to see if we are forcing the
+	# CI run anyway.
+	[ $res -eq 0 ] && res=$(check_force_label)
+	exit $res
+}
+
+main "$@"

--- a/.ci/ci-fast-return.yaml
+++ b/.ci/ci-fast-return.yaml
@@ -1,0 +1,43 @@
+---
+
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# List 'egrep' patterns of files that can:
+# - be skipped by the CI
+# - force the CI to always run (cannot be skipped), even if they match the 'can
+#   be skipped' patterns.
+#
+# Entries are of the form:
+#  repo_name:
+#    [skip_pattterns | check_patterns]: |
+#     (list of patterns, ideally one per line)
+#
+# The repo name 'common' is special, in that it will apply to all repos being checked.
+# The rules for 'common' and the repo under test are merged together before the checks
+# are carried out.
+#
+# Missing repo sections and missing pattern sections are handled correctly.
+#
+# 'yq' has a bug (https://github.com/mikefarah/yq/issues/188) whereby the yaml
+# parser tries to interpret '\.' as a special character expansion (like it would
+# for '\t') in many YAML string types (which in itself I think is another bug),
+# and explodes. Work around that by placing our pattern strings into a
+# ['literal block scalar'](https://yaml.org/spec/1.2/spec.html#id2793652),
+# that seems to work.
+
+common:
+        skip_patterns: |
+                ^CODEOWNERS$
+                ^LICENSE$
+                .*\.md
+                *\.travis\.yml
+                .*\.txt
+                ^VERSION$
+        check_patterns:
+
+documentation:
+        check_patterns: |
+                install/.*\.md

--- a/.ci/ci-fast-return/test.yaml
+++ b/.ci/ci-fast-return/test.yaml
@@ -1,0 +1,33 @@
+---
+
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# YAML file of test structures and patterns used in the ci-fast-return.sh
+# file unit tests.
+
+common:
+        skip_patterns: |
+                ^CODEOWNERS$
+                .*\.md
+        check_patterns: |
+                check1
+                .*check2$
+        empty_patterns:
+                # 'undefined_patterns' deliberately commented out to check
+                # we can correctly handle undefined patterns.
+        #undefined_patterns
+
+documentation:
+        doc_single_entry: |
+                single_pattern
+        doc_complex_patterns: |
+                ^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$
+                ^#?([a-f0-9]{6}|[a-f0-9]{3})$
+
+# Whole repo section and subsection deliberately commented out so unit tests can check we
+# do not pick it up.
+#nonrepo:
+        #nonrepo_pattern:

--- a/.ci/ci_cache_qemu.sh
+++ b/.ci/ci_cache_qemu.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+source "${cidir}/../lib/common.bash"
+source "${cidir}/lib.sh"
+
+WORKSPACE=${WORKSPACE:-$(pwd)}
+CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.version")
+QEMU_TAR="kata-qemu-static.tar.gz"
+QEMU_SHA_FILE="sha256sum-${QEMU_TAR}"
+
+cache_qemu_artifacts() {
+	local qemu_tar_location="$1"
+	[ -n "$qemu_tar_location" ] || die "couldn't retrieve QEMU location"
+	echo "${CURRENT_QEMU_VERSION}" >  "latest"
+
+	mkdir -p "${WORKSPACE}/artifacts"
+	sudo chown -R "${USER}:${USER}" .
+	sha256sum "${QEMU_TAR}" > "${QEMU_SHA_FILE}"
+	cat "${QEMU_SHA_FILE}"
+	mv "$QEMU_TAR" "$WORKSPACE/artifacts"
+	mv "${QEMU_SHA_FILE}" "$WORKSPACE/artifacts"
+	mv "latest" "$WORKSPACE/artifacts"
+}
+
+cache_qemu_artifacts "$QEMU_TAR"
+
+echo "artifacts:"
+ls -la "${WORKSPACE}/artifacts/"
+#The script is running in a VM as part of a CI Job, the artifacts will be
+#collected by the CI master node, sync to make sure any data is updated.
+sync

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -51,6 +51,11 @@ if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	runtime_config_path="${NEW_RUNTIME_CONFIG}"
 fi
 
+if [ "$KATA_HYPERVISOR" = "acrn" ]; then
+	echo "Enable acrn configuration.toml"
+	sudo mv "${PKGDEFAULTSDIR}/configuration-acrn.toml" "${PKGDEFAULTSDIR}/configuration.toml"
+fi
+
 if [ "$KATA_HYPERVISOR" = "firecracker" ]; then
 	echo "Enable firecracker configuration.toml"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-fc.toml" "${PKGDEFAULTSDIR}/configuration.toml"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -39,10 +39,6 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
 build_and_install "github.com/kata-containers/runtime" "" "true"
 
-# Check system supports running Kata Containers
-kata_runtime_path=$(command -v kata-runtime)
-sudo -E PATH=$PATH "$kata_runtime_path" kata-check
-
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file
 	sudo rm -f "${runtime_config_path}"
@@ -65,6 +61,10 @@ if [ "$KATA_HYPERVISOR" = "nemu" ]; then
 	echo "Enable nemu configuration.toml"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-nemu.toml" "${PKGDEFAULTSDIR}/configuration.toml"
 fi
+
+# Check system supports running Kata Containers
+kata_runtime_path=$(command -v kata-runtime)
+sudo -E PATH=$PATH "$kata_runtime_path" kata-check
 
 if [ -z "${METRICS_CI}" ]; then
 	echo "Enabling all debug options in file ${runtime_config_path}"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -107,6 +107,17 @@ then
 	fi
 fi
 
+# Check if we can fastpath return/skip the CI
+# Specifically do this **after** we have potentially done the static
+# checks, as we always want to run those.
+# Work around the 'set -e' dying if the check fails by using a bash
+# '{ group command }' to encapsulate.
+{ .ci/ci-fast-return.sh; ret=$?; } || true
+if [ "$ret" -eq 0 ]; then
+	echo "Short circuit fast path skipping the rest of the CI."
+	exit 0
+fi
+
 # Setup Kata Containers Environment
 #
 # - If the repo is "tests", this will call the script living in that repo

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -9,6 +9,7 @@
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
+export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -25,8 +25,6 @@ case "${CI_JOB}" in
 	"FIRECRACKER"|"NEMU")
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
-		echo "INFO: Running soak test"
-		sudo -E PATH="$PATH" bash -c "make docker-stability"
 		echo "INFO: Running oci call test"
 		sudo -E PATH="$PATH" bash -c "make oci"
 		echo "INFO: Running networking tests"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -25,6 +25,8 @@ case "${CI_JOB}" in
 	"FIRECRACKER"|"NEMU")
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
+		echo "INFO: Running soak test"
+		sudo -E PATH="$PATH" bash -c "make docker-stability"
 		echo "INFO: Running oci call test"
 		sudo -E PATH="$PATH" bash -c "make oci"
 		echo "INFO: Running networking tests"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -87,15 +87,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/CentOS_${VERSION_ID}/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
-		repo_file="/etc/yum.repos.d/home\:katacontainers\:releases\:$(arch)\:master.repo"
-		sudo bash -c "echo timeout=10 >> $repo_file"
-		sudo bash -c "echo retries=2 >> $repo_file"
-	fi
-
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -65,14 +65,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/Debian_${VERSION_ID}"
-		sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
-		curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
-		chronic sudo -E apt-get update
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -66,12 +66,6 @@ main()
 	echo "Install kata containers dependencies"
 	chronic sudo -E dnf -y groupinstall "Development tools"
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/Fedora_$VERSION_ID/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID dnf config-manager --add-repo "$obs_url"
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -63,14 +63,6 @@ main()
 	echo "Install YAML validator"
 	chronic sudo -E easy_install pip
 	chronic sudo -E pip install yamllint
-
-	[ "$setup_type" = "minimal" ] && exit 0
-
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/openSUSE_Leap_${VERSION_ID}"
-		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-	fi
 }
 
 main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -69,16 +69,6 @@ main()
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	if [ "$(arch)" == "x86_64" ]; then
-		VERSION_ID="7"
-		echo "Install Kata Containers OBS repository for CentOS (see https://github.com/kata-containers/packaging/pull/555)"
-		obs_url="${KATA_OBS_REPO_BASE}/CentOS_${VERSION_ID}/home:katacontainers:releases:$(arch):master.repo"
-		sudo -E VERSION_ID=$VERSION_ID yum-config-manager --add-repo "$obs_url"
-		repo_file="/etc/yum.repos.d/home\:katacontainers\:releases\:$(arch)\:master.repo"
-		sudo bash -c "echo timeout=10 >> $repo_file"
-		sudo bash -c "echo retries=2 >> $repo_file"
-	fi
-
 	echo "Install GNU parallel"
 	# GNU parallel not available in Centos repos, so build it instead.
 	build_install_parallel

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -80,12 +80,6 @@ main()
 	echo "Install Build Tools"
 	chronic sudo -E zypper -n install -t pattern "Basis-Devel"
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="${KATA_OBS_REPO_BASE}/SLE_${VERSION//-/_}/"
-		chronic sudo -E zypper addrepo --no-gpgcheck "${obs_url}/home:katacontainers:releases:$(arch):master.repo"
-	fi
-
 	echo "Add crudini repo"
 	VERSIONID="12_SP1"
 	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -74,14 +74,6 @@ main()
 	echo "Install os-tree"
 	chronic sudo -E apt install -y libostree-dev
 
-	if [ "$(arch)" == "x86_64" ]; then
-		echo "Install Kata Containers OBS repository"
-		obs_url="$KATA_OBS_REPO_BASE/xUbuntu_$(lsb_release -rs)/"
-		sudo sh -c "echo 'deb $obs_url /' > /etc/apt/sources.list.d/kata-containers.list"
-		curl -sL  "${obs_url}/Release.key" | sudo apt-key add -
-		chronic sudo -E apt-get update
-	fi
-
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
 		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -519,10 +519,10 @@ static_check_docs()
 		docs_status=$(get_pr_changed_file_details || true)
 		docs_status=$(echo "$docs_status" | grep "\.md$" || true)
 
-		docs=$(echo "$docs_status" | awk '{print $NF}')
+		docs=$(echo "$docs_status" | awk '{print $NF}' | sort)
 
 		# Newly-added docs
-		new_docs=$(echo "$docs_status" | awk '/^A/ {print $NF}')
+		new_docs=$(echo "$docs_status" | awk '/^A/ {print $NF}' | sort)
 
 		for doc in $new_docs
 		do

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -218,7 +218,7 @@ get_pr_changed_file_details_full()
 # Returns the information in format "${filter}\t${file}".
 get_pr_changed_file_details()
 {
-	get_pr_changed_file_details_full | grep -v "vendor/"
+	get_pr_changed_file_details_full | grep -vE "\<vendor/"
 }
 
 static_check_commits()
@@ -507,7 +507,7 @@ static_check_docs()
 	local new_urls
 	local url
 
-	all_docs=$(find . -name "*.md" | grep -v "vendor/" | sort || true)
+	all_docs=$(find . -name "*.md" | grep -v "/vendor/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
 	then
@@ -733,7 +733,7 @@ static_check_files()
 	then
 		info "Checking all files in $branch branch"
 
-		files=$(find . -type f | egrep -v "(.git|vendor)/" || true)
+		files=$(find . -type f | egrep -v "/(.git|vendor)/" || true)
 	else
 		info "Checking local branch for changed files only"
 
@@ -820,7 +820,7 @@ static_check_vendor()
 	if [ -n "$files" ]
 	then
 		# PR changed files so check if it changed any vendored files
-		vendor_files=$(echo "$files" | grep "vendor/" || true)
+		vendor_files=$(echo "$files" | grep -E "\<vendor/" || true)
 
 		if [ -n "$vendor_files" ]
 		then

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -52,6 +52,8 @@ typeset url_check_max_tries="${url_check_max_tries:-3}"
 typeset -A long_options
 
 long_options=(
+	[all]="Force checking of all changes, including files in the base branch"
+	[branch]="Specify upstream branch to compare against (default '$branch')"
 	[commits]="Check commits"
 	[docs]="Check document files"
 	[files]="Check files"
@@ -61,13 +63,11 @@ long_options=(
 	[labels]="Check labels databases"
 	[licenses]="Check licenses"
 	[list]="List tests that would run"
-	[branch]="Specify upstream branch to compare against (default '$branch')"
-	[all]="Force checking of all changes, including files in the base branch"
+	[no-arch]="Run/list all tests except architecture-specific ones"
+	[only-arch]="Only run/list architecture-specific tests"
 	[repo:]="Specify GitHub URL of repo to use (github.com/user/repo)"
 	[vendor]="Check vendor files"
 	[versions]="Check versions files"
-	[no-arch]="Run/list all tests except architecture-specific ones"
-	[only-arch]="Only run/list architecture-specific tests"
 )
 
 yamllint_cmd="yamllint"

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -46,6 +46,11 @@ if [ "$ID" == "debian" ]; then
 	exit
 fi
 
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	echo "Skip soak test (see https://github.com/kata-containers/tests/issues/1804)"
+	exit
+fi
+
 check_vsock_active() {
 	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
 	vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -46,11 +46,6 @@ if [ "$ID" == "debian" ]; then
 	exit
 fi
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	echo "Skip soak test (see https://github.com/kata-containers/tests/issues/1804)"
-	exit
-fi
-
 check_vsock_active() {
 	vsock_configured=$($RUNTIME_PATH kata-env | awk '/UseVSock/ {print $3}')
 	vsock_supported=$($RUNTIME_PATH kata-env | awk '/SupportVSock/ {print $3}')
@@ -110,10 +105,10 @@ check_all_running() {
 			((goterror++))
 		fi
 
-		# check we have the right number of qemu's
-		how_many_qemus=$(pgrep -a -f ${HYPERVISOR_PATH} | wc -l)
-		if (( ${how_many_running} != ${how_many_qemus} )); then
-			echo "Wrong number of qemus running (${how_many_running} != ${how_many_qemus}) - stopping"
+		# check we have the right number of vm's
+		how_many_vms=$(pgrep -a $(basename ${HYPERVISOR_PATH} | cut -d '-' -f1) | wc -l)
+		if (( ${how_many_running} != ${how_many_vms} )); then
+			echo "Wrong number of $KATA_HYPERVISOR running (${how_many_running} != ${how_many_vms}) - stopping"
 			((goterror++))
 		fi
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -197,7 +197,7 @@ show_system_state() {
 	local RPATH=$(command -v ${RUNTIME})
 	sudo ${RPATH} list
 
-	local processes="kata-proxy kata-shim kata-runtime qemu"
+	local processes="kata-proxy kata-shim kata-runtime $(basename ${HYPERVISOR_PATH} | cut -d '-' -f1)"
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
7b7f4f7 tests: Fix soak tests
4f709a2 tests: Skip soak test in firecracker
c795e8a ci: fast path return check
ad852a7 ci: add ci fastpath check file
54ea380 ci: run kata-check after correct config file is in place
148a9f7 CI: Add acrn to the supported hypervisors
4317bf1 ci: Remove installation from OBS
a0456e9 CI: Check documents in order
17caa52 CI: Sort long options
d9326fb CI: Improve vendor filtering
78774fd CI: Use cached qemu if up to date