### PR TITLE
filter: build filter frame for k8s intergration tests on aarch64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -27,3 +27,7 @@ docker:
     - Checking CPU cgroups in the host
   Context:
   It:
+
+kubernetes:
+  - k8s-cpu-ns
+  - k8s-limit-range

--- a/.ci/filter/filter_k8s_test.sh
+++ b/.ci/filter/filter_k8s_test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_LOCAL="${GOPATH%%:*}"
+KATA_DIR="${GOPATH_LOCAL}/src/github.com/kata-containers"
+TEST_DIR="${KATA_DIR}/tests"
+CI_DIR="${TEST_DIR}/.ci"
+
+K8S_FILTER_FLAG="kubernetes"
+
+source "${CI_DIR}/lib.sh"
+
+main()
+{
+	local K8S_CONFIG_FILE="$1"
+	local K8S_TEST_UNION="$2"
+	local result=()
+
+	mapfile -d " " -t _K8S_TEST_UNION <<< "${K8S_TEST_UNION}"
+
+	# install yq if not exist
+        ${CI_DIR}/install_yq.sh > /dev/null
+
+        local K8S_SKIP_UNION=$("${GOPATH_LOCAL}/bin/yq" read "${K8S_CONFIG_FILE}" "${K8S_FILTER_FLAG}")
+        [ "${K8S_SKIP_UNION}" == "null" ] && return
+        mapfile -t _K8S_SKIP_UNION <<< "${K8S_SKIP_UNION}"
+
+	for TEST_ENTRY in "${_K8S_TEST_UNION[@]}"
+	do
+		local flag="false"
+		for SKIP_ENTRY in "${_K8S_SKIP_UNION[@]}"
+		do
+			SKIP_ENTRY="${SKIP_ENTRY#- }.bats"
+			[ "$SKIP_ENTRY" == "$TEST_ENTRY" ] && flag="true"
+		done
+		[ "$flag" == "false" ] && result+=("$TEST_ENTRY")
+	done
+	echo ${result[@]}
+}
+
+main "$@"


### PR DESCRIPTION
Hi guys.
Recent days, I have been focusing on including k8s integration tests on ARM CI.
The last majority work may be building up k8s filter frame, just like what I did for docker integration tests.
Since for now, a few advanced feature hasn't been fully supported on aarch64, like cpu hotplug, we need to skip a few k8s intergration tests involving these features.