### PR TITLE
spellcheck: add macOS

### DIFF
--- a/cmd/check-spelling/data/distros.txt
+++ b/cmd/check-spelling/data/distros.txt
@@ -8,6 +8,7 @@ CentOS/B
 Debian/B
 EulerOS/B
 Fedora/B
+macOS/B
 openSUSE/B
 RHEL/B
 SLES/B


### PR DESCRIPTION
We refer to macOS in some docs - either that things are or are not
supported on that platform for instance.
`macOS` is not in the standard base hunspell dict, so add it to our
local distro dict.

Fixes: #1825

Signed-off-by: Graham Whaley <graham.whaley@intel.com>