### PR TITLE
k8s: Add cniVersion to flannel config file

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -15,6 +15,9 @@ source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+RUNTIME=${RUNTIME:-kata-runtime}
+RUNTIME_PATH=${RUNTIME_PATH:-$(command -v $RUNTIME)}
+
 system_pod_wait_time=120
 sleep_time=5
 wait_pods_ready()

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -71,7 +71,7 @@ is_a_kata_runtime(){
 
 # Try to find the real runtime path for the docker runtime passed in $1
 get_docker_kata_path(){
-	local jpaths=$(docker info --format "{{json .Runtimes}}" || true)
+	local jpaths=$(sudo docker info --format "{{json .Runtimes}}" || true)
 	local rpath=$(jq .\"$1\".path <<< "$jpaths")
 	# Now we have to de-quote it..
 	rpath="${rpath%\"}"
@@ -214,7 +214,7 @@ clean_env()
 	# Docker has a built in 10s default timeout, so make ours
 	# longer than that.
 	KATA_DOCKER_TIMEOUT=${KATA_DOCKER_TIMEOUT:-30}
-	containers_running=$(timeout ${KATA_DOCKER_TIMEOUT} docker ps -q)
+	containers_running=$(sudo timeout ${KATA_DOCKER_TIMEOUT} docker ps -q)
 
 	if [ ! -z "$containers_running" ]; then
 		# First stop all containers that are running


### PR DESCRIPTION
`cniVersion` is needed inside the flannel config file. If it
is not provided, cni has issues releasing ip adresses after
pods are deleted.

Fixes: #1936.

In addition:
- add `RUNTIME` and `RUNTIME_PATH` default values 
to the kubernetes `init.sh` script.
- use sudo for docker calls as some environments may not be 
able to call docker without using sudo.



Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>