### PR TITLE
ci: Fix moreutils repository for SLES

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -20,7 +20,7 @@ echo "Install perl-IPC-Run"
 sudo -E zypper -n install perl-IPC-Run
 
 echo "Add repo for moreutils"
-moreutils_repo="https://download.opensuse.org/repositories/utilities/SLE_${VERSION//-/_}_Backports/utilities.repo"
+moreutils_repo="https://download.opensuse.org/repositories/utilities/SLE_12_SP3_Backports/utilities.repo"
 sudo -E zypper addrepo --no-gpgcheck ${moreutils_repo}
 sudo -E zypper refresh
 


### PR DESCRIPTION
Currently the CI fails to retry the moreutils repository and the main reason
is that this repository does not longer exists for SLES 12 SP4 so we need to
retry the repository for SLES 12 SP3.

Fixes #1929

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>