### PR TITLE
integration: add hypervisor kill test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ docker-stability:
 	cd integration/stability && \
 	export ITERATIONS=2 && export MAX_CONTAINERS=20 && ./soak_parallel_rm.sh
 	cd integration/stability && ./bind_mount_linux.sh
+	cd integration/stability && ./hypervisor_stability_kill_test.sh
 
 kubernetes:
 	bash -f .ci/install_bats.sh

--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This test will kill a running container's
+# hypervisor, and see how we react to cleanup.
+
+set -e
+
+cidir=$(dirname "$0")
+
+source "${cidir}/../../metrics/lib/common.bash"
+
+# Environment variables
+IMAGE="${IMAGE:-busybox}"
+CONTAINER_NAME="${CONTAINER_NAME:-test}"
+PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
+
+# Set the runtime if not set already
+RUNTIME="${RUNTIME:-kata-runtime}"
+
+setup()  {
+	clean_env
+	sudo docker run --runtime=$RUNTIME -d --name $CONTAINER_NAME $IMAGE $PAYLOAD_ARGS
+	num=$(ps aux | grep ${HYPERVISOR_PATH} | grep -v grep | wc -l)
+	[ ${num} -eq 1 ] || die "hypervisor count:${num} expected:1"
+}
+
+kill_hypervisor()  {
+	pid=$(ps aux | grep ${HYPERVISOR_PATH} | grep -v grep | awk '{print $2}')
+	[ -n ${pid} ] || die "failed to find hypervisor pid"
+	sudo kill -KILL ${pid} || die "failed to kill hypervisor (pid ${pid})"
+	num=$(ps aux | grep ${HYPERVISOR_PATH} | grep -v grep | wc -l)
+	[ ${num} -eq 0 ] || die "hypervisor count:${num} expected:0"
+	sudo docker rm -f $CONTAINER_NAME
+	[ $? -eq 0 ] || die "failed to force removing container $CONTAINER_NAME"
+}
+
+teardown()  {
+	echo "Ending hypervisor stability test"
+	clean_env
+}
+
+trap teardown EXIT
+
+echo "Starting hypervisor stability test"
+setup
+
+echo "Running hypervisor stability test"
+kill_hypervisor


### PR DESCRIPTION
Kill hypervisor and then force remove the container.
We should be able to handle the exceptional case properly.

Fixes: #1838
Depends-on: github.com/kata-containers/runtime#1897