### PR TITLE
docs: Fix Unit Test Advice document

### DIFF
--- a/Unit-Test-Advice.md
+++ b/Unit-Test-Advice.md
@@ -65,7 +65,7 @@ func TestJoinParamsWithDash(t *testing.T) {
         // Call the function under test
         result, err := joinParamsWithDash(d.param1, d.param2)
 
-        if expectError {
+        if d.expectError {
             assert.Error(err, msg)
 
             // If an error is expected, there is no point


### PR DESCRIPTION
The expectError should be replace by d.expectError at the Unit Test
Advice document.

Fixes #1837

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>