### PR TITLE
ci: Fix FC installation script

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -63,10 +63,10 @@ path="/usr/local/bin/kata-runtime"
 
 if [ -f $docker_configuration_file ]; then
 	# Check devicemapper flag
-	check_devicemapper=$(grep -w '"storage-driver": "${driver}"' $docker_configuration_file | wc -l)
+	check_devicemapper=$(grep -w '"storage-driver": "'${driver}'"' $docker_configuration_file | wc -l)
 	[ $check_devicemapper -eq 0 ] && die "${driver} is not enabled at $docker_configuration_file"
 	# Check kata runtime flag
-	check_kata=$(grep -w '"path": "${path}"' $docker_configuration_file | wc -l)
+	check_kata=$(grep -w '"path": "'${path}'"' $docker_configuration_file | wc -l)
 	[ $check_kata -eq 0 ] && die "Kata Runtime path not found at $docker_configuration_file"
 else
 	cat <<-EOF | sudo tee "$docker_configuration_file"


### PR DESCRIPTION
While running multiple times the fc installation script fails to
detect the variables of driver and path at the configuration file. This
ensures that we can detect those variables.

Fixes #1854

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>