### PR TITLE
ci: Add support for docker 18.06 to fedora 30

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -109,9 +109,17 @@ install_docker(){
 			repo_url="https://download.docker.com/linux/fedora/docker-ce.repo"
 			sudo -E dnf -y install dnf-plugins-core
 			sudo -E dnf config-manager --add-repo "$repo_url"
-			sudo -E dnf makecache
-			docker_version_full=$(dnf --showduplicate list "$pkg_name" | grep "$docker_version" | awk '{print $2}' | tail -1)
-			sudo -E dnf -y install "${pkg_name}-${docker_version_full}"
+			if [ "$VERSION_ID" -ge "30" ]; then
+				warning "This step will be removed once  https://github.com/kata-containers/tests/issues/1954 is solved"
+				sudo sed -i 's/$releasever/28/' /etc/yum.repos.d/docker-ce.repo
+				sudo -E dnf config-manager --set-enabled docker-ce-stable
+				sudo -E dnf makecache
+				sudo -E dnf install -y docker-ce-18.06.3.ce-3.fc28
+			else
+				sudo -E dnf makecache
+				docker_version_full=$(dnf --showduplicate list "$pkg_name" | grep "$docker_version" | awk '{print $2}' | tail -1)
+				sudo -E dnf -y install "${pkg_name}-${docker_version_full}"
+			fi
 		elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
 			sudo -E yum install -y yum-utils
 			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"


### PR DESCRIPTION
Currently Fedora 30 does not support docker-ce 18.06 so we need to modify
the cmd/manage_ctr_mgr.sh to support this docker version.

Fixes #1951

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>