### PR TITLE
ci: Fail if OBS packages are not found on kata manager

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -304,6 +304,14 @@ exec_document()
 
 	info "$msg"
 
+	# verify that we have OBS packages for the distro VERSION_ID
+	check_version=$(grep -E "\<${VERSION_ID}\>" "${install_script}" || true)
+
+	if [ -z "${check_version}" ]; then
+		rm -f "${install_script}"
+		die "OBS packages not available on ${ID} ${VERSION_ID}"
+	fi
+
 	# run the installation
 	bash "${install_script}"
 


### PR DESCRIPTION
Fail in case that OBS packages are not found for a specific VERSION ID
while executing the installation guide from the documentation.

Fixes #1691

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>