### PR TITLE
test: Fix zookeeper docker integration test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -458,7 +458,7 @@ setup() {
 
 @test "[run application] start zookeeper container" {
 	image="zookeeper"
-	docker run --rm --runtime=$RUNTIME -i $image zkServer.sh start
+	docker run --rm --runtime=$RUNTIME -i $image zkServer.sh
 }
 
 teardown() {


### PR DESCRIPTION
Currently, the zookeeper docker integration test is failing this will
fix the issue.

Fixes #1905

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>