### PR TITLE
spellcheck: add minikube

### DIFF
--- a/cmd/check-spelling/data/distros.txt
+++ b/cmd/check-spelling/data/distros.txt
@@ -9,6 +9,7 @@ Debian/B
 EulerOS/B
 Fedora/B
 macOS/B
+minikube/B
 openSUSE/B
 RHEL/B
 SLES/B


### PR DESCRIPTION
Add minikube to dictionary.

Fixes: #1842

Signed-off-by: Eric Ernst <eric.ernst@intel.com>