### PR TITLE
modules: Verification for go modules

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -780,6 +780,17 @@ static_check_vendor()
 	local vendor_files
 	local result
 
+	# Check if repo has been changed to use go modules
+	if [ -f "go.mod" ]; then
+		info "go.mod file found, running go mod verify instead"
+		# This verifies the integrity of modules in the local cache.
+		# This does not really verify the integrity of vendored code:
+		# https://github.com/golang/go/issues/27348
+		# Once that is added we need to add an extra step to verify vendored code.
+		GO111MODULE=on go mod verify
+		return
+	fi
+
 	# All vendor operations should modify this file
 	local vendor_ctl_file="Gopkg.lock"
 


### PR DESCRIPTION
While we move to go modules, perform the dep check for repos
that still use dep.
Run `go mod verify` instead for go modules.
Note, this just verifies the integrity of modules in the local
cache. We would have instead wanted to verify the vendored code
here, but that is still not supported.
https://github.com/golang/go/issues/27348

Fixes #1879

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>