### PR TITLE
metrics: update baseline to account for recent changes

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric2.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.85
+midval = 0.80
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 132458.0
+midval = 122904.0
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 56366.5
+midval = 49821.0
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
Our metrics shifted (in the good direction), probably due to
changes in the kernel configs and qemu updates.

Reset the values to a new baseline. Data gathered using
the new metrics history script. Base ouput data was:

  allvalues are [0.8041 0.8085000000000001 0.7976500000000002 0.82155 0.7955 0.80935 0.8016500000000001 0.8127000000000001 ]
  boot-times: mean .80, 95% mean .76, 105% mean .84
  min 0.7955 (99.00% of mean), max 0.82155 (102.00% of mean)

  allvalues are [122674.13 122790.79 123279.39 123288.42 123087.39 122773.55 121926.11 123410.47 ]
  memory-footprint: mean 122903.78, 95% mean 116758.59, 105% mean 129048.96
  min 121926.11 (99.00% of mean), max 123410.47 (100.00% of mean)

  allvalues are [49832.46 49696.02 49865.95 49930 49941.06 49783.15 49618.4 49900.52 ]
  memory-footprint-ksm: mean 49820.94, 95% mean 47329.89, 105% mean 52311.98
  min 49618.4 (99.00% of mean), max 49941.06 (100.00% of mean)

Fixes: #1884

Signed-off-by: Graham Whaley <graham.whaley@intel.com>