### PR TITLE
cri-o: Run tests sequentially when using devicemapper

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -97,7 +97,11 @@ if [ "$ID" == "ubuntu" ]; then
 	if sudo fdisk -l "$LVM_DEVICE" | grep "${LVM_DEVICE}[1-9]"; then
 		die "detected partitions on block device: ${LVM_DEVICE}. Will not continue"
 	fi
-	export STORAGE_OPTIONS="$DM_STORAGE_OPTIONS --storage-opt dm.directlvm_device=${LVM_DEVICE}"
+	# When using devicemapper, do not run tests in parallel as each test
+	# will launch a new cri-o process which will try to use same block device.
+	export JOBS=1 \
+		STORAGE_OPTIONS="$DM_STORAGE_OPTIONS --storage-opt dm.directlvm_device=${LVM_DEVICE}"
+
 fi
 
 # On other distros or on ZUUL, use overlay.


### PR DESCRIPTION
cri-o implemented parallel tests for 1.15, but this doesn't
work when running the tests with `devicemapper` driver as
each thread will launch different cri-o processes in parallel
and will try to use the same block device.

For this case use `JOBS=1` to run the tests sequentially.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>