### PR TITLE
backport 1.8 tests improvements

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -67,6 +67,8 @@ local_info() {
 #  to the empty string)
 #
 read_yaml() {
+	${cidir}/install_yq.sh >&2
+
 	res=$(yq read "$1" "$2")
 	[ "$res" == "null" ] && res=""
 	echo $res

--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -96,6 +96,10 @@ if command -v go; then
 	fi
 fi
 
+if [ "$(uname -s)" == "Darwin" ]; then
+	goarch=amd64
+fi
+
 case "$(arch)" in
 	"aarch64")
 		goarch=arm64
@@ -118,8 +122,9 @@ case "$(arch)" in
 esac
 
 info "Download go version ${go_version}"
-curl -OL "https://storage.googleapis.com/golang/go${go_version}.linux-${goarch}.tar.gz"
+kernel_name=$(uname -s)
+curl -OL "https://storage.googleapis.com/golang/go${go_version}.${kernel_name,,}-${goarch}.tar.gz"
 info "Install go"
 mkdir -p "${install_dest}"
-sudo tar -C "${install_dest}" -xzf "go${go_version}.linux-${goarch}.tar.gz"
+sudo tar -C "${install_dest}" -xzf "go${go_version}.${kernel_name,,}-${goarch}.tar.gz"
 popd

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -112,7 +112,7 @@ fi
 # checks, as we always want to run those.
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
-{ .ci/ci-fast-return.sh; ret=$?; } || true
+{ ${tests_repo_dir}/.ci/ci-fast-return.sh; ret=$?; } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."
 	exit 0

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -162,6 +162,9 @@ then
 
 	# Code coverage
 	bash <(curl -s https://codecov.io/bash)
+else
+	echo "Running the metrics tests:"
+	.ci/run_metrics_PR_ci.sh
 fi
 
 popd

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -164,7 +164,7 @@ then
 	bash <(curl -s https://codecov.io/bash)
 else
 	echo "Running the metrics tests:"
-	.ci/run_metrics_PR_ci.sh
+	"${tests_repo_dir}/.ci/run_metrics_PR_ci.sh"
 fi
 
 popd

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -322,3 +322,41 @@ check_git_version() {
 
 	echo "${result}"
 }
+
+# Obtain a list of the files the PR changed.
+# Returns the information in format "${filter}\t${file}".
+get_pr_changed_file_details_full()
+{
+	# List of filters used to restrict the types of file changes.
+	# See git-diff-tree(1) for further info.
+	local filters=""
+
+	# Added file
+	filters+="A"
+
+	# Copied file
+	filters+="C"
+
+	# Modified file
+	filters+="M"
+
+	# Renamed file
+	filters+="R"
+
+	# Unmerged (U) and Unknown (X) files. These particular filters
+	# shouldn't be necessary but just in case...
+	filters+="UX"
+
+	git diff-tree \
+		-r \
+		--name-status \
+		--diff-filter="${filters}" \
+		"origin/${branch}" HEAD
+}
+
+# Obtain a list of the files the PR changed, ignoring vendor files.
+# Returns the information in format "${filter}\t${file}".
+get_pr_changed_file_details()
+{
+	get_pr_changed_file_details_full | grep -v "vendor/"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,13 @@ matrix:
 language: go
 go_import_path: github.com/kata-containers/tests
 
-go:
-  - "1.11.x"
-  - stable
-
 env:
   - target_branch=$TRAVIS_BRANCH
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then .ci/setup.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint gnu-getopt; fi
+  - bash .ci/install_go.sh -p -f
 
 script:
   - bash .ci/static-checks.sh github.com/kata-containers/tests

--- a/cmd/check-spelling/data/distros.txt
+++ b/cmd/check-spelling/data/distros.txt
@@ -9,6 +9,7 @@ Debian/B
 EulerOS/B
 Fedora/B
 macOS/B
+minikube/B
 openSUSE/B
 RHEL/B
 SLES/B

--- a/cmd/check-spelling/data/distros.txt
+++ b/cmd/check-spelling/data/distros.txt
@@ -8,6 +8,7 @@ CentOS/B
 Debian/B
 EulerOS/B
 Fedora/B
+macOS/B
 openSUSE/B
 RHEL/B
 SLES/B


### PR DESCRIPTION
efe44db spellcheck: add minikube
a38e336 ci: metrics: run metrics script using full tests repo path
ccef774 ci: jenkins: metrics: add metrics call direct to jenkins script
ef5b03b ci: Allow travis to use go install script
87caf2a ci: fast-path: install yq before use
f9ca367 ci: Set the complete path for the ci-fast-return.sh
7c39ca0 spellcheck: add macOS
c6a4c1b ci: move pr file list funcs out to library file
