### PR TITLE
ci: Allow travis to use go install script

### DIFF
--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -96,6 +96,10 @@ if command -v go; then
 	fi
 fi
 
+if [ "$(uname -s)" == "Darwin" ]; then
+	goarch=amd64
+fi
+
 case "$(arch)" in
 	"aarch64")
 		goarch=arm64
@@ -118,8 +122,9 @@ case "$(arch)" in
 esac
 
 info "Download go version ${go_version}"
-curl -OL "https://storage.googleapis.com/golang/go${go_version}.linux-${goarch}.tar.gz"
+kernel_name=$(uname -s)
+curl -OL "https://storage.googleapis.com/golang/go${go_version}.${kernel_name,,}-${goarch}.tar.gz"
 info "Install go"
 mkdir -p "${install_dest}"
-sudo tar -C "${install_dest}" -xzf "go${go_version}.linux-${goarch}.tar.gz"
+sudo tar -C "${install_dest}" -xzf "go${go_version}.${kernel_name,,}-${goarch}.tar.gz"
 popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,13 @@ matrix:
 language: go
 go_import_path: github.com/kata-containers/tests
 
-go:
-  - "1.11.x"
-  - stable
-
 env:
   - target_branch=$TRAVIS_BRANCH
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then .ci/setup.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint gnu-getopt; fi
+  - bash .ci/install_go.sh -p -f
 
 script:
   - bash .ci/static-checks.sh github.com/kata-containers/tests


### PR DESCRIPTION
This allows to use the install_go.sh script to be used by Travis instead
of a specific version.

Fixes #1738

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>