### PR TITLE
ci: fix firecracker 0.18 installation

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -41,9 +41,9 @@ go get -d ${firecracker_repo} || true
 # Checkout to specific version
 pushd "${GOPATH}/src/${firecracker_repo}"
 git checkout tags/${firecracker_version}
-./tools/devtool --unattended build --release -- --features vsock
-sudo install ${GOPATH}/src/${firecracker_repo}/build/release-musl/firecracker /usr/bin/
-sudo install ${GOPATH}/src/${firecracker_repo}/build/release-musl/jailer /usr/bin/
+./tools/devtool --unattended build --release
+sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/x86_64-*-linux-musl/release/firecracker /usr/bin/
+sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/x86_64-*-linux-musl/release/jailer /usr/bin/
 popd
 
 echo "Install and configure docker"

--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -26,17 +26,17 @@ HYPERVISOR_NAME=$(basename ${HYPERVISOR_PATH})
 setup()  {
 	clean_env
 	sudo docker run --runtime=$RUNTIME -d --name $CONTAINER_NAME $IMAGE $PAYLOAD_ARGS
-	num=$(ps aux | grep ${HYPERVISOR_NAME} | grep -Ev "grep|PATH|defunct" | wc -l)
+	num=$(pidof ${HYPERVISOR_NAME} | wc -w)
 	[ ${num} -eq 1 ] || die "hypervisor count:${num} expected:1"
 }
 
 kill_hypervisor()  {
-	pid=$(ps aux | grep ${HYPERVISOR_NAME} | grep -Ev "grep|PATH|defunct" | awk '{print $2}')
+	pid=$(pidof ${HYPERVISOR_NAME})
 	[ -n ${pid} ] || die "failed to find hypervisor pid"
 	sudo kill -KILL ${pid} || die "failed to kill hypervisor (pid ${pid})"
 	# signal is async and we've seen failures hypervisor not being killed immediately.
 	sleep 1
-	num=$(ps aux | grep ${HYPERVISOR_NAME} | grep -Ev "grep|PATH|defunct" | wc -l)
+	num=$(pidof ${HYPERVISOR_NAME} | wc -w)
 	[ ${num} -eq 0 ] || die "hypervisor count:${num} expected:0"
 	sudo docker rm -f $CONTAINER_NAME
 	[ $? -eq 0 ] || die "failed to force removing container $CONTAINER_NAME"


### PR DESCRIPTION
Don't use --features flags since vsocks support is enabled by default
Update firecracker and jailer path

Depends-on: github.com/kata-containers/runtime#2050

fixes #1959

Signed-off-by: Julio Montes <julio.montes@intel.com>