### PR TITLE
ci: metrics: run metrics script using full tests repo path

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -164,7 +164,7 @@ then
 	bash <(curl -s https://codecov.io/bash)
 else
 	echo "Running the metrics tests:"
-	.ci/run_metrics_PR_ci.sh
+	"${tests_repo_dir}/.ci/run_metrics_PR_ci.sh"
 fi
 
 popd


### PR DESCRIPTION
As we `pushd` into the kata repositories paths (other than
tests) we need to specify the `tests_repo_dir` to call
the metrics script

Fixes: #1840.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>