### PR TITLE
expose-ip: replace hello-app with agnostic image agnhost:2.2

### DIFF
--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -44,7 +44,8 @@ setup() {
 	svcip=$(kubectl get service ${service} -o=json | jq '.spec.clusterIP' | sed 's/"//g')
 	svcport=$(kubectl get service ${service} -o=json | jq '.spec.ports[].port')
 	# And check we can curl the expected response from that IP address
-	curl http://$svcip:$svcport | grep "Hello, world!"
+	echo_msg="hello,world"
+	curl http://$svcip:$svcport/echo?msg=${echo_msg} | grep "$echo_msg"
 
 	# NOTE - we do not test the 'public IP' address of the node balancer here as
 	# that may not be set up, as it may require an IP/DNS allocation and local

--- a/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
@@ -21,6 +21,8 @@ spec:
       runtimeClassName: kata
       containers:
       - name: hello-world
-        image: gcr.io/google-samples/hello-app:1.0
+        image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
+        args:
+        - netexec
         ports:
         - containerPort: 8080


### PR DESCRIPTION
The `agnhost` image was created by k8s for testing purposes. one benefit is to be able to aggregate, like 10 images worth of functionality into 1 image.
Sub-command netexec is to start a HTTP server on given TCP / UDP ports with a few endpoints.
The `/echo` endpoint returns the given msg, e.g./echo?msg=echoed_msg. Therefore, we could use above functionality to achieve what hello-app is intended for.
Detailed info about `agnhost` image is [here](https://github.com/kubernetes/kubernetes/tree/master/test/images/agnhost).
Otherwise, hello-app is also single-arch image only for amd64, while agnhost is multi-arch image for multiple archs, including x86_64, arm64, s390x, etc.