### PR TITLE
cri-containerd: acquire cri_containerd version in faster way

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -14,7 +14,6 @@ source /etc/os-release || source /usr/lib/os-release
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cri_repository="github.com/containerd/cri"
-containerd_repository="github.com/containerd/containerd"
 
 # Flag to do tasks for CI
 CI=${CI:-""}
@@ -31,12 +30,8 @@ cri_containerd_tarball_version=$(get_version "externals.cri-containerd.version")
 cri_containerd_repo=$(get_version "externals.cri-containerd.url")
 
 echo "Get cri_containerd version"
-go get "${containerd_repository}"
-cri_containerd_version=$(
-	cd "${GOPATH}/src/${containerd_repository}";
-	git checkout "v${cri_containerd_tarball_version}" >&2;
-	cat vendor.conf | grep "github.com/containerd/cri" | awk '{print $2}';
-)
+cri_containerd_version_url="https://raw.githubusercontent.com/containerd/containerd/v${cri_containerd_tarball_version}/vendor.conf"
+cri_containerd_version=$(curl -sL $cri_containerd_version_url | grep "github.com/containerd/cri" | awk '{print $2}')
 
 echo "Set up environment"
 if [ "$ID" == centos ]; then


### PR DESCRIPTION
To acquire version of `cri_containerd`, you only need the file `vendor.conf` under `containerd/containerd` repo. 
You don't need to download the whole repo, that's time-consuming.