### PR TITLE
static-checks: Ignore go modules metadata files.

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -379,6 +379,8 @@ static_check_license_headers()
 		--exclude="*.xml" \
 		--exclude="*.yaml" \
 		--exclude="*.yml" \
+		--exclude="go.mod" \
+		--exclude="go.sum" \
 		-EL "\<${pattern}\>" \
 		$files || true)
 


### PR DESCRIPTION
go.mod and go.sum are generated by go modules tooling.
Ignore license checks for these files.

Fixes #1859

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>