### PR TITLE
revert: "ci: Fail if OBS packages are not found on kata manager"

### DIFF
--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -304,14 +304,6 @@ exec_document()
 
 	info "$msg"
 
-	# verify that we have OBS packages for the distro VERSION_ID
-	check_version=$(grep -E "\<${VERSION_ID}\>" "${install_script}" || true)
-
-	if [ -z "${check_version}" ]; then
-		rm -f "${install_script}"
-		die "OBS packages not available on ${ID} ${VERSION_ID}"
-	fi
-
 	# run the installation
 	bash "${install_script}"
 


### PR DESCRIPTION
This reverts commit 2aa6cf2401ea0505aebbf395bcfade0d0edeaad3.

Undo change that breaks OBS installs; the check introduced by [1] always fails since the release number is not encoded in the installation document - it's defined as a variable.

[1] - https://github.com/kata-containers/tests/pull/1875

Fixes: #1881.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>