### PR TITLE
test: Remove ubuntu-upstart docker integration test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -441,11 +441,6 @@ setup() {
 	docker run --rm --runtime=$RUNTIME -i $image sh -c 'if [ -f /etc/bash.bashrc ]; then echo "/etc/bash.bashrc exists"; fi'
 }
 
-@test "[run application] search nano in an ubuntu upstart container" {
-	image="ubuntu-upstart"
-	docker run --rm --runtime=$RUNTIME -i $image bash -c "apt-cache search nano"
-}
-
 @test "[run application] start server in a vault container" {
 	image="vault"
 	docker run --rm --runtime=$RUNTIME -i -e 'VAULT_DEV_ROOT_TOKEN_ID=mytest' $image timeout 10 vault server -dev


### PR DESCRIPTION
Today the image of ubuntu-upstart has been deprecated at docker hub so
it is not possible to retrieve the image. This removes the test.

Fixes #1910

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>