### PR TITLE
ci: Add repo for pandoc and hunspell packages

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -24,6 +24,9 @@ moreutils_repo="https://download.opensuse.org/repositories/utilities/SLE_12_SP3_
 sudo -E zypper addrepo --no-gpgcheck ${moreutils_repo}
 sudo -E zypper refresh
 
+echo "Add repo for hunspell and pandoc packages"
+SUSEConnect -p PackageHub/${VERSION_ID}/${arch}
+
 echo "Install chronic"
 sudo -E zypper -n install moreutils
 


### PR DESCRIPTION
This adds the repository to retry these packages for SLES 12 SP4.

Fixes #1957

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>