### PR TITLE
Spell checker update dictionary

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -77,7 +77,7 @@ templating
 timestamp/AB
 tracability
 unbootable
-uncomment
+uncomment/ACD
 unported
 unskip/AC
 untrusted

--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -52,6 +52,7 @@ OpenTracing/B
 osbuilder/B
 packagecloud/B
 Pandoc/B
+Podman/B
 PullApprove/B
 QuickAssist/B
 R/B


### PR DESCRIPTION
Allow the word "Podman" to be accepted by the spell checker.

Also, allow the word "uncomment" to be specified in the plural, past tense or present continuous tense.

Fixes: #1948.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>