### PR TITLE
tests: install kata with specific version

### DIFF
--- a/.ci/install_agent.sh
+++ b/.ci/install_agent.sh
@@ -8,7 +8,8 @@
 set -e
 
 cidir=$(dirname "$0")
+tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/agent"
+build_and_install "github.com/kata-containers/agent" "" "" "${tag}"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -10,6 +10,7 @@ set -o nounset
 set -o pipefail
 
 cidir=$(dirname "$0")
+tag="${1:-""}"
 source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
@@ -32,10 +33,10 @@ else
 fi
 
 echo "Install shim"
-"${cidir}/install_shim.sh"
+"${cidir}/install_shim.sh" "${tag}"
 
 echo "Install proxy"
-"${cidir}/install_proxy.sh"
+"${cidir}/install_proxy.sh" "${tag}"
 
 echo "Install runtime"
-"${cidir}/install_runtime.sh"
+"${cidir}/install_runtime.sh" "${tag}"

--- a/.ci/install_proxy.sh
+++ b/.ci/install_proxy.sh
@@ -8,7 +8,8 @@
 set -e
 
 cidir=$(dirname "$0")
+tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/proxy"
+build_and_install "github.com/kata-containers/proxy" "" "" "${tag}"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -20,6 +20,7 @@ arch=$("${cidir}"/kata-arch.sh -d)
 
 # enable verbose build
 export V=1
+tag="$1"
 
 # tell the runtime build to use sane defaults
 export SYSTEM_BUILD_TYPE=kata
@@ -37,7 +38,7 @@ runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
-build_and_install "github.com/kata-containers/runtime" "" "true"
+build_and_install "github.com/kata-containers/runtime" "" "true" "${tag}"
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file

--- a/.ci/install_shim.sh
+++ b/.ci/install_shim.sh
@@ -8,7 +8,8 @@
 set -e
 
 cidir=$(dirname "$0")
+tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/shim"
+build_and_install "github.com/kata-containers/shim" "" "" "${tag}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -88,8 +88,9 @@ function build_version() {
 function build() {
 	github_project="$1"
 	make_target="$2"
+	version="${3:-"HEAD"}"
 
-	build_version "${github_project}" "${make_target}" "HEAD"
+	build_version "${github_project}" "${make_target}" "${version}"
 }
 
 function build_and_install() {


### PR DESCRIPTION
Some new features maybe not supported in some hosts
with old kernel, so let older version of kata installed
easier by adding a version argument.

fixed: #1908
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
@jodh-intel  @grahamwhaley  @Pennyzct 