### PR TITLE
cri-containerd: Remove wrong artifacts before test-integration

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -166,6 +166,9 @@ main() {
 
 	pushd "${GOPATH}/src/${cri_containerd_repo}"
 
+	# Make sure the right artifacts are going to be built
+	make clean
+
 	check_daemon_setup
 
 	info "containerd(cri): testing using runtime: ${containerd_runtime_test}"


### PR DESCRIPTION
Remove the artifacts leftover from installation from source before
execution.
This ensures that make test-integration builds the CI-Version
of cri-containerd.

Fixes: #1851

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>