### PR TITLE
ci: cri-o: limit number of parallel jobs to nproc value

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -13,6 +13,8 @@ source "${SCRIPT_PATH}/crio_skip_tests.sh"
 source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
+export JOBS="${JOBS:-$(nproc)}"
+
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.
 # For non CI execution, run the cri-o tests always.


### PR DESCRIPTION
By default, cri-o uses `nproc`*4 as the number of parallel jobs
to run the tests. As Kata consumes more resources and our CI uses
nested virtualization environments, using this number may
lead to this error: `container create failed: rpc error: code
= Unavailable desc = transport is closing`.

By setting the number to `nproc` value, this error doesn't appear.

Fixes: #1943.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>