### PR TITLE
bare-metal: delete stale veth interfaces on bare-metal machine

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -50,3 +50,10 @@ if [ -n "$runc_container_union" ]; then
 		fi
 	done <<< "${runc_container_union}"
 fi
+
+# delete stale veth interfaces, which is named after vethXXX.
+veth_interfaces_union=$(sudo ip link | grep "veth" | awk '{print $2}' | cut -d '@' -f1)
+while read veth_interface; do
+	sudo ip link set dev $veth_interface down
+	sudo ip link del $veth_interface
+done <<< "$veth_interfaces_union"


### PR DESCRIPTION
Everytime, when creating a new container, a veth pair including one `eth0` in container namespace, and one `vethXXX` in pod namespace has been created.
Then, the `vethXXX` has been plugged into the bridge `cni0` for intra-node communication.
 In cleaning process, we only deleted `cni0` interface for now. 
See one quick kubernetes integration tests on AArch64.
**Before, we have only five interfaces:**
```
$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp9s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 68:05:ca:83:6f:34 brd ff:ff:ff:ff:ff:ff
3: virbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
4: virbr0-nic: <BROADCAST,MULTICAST> mtu 1500 qdisc fq_codel master virbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default
    link/ether 02:42:2b:a4:3c:0b brd ff:ff:ff:ff:ff:ff

```
**After, we have 38 interfaces, all extra interfaces belong to `vethXXX` family:**
```
$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp9s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 68:05:ca:83:6f:34 brd ff:ff:ff:ff:ff:ff
3: virbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
4: virbr0-nic: <BROADCAST,MULTICAST> mtu 1500 qdisc fq_codel master virbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 52:54:00:f7:f6:2c brd ff:ff:ff:ff:ff:ff
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default
    link/ether 02:42:2b:a4:3c:0b brd ff:ff:ff:ff:ff:ff
94: veth66750f03@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 8a:a6:e5:4a:75:f7 brd ff:ff:ff:ff:ff:ff link-netnsid 70
95: vethfbe0b769@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 3e:72:f0:d6:df:b8 brd ff:ff:ff:ff:ff:ff link-netnsid 71
-bash: root@entos-thunderx2-desktop:~/go/src/github.com/kata-containers/tests/integration/kubernetes#: No such file or directory
96: veth5b6c7660@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 96:b1:5f:01:59:c1 brd ff:ff:ff:ff:ff:ff link-netnsid 72
97: vethee69e880@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 1e:4d:f3:09:8a:31 brd ff:ff:ff:ff:ff:ff link-netnsid 73
98: veth3e4d6e1b@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 76:54:2b:41:24:a6 brd ff:ff:ff:ff:ff:ff link-netnsid 74
99: veth7d3e1974@if3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default
    link/ether 6e:8b:40:b9:de:52 brd ff:ff:ff:ff:ff:ff link-netnsid 75
......

```
if you are running the tests on bare-metal machine like ARM CI, the results get accumulated with time goes on. ☹