### PR TITLE
CI: Ignore vendor files harder

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -482,7 +482,7 @@ static_check_docs()
 	local new_urls
 	local url
 
-	all_docs=$(git ls-files "*.md" | grep -v "/vendor/" | sort || true)
+	all_docs=$(git ls-files "*.md" | grep -v "^vendor/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
 	then
@@ -705,7 +705,7 @@ static_check_files()
 	then
 		info "Checking all files in $branch branch"
 
-		files=$(git ls-files | egrep -v "/(.git|vendor)/" || true)
+		files=$(git ls-files | grep -v "^(.git|vendor)/" || true)
 	else
 		info "Checking local branch for changed files only"
 
@@ -815,7 +815,7 @@ static_check_xml()
 	local all_xml
 	local files
 
-	all_xml=$(git ls-files "*.xml" | grep -v "/vendor/" | sort || true)
+	all_xml=$(git ls-files "*.xml" | grep -v "^vendor/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
 	then
@@ -867,7 +867,7 @@ static_check_shell()
 	local all_scripts
 	local scripts
 
-	all_scripts=$(git ls-files "*.sh" "*.bash" | grep -v "/vendor/" | sort || true)
+	all_scripts=$(git ls-files "*.sh" "*.bash" | grep -v "^vendor/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
 	then
@@ -904,7 +904,7 @@ static_check_json()
 	local all_json
 	local json_files
 
-	all_json=$(git ls-files "*.json" | grep -v "/vendor/" | sort || true)
+	all_json=$(git ls-files "*.json" | grep -v "^vendor/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
 	then


### PR DESCRIPTION
We recently switched from using `find(1)` to `git-ls-files(1)` to determine which files run static checks for [1]. Unfortunately, the formats of these commands are slightly different so update the code to ignore vendor files as previously, vendor files were being checked.

[1] - https://github.com/kata-containers/tests/pull/1868

Fixes: #1892.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>