### PR TITLE
ci: jenkins: metrics: add metrics call direct to jenkins script

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -162,6 +162,9 @@ then
 
 	# Code coverage
 	bash <(curl -s https://codecov.io/bash)
+else
+	echo "Running the metrics tests:"
+	.ci/run_metrics_PR_ci.sh
 fi
 
 popd


### PR DESCRIPTION
Currently we call the jenkins script to set up the system, and then call
the run_metrics_PR_ci.sh script from the metrics jenkins job files to
run the actul metrics.
This flow does not 'understand' the new ci fast path, and then fails.
The best fix is to move the call to the metrics script into the main
jenkins file, and remove it from the jenkins job files.

Fixes: #1835

Signed-off-by: Graham Whaley <graham.whaley@intel.com>