### PR TITLE
clean_baremetal: granting a shell `sudo` rights, not `rm`

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -23,8 +23,8 @@ sudo iptables-restore < "$iptables_cache"
 sudo -E rm -rf "$HOME/.kube"
 
 # Remove existing CNI configurations and binaries.
-sudo rm -rf /var/lib/cni/networks/*
-sudo rm -rf /opt/cni/bin/*
+sudo sh -c 'rm -rf /var/lib/cni/networks/*'
+sudo sh -c 'rm -rf /opt/cni/bin/*'
 
 # delete containers resource created by runc
 cri_runtime="${CRI_RUNTIME:-crio}"


### PR DESCRIPTION
This is one bug report for my one previous PR #1812.
I have tried to clean up stale files under `/var/lib/cni/networks/*` and `/opt/cni/bin/*`, which need `sudo` rights to do cleaning up.
Actually, original plan didn't really fulfill the task, and all stale file still remained left. But since we add `-f` flag, error has been hidden away. when we turn off this flag, it will output:
`rm: cannot remove '/opt/cni/bin/*': No such file or directory`
All is due to that in original plan, `sudo rm -rf /opt/cni/bin/*`, `sudo` right is granted to `rm` command, not the shell `cleanup_bare_metal_env.sh`. 
So when the shell do wildcard expansion with `/opt/cni/bin/*`, it does not have permission to expand. 
Nevertheless, to get around this, we need a shell with `sudo` rights executing `rm`.