### PR TITLE
ci: Add leap oss repository for SLES 12 SP4

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -16,6 +16,12 @@ perl_repo="https://download.opensuse.org/repositories/devel:languages:perl/SLE_$
 sudo -E zypper addrepo --no-gpgcheck ${perl_repo}
 sudo -E zypper refresh
 
+echo "Add repo for myspell"
+leap_repo="http://download.opensuse.org/update/leap/15.0/oss/"
+leap_repo_name="leap-oss"
+sudo -E zypper addrepo --no-gpgcheck ${leap_repo} ${leap_repo_name}
+sudo -E zypper refresh  ${leap_repo_name}
+
 echo "Install perl-IPC-Run"
 sudo -E zypper -n install perl-IPC-Run
 


### PR DESCRIPTION
In order to retry packages of myspell we need to add the leap oss repository
for SLES 12 SP4.

Fixes #1969

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>