### PR TITLE
test: Make aware test pod cgroup option.

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -28,8 +28,7 @@ runtime_repo="${runtime_repo:-github.com/kata-containers/runtime}"
 # This script is intended to execute under Jenkins
 # If we do not know where the Jenkins defined WORKSPACE area is
 # then quit
-if [ -z "${WORKSPACE}" ]
-then
+if [ -z "${WORKSPACE}" ]; then
 	echo "Jenkins WORKSPACE env var not set - exiting" >&2
 	exit 1
 fi
@@ -93,13 +92,11 @@ fi
 "${GOPATH}/src/${tests_repo}/.ci/resolve-kata-dependencies.sh"
 
 # Run the static analysis tools
-if [ -z "${METRICS_CI}" ]
-then
+if [ -z "${METRICS_CI}" ]; then
 	# We also run static checks on travis for x86 and ppc64le,
 	# so run them on jenkins only on architectures that travis
 	# do not support.
-	if [ "$arch" = "s390x" ] || [ "$arch" = "aarch64" ]
-	then
+	if [ "$arch" = "s390x" ] || [ "$arch" = "aarch64" ]; then
 		specific_branch=""
 		# If not a PR, we are testing on stable or master branch.
 		[ -z "$pr_number" ] && specific_branch="true"
@@ -112,7 +109,10 @@ fi
 # checks, as we always want to run those.
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
-{ ${tests_repo_dir}/.ci/ci-fast-return.sh; ret=$?; } || true
+{
+	${tests_repo_dir}/.ci/ci-fast-return.sh
+	ret=$?
+} || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."
 	exit 0
@@ -124,13 +124,19 @@ fi
 #   directly.
 # - If the repo is not "tests", call the repo-specific script (which is
 #   expected to call the script of the same name in the "tests" repo).
-if [  "$CI_JOB" == "CRI_CONTAINERD_K8S" ]; then
+case "${CI_JOB}" in
+"CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s
 	export CRI_CONTAINERD="yes"
 	export KUBERNETES="yes"
 	export CRIO="no"
 	export OPENSHIFT="no"
-fi
+	;;
+"SANDBOX_CGROUP_ONLY")
+	# Used by runtime makefile to enable option on intall
+	export DEFSANDBOXCGROUPONLY=true
+	;;
+esac
 .ci/setup.sh
 
 # Now we have all the components installed, log that info before we
@@ -142,12 +148,9 @@ else
 	echo "WARN: Kata runtime is not installed"
 fi
 
-if [ -z "${METRICS_CI}" ]
-then
-	if [ "${kata_repo}" != "${tests_repo}" ]
-	then
-		if [ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ]
-		then
+if [ -z "${METRICS_CI}" ]; then
+	if [ "${kata_repo}" != "${tests_repo}" ]; then
+		if [ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ]; then
 			echo "INFO: issue ${unit_issue}"
 		else
 			echo "INFO: Running unit tests for repo $kata_repo"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -10,6 +10,7 @@ export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
+export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/.ci/rollback_enable_sandbox_cgroup_only.sh
+++ b/.ci/rollback_enable_sandbox_cgroup_only.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+readonly script_dir=$(dirname $(readlink -f "$0"))
+
+# Source to trap error line number
+# shellcheck source=../lib/common.bash
+source "${script_dir}/../lib/common.bash"
+# shellcheck source=./lib.sh
+source "${script_dir}/lib.sh"
+
+option="sandbox_cgroup_only"
+bk_suffix="${option}-bk"
+bk_file="${KATA_ETC_CONFIG_PATH}-${bk_suffix}"
+
+info "Check if exist ${bk_file}"
+
+if [ -f "${bk_file}" ]; then
+	info "restore backup ${KATA_ETC_CONFIG_PATH} "
+	sudo mv "${bk_file}" "${KATA_ETC_CONFIG_PATH}"
+else
+	info "No backup to restore from ${KATA_ETC_CONFIG_PATH} "
+fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# This script will execute the Kata Containers Test Suite. 
+# This script will execute the Kata Containers Test Suite.
 
 set -e
 
@@ -21,8 +21,17 @@ case "${CI_JOB}" in
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+
+		# Make sure the feature works with K8s + containerd
+		"${cidir}/toggle_sandbox_cgroup_only.sh" true
+		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		"${cidir}/toggle_sandbox_cgroup_only.sh" true
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+		# remove config created by toggle_sandbox_cgroup_only.sh
+		"${cidir}/toggle_sandbox_cgroup_only.sh" false
+		sudo rm -f "/etc/kata-containers/configuration.toml"
 		;;
-	"FIRECRACKER"|"NEMU")
+	"FIRECRACKER" | "NEMU")
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
 		echo "INFO: Running soak test"

--- a/.ci/toggle_sandbox_cgroup_only.sh
+++ b/.ci/toggle_sandbox_cgroup_only.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+readonly script_dir=$(dirname $(readlink -f "$0"))
+readonly script_name="$(basename "${BASH_SOURCE[0]}")"
+# Source to trap error line number
+# shellcheck source=../lib/common.bash
+source "${script_dir}/../lib/common.bash"
+# shellcheck source=./lib.sh
+source "${script_dir}/lib.sh"
+
+option="sandbox_cgroup_only"
+request=${1:-}
+
+usage(){
+	cat <<EOT
+Usage:
+${script_name} <true|false|clean>"
+
+false: Disable ${option}
+true:  Enable ${option}
+
+The configuration changes are applied in kata user config:
+${KATA_ETC_CONFIG_PATH}
+
+Remove it if you want to use the stateless options.
+EOT
+}
+
+case ${request} in
+	true)
+		;;
+	false)
+		;;
+	*)
+		usage
+		exit 1
+		;;
+esac
+
+current_value=$(kata-runtime kata-env --json | jq ".Runtime.SandboxCgroupOnly")
+if [ "$current_value" == "${request}" ]; then
+	info "already ${request}"
+	exit 0
+fi
+
+kata_config_path=$(kata-runtime kata-env --json | jq -r .Runtime.Config.Path)
+
+bk_suffix="${option}-bk"
+
+
+if [ -f "${KATA_ETC_CONFIG_PATH}" ] && [ "${KATA_ETC_CONFIG_PATH}" != ${kata_config_path} ]; then
+	bk_file="${KATA_ETC_CONFIG_PATH}-${bk_suffix}"
+	info "backup ${KATA_ETC_CONFIG_PATH} in ${bk_file}"
+	sudo cp "${KATA_ETC_CONFIG_PATH}" "${bk_file}"
+fi
+
+if [ "${KATA_ETC_CONFIG_PATH}" != "${kata_config_path}" ]; then
+	info "Creating etc config based on ${kata_config_path}"
+	sudo cp "${kata_config_path}" "${KATA_ETC_CONFIG_PATH}"
+fi
+
+info "modifying config file : ${KATA_ETC_CONFIG_PATH}"
+sudo crudini --set "${KATA_ETC_CONFIG_PATH}" "runtime" "${option}" "${request}"
+
+info "Validate option is ${request}"
+current_value=$(kata-runtime kata-env --json | jq ".Runtime.SandboxCgroupOnly")
+
+[ "$current_value" == "${request}" ] || die "The option was not updated"
+
+info "OK"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -78,6 +78,20 @@ fi
 
 echo "Start ${cri_runtime} service"
 sudo systemctl start ${cri_runtime}
+max_cri_socket_check=5
+wait_time_cri_socket_check=5
+
+for i in $(seq ${max_cri_socket_check}); do
+	#when the test runs two times in the CI, the second time crio takes some time to be ready
+	sleep "${wait_time_cri_socket_check}"
+	if [ -f "${cri_runtime_socket}" ]; then
+		break
+	fi
+
+	echo "Waiting for cri socket ${cri_runtime_socket} (try ${i})"
+done
+
+sudo systemctl status "${cri_runtime}"
 
 echo "Init cluster using ${cri_runtime_socket}"
 kubeadm_config_template="${SCRIPT_PATH}/kubeadm/config.yaml"


### PR DESCRIPTION
- Add scripts to enable it if needed.
- Add script to rolback config to enable it.
- Check in docker test if option is enabled to not check cgroups in the
host.

Depends-on: github.com/kata-containers/runtime#1880

Fixes: #1810

Signed-off-by: Jose Carlos Venegas Munoz <jcvenega@jcvenega-nuc.zpn.intel.com>