### PR TITLE
test: Update vault test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -448,7 +448,7 @@ setup() {
 
 @test "[run application] start server in a vault container" {
 	image="vault"
-	docker run --rm --runtime=$RUNTIME -i -e 'VAULT_DEV_ROOT_TOKEN_ID=mytest' $image timeout -t 10 vault server -dev
+	docker run --rm --runtime=$RUNTIME -i -e 'VAULT_DEV_ROOT_TOKEN_ID=mytest' $image timeout 10 vault server -dev
 }
 
 @test "[perl application] start wordpress container" {


### PR DESCRIPTION
The -t option for the timeout has been deprecated, this will fix to run the
vault image for the docker popular image test.

Fixes #1898

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>