### PR TITLE
ci: Set the complete path for the ci-fast-return.sh

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -112,7 +112,7 @@ fi
 # checks, as we always want to run those.
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
-{ .ci/ci-fast-return.sh; ret=$?; } || true
+{ ${tests_repo_dir}/.ci/ci-fast-return.sh; ret=$?; } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."
 	exit 0


### PR DESCRIPTION
It seems that we need to add the complete path in order that the jenkins_job
finds the script to perform the ci-fast-return.sh

Fixes #1829

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>