### PR TITLE
ci: Fix install prebuilt nemu and qemu

### DIFF
--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -58,7 +58,6 @@ install_firmware() {
 }
 
 install_prebuilt_nemu() {
-	pushd "${KATA_TESTS_CACHEDIR}"
 	sudo -E curl -fL --progress-bar "${latest_build_url}/${NEMU_TAR}" -o "${NEMU_TAR}" || return 1
 	info "Install pre-built nemu version"
 	sudo tar -xvf "${NEMU_TAR}" -C /
@@ -66,7 +65,6 @@ install_prebuilt_nemu() {
 	info "Verify download checksum"
 	sudo -E curl -fsOL "${latest_build_url}/sha256sum-${NEMU_TAR}" || return 1
 	sudo sha256sum -c "sha256sum-${NEMU_TAR}" || return 1
-	popd
 }
 
 main() {

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -63,7 +63,7 @@ install_cached_qemu() {
 	curl -fsOL "${qemu_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
-	uncompress_static_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
+	uncompress_static_qemu "${QEMU_TAR}"
 }
 
 clone_qemu_repo() {


### PR DESCRIPTION
This will fix the install prebuilt nemu and qemu and avoid the
source installation of these kata components.

Fixes #1923

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>