### PR TITLE
ci: static-checks: fix check_commits comparison

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -967,7 +967,7 @@ main()
 
 	for func in $all_check_funcs
 	do
-		if [ "$func" = "check_commits" ]; then
+		if [ "$func" = "static_check_commits" ]; then
 			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "master" ]
 			then
 				echo "Skipping checkcommits"


### PR DESCRIPTION
`check_commits` was renamed to `static_check_commits`.

Fixes #1820.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>