### PR TITLE
liveness: replace test image liveness and goproxy with unified agnhost

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -13,9 +13,9 @@ spec:
   runtimeClassName: kata
   containers:
   - name: liveness
-    image: k8s.gcr.io/liveness
+    image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
     args:
-    - /server
+    - liveness
     livenessProbe:
       httpGet:
         path: /healthz

--- a/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -8,12 +8,14 @@ kind: Pod
 metadata:
   name: tcptest
   labels:
-    app: goproxy
+    app: tcp-liveness
 spec:
   runtimeClassName: kata
   containers:
-  - name: goproxy
-    image: k8s.gcr.io/goproxy:0.1
+  - name: tcp-liveness
+    image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
+    args:
+    - liveness
     ports:
     - containerPort: 8080
     readinessProbe:


### PR DESCRIPTION
original image `liveness` and `goproxy:0.1` have all been discarded by kubernetes community. And they are also single-arch images only for amd64.
kubernetes community has centralized quite a few images into the unified `agnhost`, including `liveness`, detailed info seen here [kubernetes/kubernetes#78389](https://github.com/kubernetes/kubernetes/pull/78389).
The `agnhost` binary has several sub-commands which are can be used to test different Kubernetes features. And `agnhost` image is multi-arch image for several platforms, including amd64, arm64, ppc64le, etc.
```
$ docker manifest inspect gcr.io/kubernetes-e2e-test-images/agnhost:2.2
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1779,
         "digest": "sha256:528ffe052695654a76abf10a43901ee7816e2884a7bcc17f77597fd9a665421d",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1990,
         "digest": "sha256:5cc391bacd3309f925dfe34426a1b6e8a29e0ee90bc955249602f3d0c2c317c8",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1990,
         "digest": "sha256:58fd2ae81c26068f43f28f04ae080c6ebfe5cda24822eb201f3b7c8730275e9c",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1990,
         "digest": "sha256:18f96f0a83fe22d57b877f05869eb2f00e2c67f0a68251c17a927533d1f1b1d0",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1990,
         "digest": "sha256:f19adaef08ef40a088e6758e3cdc9453daf861113815d836a4a8177fb6d90a34",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```
The `liveness` sub-command will start a simple server that is alive for 10 seconds, then reports unhealthy for the rest of its (hopefully) short existence. 
detailed info about `agnhost` image could be found [here](https://github.com/kubernetes/kubernetes/tree/master/test/images/agnhost).