### PR TITLE
test: Skip hypervisor stability test on FC

### DIFF
--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -21,6 +21,14 @@ PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 # Set the runtime if not set already
 RUNTIME="${RUNTIME:-kata-runtime}"
 
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	issue="https://github.com/kata-containers/tests/issues/1849"
+	echo "Skip hypervisor stability kill test, see: $issue"
+	exit
+fi
+
 setup()  {
 	clean_env
 	sudo docker run --runtime=$RUNTIME -d --name $CONTAINER_NAME $IMAGE $PAYLOAD_ARGS


### PR DESCRIPTION
We need to disable this test on FC as it is failing
(see https://github.com/kata-containers/tests/issues/1848) in order
to not affect the firecracker CI.

Fixes #1849

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>