### PR TITLE
spelling: Add IoT to spell check dictionary

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -28,6 +28,7 @@ GPU/AB
 gRPC/AB
 GVT/AB
 IOMMU/AB
+IoT/AB	# Internet of Things
 IOV/AB
 JSON/AB
 k8s/B


### PR DESCRIPTION
Add the "IoT" (Internet of Things) acronym to the spell checker dictionary.

Fixes: #1932.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>