### PR TITLE
Add distro words and minor spell checker fixes

### DIFF
--- a/cmd/check-spelling/data/distros.txt
+++ b/cmd/check-spelling/data/distros.txt
@@ -9,8 +9,10 @@ Debian/B
 EulerOS/B
 Fedora/B
 macOS/B
+MacOS/B
 minikube/B
 openSUSE/B
+OpenSUSE/B
 RHEL/B
 SLES/B
 Ubuntu/B

--- a/cmd/check-spelling/kata-spell-check.sh
+++ b/cmd/check-spelling/kata-spell-check.sh
@@ -339,7 +339,7 @@ main()
 {
 	setup
 
-	[ -z "$1" ] && die "need command"
+	[ -z "${1:-}" ] && die "need command"
 
 	case "$1" in
 		check) shift && spell_check_file "$1" ;;

--- a/cmd/check-spelling/kata-spell-check.sh
+++ b/cmd/check-spelling/kata-spell-check.sh
@@ -339,7 +339,7 @@ main()
 {
 	setup
 
-	[ -z "${1:-}" ] && die "need command"
+	[ -z "${1:-}" ] && usage && echo && die "need command"
 
 	case "$1" in
 		check) shift && spell_check_file "$1" ;;


### PR DESCRIPTION
Add "MacOS" and "OpenSUSE" to the distros fragment for the custom dictionary.

Both these terms already existed in distros fragments file, but with different capitalisation, correct for each term.

Although `hunspell(1)` will automatically accept the capitalised versions of custom words specified in the dictionary in all lower-case, it will *not* accept capitalised custom words starting with a lower-case letter but containing an upper-case one, like both of the previously specified terms.

Also fix an unbound variable error if no spell checker CLI command is specified and improve the error message in that scenario.

Fixes: #1866.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
