### PR TITLE
cleanup_k8s: ensure execution of cleanup no matter what

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -45,6 +45,8 @@ runc_container_union="$($runc_path list)"
 if [ -n "$runc_container_union" ]; then
 	while IFS='$\n' read runc_container; do
 		container_id="$(echo "$runc_container" | awk '{print $1}')"
-		[ "$container_id" != "ID" ] && $runc_path delete -f $container_id
+		if [ "$container_id" != "ID" ]; then
+			$runc_path delete -f $container_id
+		fi
 	done <<< "${runc_container_union}"
 fi

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -28,14 +28,14 @@ sudo -E kubeadm reset -f --cri-socket="${cri_runtime_socket}"
 
 sudo systemctl stop "${cri_runtime}"
 
-sudo ip link set dev cni0 down
-sudo ip link set dev flannel.1 down
-sudo ip link del cni0
-sudo ip link del flannel.1
+sudo ip link set dev cni0 down || true
+sudo ip link set dev flannel.1 down || true
+sudo ip link del cni0 || true
+sudo ip link del flannel.1 || true
 
 # if CI run in bare-metal, we need a set of extra clean
 BAREMETAL="${BAREMETAL:-false}"
-if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ];  then
+if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
 	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 fi
 

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -28,6 +28,9 @@ if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	die "Kubernetes tests will not run with $KATA_HYPERVISOR"
 fi
 
+# Using trap to ensure the cleanup occurs when the script exists.
+trap '${kubernetes_dir}/cleanup_env.sh' EXIT
+
 # Docker is required to initialize kubeadm, even if we are
 # using cri-o as the runtime.
 systemctl is-active --quiet docker || sudo systemctl start docker
@@ -72,5 +75,4 @@ for K8S_TEST_ENTRY in ${K8S_TEST_UNION[@]}
 do
 	bats "${K8S_TEST_ENTRY}"
 done
-./cleanup_env.sh
 popd


### PR DESCRIPTION
there are several scenarios where `cleanup_env.sh` wouldn't be invoked or be interrupted in the middle.
a) for now, `cleanup_env.sh` is only invoked on successful completion of the script.
Hence, we use `trap` to ensure the cleanup happens on any exit.
b) Sometimes, we failed on `kubeadm init`. on such point, the cluster network may not be initialized, which means no `cni0` interface, regardless of `flannel` interface. Hence, cleanup will exit in the middle.
```
Cannot find device "cni0"
```
So adding `|| true` ensures that the resulting compound command
always exits with status zero.
c) When `runc list` returned no stale container resource like the following:
```
ID          PID         STATUS      BUNDLE      CREATED     OWNER
```
the compound `&&` command would exit with `1`, leading the whole script exiting with none-zero status.
```
Failed at 41: ${SCRIPT_PATH}/cleanup_bare_metal_env.sh
```
So switching compound command with if statement. ;)