### PR TITLE
backport fixes to stable-1.8

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -63,10 +63,10 @@ path="/usr/local/bin/kata-runtime"
 
 if [ -f $docker_configuration_file ]; then
 	# Check devicemapper flag
-	check_devicemapper=$(grep -w '"storage-driver": "${driver}"' $docker_configuration_file | wc -l)
+	check_devicemapper=$(grep -w '"storage-driver": "'${driver}'"' $docker_configuration_file | wc -l)
 	[ $check_devicemapper -eq 0 ] && die "${driver} is not enabled at $docker_configuration_file"
 	# Check kata runtime flag
-	check_kata=$(grep -w '"path": "${path}"' $docker_configuration_file | wc -l)
+	check_kata=$(grep -w '"path": "'${path}'"' $docker_configuration_file | wc -l)
 	[ $check_kata -eq 0 ] && die "Kata Runtime path not found at $docker_configuration_file"
 else
 	cat <<-EOF | sudo tee "$docker_configuration_file"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -892,15 +892,17 @@ main()
 
 	local long_option_names="${!long_options[@]}"
 
-	local args=$(getopt \
+	local args
+
+	args=$(getopt \
 		-n "$script_name" \
 		-a \
 		--options="h" \
 		--longoptions="$long_option_names" \
 		-- "$@")
+	[ $? -eq 0 ] || { usage >&2; exit 1; }
 
 	eval set -- "$args"
-	[ $? -ne 0 ] && { usage >&2; exit 1; }
 
 	local func=
 

--- a/Unit-Test-Advice.md
+++ b/Unit-Test-Advice.md
@@ -65,7 +65,7 @@ func TestJoinParamsWithDash(t *testing.T) {
         // Call the function under test
         result, err := joinParamsWithDash(d.param1, d.param2)
 
-        if expectError {
+        if d.expectError {
             assert.Error(err, msg)
 
             // If an error is expected, there is no point

--- a/cmd/check-spelling/kata-spell-check.sh
+++ b/cmd/check-spelling/kata-spell-check.sh
@@ -339,7 +339,7 @@ main()
 {
 	setup
 
-	[ -z "$1" ] && die "need command"
+	[ -z "${1:-}" ] && die "need command"
 
 	case "$1" in
 		check) shift && spell_check_file "$1" ;;

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -96,7 +96,7 @@ ci_cleanup() {
 	fi
 }
 
-create_continerd_config() {
+create_containerd_config() {
 	local runtime="$1"
 	[ -n "${runtime}" ] || die "need runtime to create config"
 
@@ -143,7 +143,7 @@ trap err_report ERR
 
 check_daemon_setup() {
 	info "containerd(cri): Check daemon works with runc"
-	create_continerd_config "runc"
+	create_containerd_config "runc"
 
 	sudo -E PATH="${PATH}:/usr/local/bin" \
 		REPORT_DIR="${REPORT_DIR}" \
@@ -170,7 +170,7 @@ main() {
 
 	info "containerd(cri): testing using runtime: ${containerd_runtime_test}"
 
-	create_continerd_config "${containerd_runtime_test}"
+	create_containerd_config "${containerd_runtime_test}"
 
 	info "containerd(cri): Running cri-tools"
 	sudo -E PATH="${PATH}:/usr/local/bin" \


### PR DESCRIPTION
b5aa2bb check-spelling: Fix unbound variable
d2a7537 cri-containerd: Fix spelling mistake in function name
023697e ci: Fix FC installation script
19f37ac CI: Fix getopt return check in static check script
da14284 docs: Fix Unit Test Advice document
