### PR TITLE
ci: fast-path: install yq before use

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -67,6 +67,8 @@ local_info() {
 #  to the empty string)
 #
 read_yaml() {
+	${cidir}/install_yq.sh >&2
+
 	res=$(yq read "$1" "$2")
 	[ "$res" == "null" ] && res=""
 	echo $res


### PR DESCRIPTION
We need `yq` installed to parse our yaml config file. Use our
`install_yq` script to ensure it is present or installed.

Fixes: #1833

Signed-off-by: Graham Whaley <graham.whaley@intel.com>