### PR TITLE
ci: Fix nemu installation

### DIFF
--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -36,7 +36,7 @@ install_nemu() {
 
 	go get -d "${PACKAGING_REPO}" || true
 
-	prefix="${KATA_NEMU_DESTDIR}" ${GOPATH}/src/${PACKAGING_REPO}/static-build/nemu/build-static-nemu.sh
+	prefix="${KATA_NEMU_DESTDIR}" ${GOPATH}/src/${PACKAGING_REPO}/static-build/nemu/build-static-nemu.sh "${arch}"
 	sudo tar -xvf ${NEMU_TAR} -C /
 	# We need to move the tar file to a specific location so we
 	# can know where it is and then we can perform the build cache


### PR DESCRIPTION
While trying to build nemu, we need to pass the arch as a parameter to
execute the packaging script. See
https://github.com/kata-containers/packaging/blob/master/static-build/nemu/build-static-nemu.sh#L18

Depends-on: github.com/kata-containers/packaging#672

Fixes #1915

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>