### PR TITLE
[WIP]k8s: Add workload examples on Overhead calculation.

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -124,6 +124,8 @@ fi
 #   directly.
 # - If the repo is not "tests", call the repo-specific script (which is
 #   expected to call the script of the same name in the "tests" repo).
+
+export DEFSANDBOXCGROUPONLY=true
 case "${CI_JOB}" in
 "CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,7 @@ ifeq (${CI}, true)
 endif
 
 # union for 'make test'
-UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
-	docker-stability oci netmon kubernetes swarm vm-factory \
-	entropy ramdisk shimv2 tracing time-drift
+UNION := kubernetes
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ and with different container managers.
 2. Integration tests to ensure compatibility with:
    - [Docker](https://github.com/kata-containers/tests/tree/master/integration/docker)
    - [Kubernetes](https://github.com/kata-containers/tests/tree/master/integration/kubernetes)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/master/integration/kubernetes)
    - [CRI-O](https://github.com/kata-containers/tests/tree/master/integration/cri-o)
    - [Containerd](https://github.com/kata-containers/tests/tree/master/integration/containerd)
    - [OpenShift](https://github.com/kata-containers/tests/tree/master/integration/openshift)
+   - [Overhead](integration/kubernetes/overhead/README.md)
 3. [Network tests](https://github.com/kata-containers/tests/tree/master/integration/network)
 4. [Stability tests](https://github.com/kata-containers/tests/tree/master/integration/stability)
 5. [Metrics](https://github.com/kata-containers/tests/tree/master/metrics)

--- a/integration/kubernetes/overhead/.gitignore
+++ b/integration/kubernetes/overhead/.gitignore
@@ -1,1 +1,2 @@
 workloads.yaml
+ovehead.csv

--- a/integration/kubernetes/overhead/.gitignore
+++ b/integration/kubernetes/overhead/.gitignore
@@ -1,0 +1,1 @@
+workloads.yaml

--- a/integration/kubernetes/overhead/README.md
+++ b/integration/kubernetes/overhead/README.md
@@ -1,0 +1,38 @@
+# Overhead calculation test
+
+Kata uses VMs to sandbox a set of containers. The additional components used by
+Kata add an extra overhead on CPU or memory.
+
+These scripts run a set of workloads where it is expected and extra CPU usage
+due to network or IO operations.
+
+- network: `tttcp`
+- IO : `fio`
+- web server: `nginx` + `apache ab`
+
+To collect the overhead information of the workloads, run the next command on a
+`kubernetes` cluster.
+
+```
+$./run-all.sh
+```
+
+To add a new workload add a directory with a prefix `test_`. The directory must
+provide the following structure:
+
+```
+/test_<workload-name>/
+|-- check_before_get_overhead.sh (optional)
+`-- workloads.yaml
+```
+
+
+- `workloads.yaml`
+
+Must provide a pod with the label `app=overhead`. That pod  will be used to
+collect its overhead.
+
+- `check_before_get_overhead.sh` optional.
+
+If the script exists, it will be called and will wait until is considered OK to
+start collecting the overhead data.

--- a/integration/kubernetes/overhead/run-all.sh
+++ b/integration/kubernetes/overhead/run-all.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+readonly script_dir=$(dirname $(readlink -f "$0"))
+run_sh="${script_dir}/run.sh"
+timeout=10m
+
+main() {
+	while read -r d; do
+		timeout --foreground "${timeout}" "${run_sh}" "${d}"
+	done < <(find "${script_dir}" -type d -name 'test_*')
+
+}
+
+main $*

--- a/integration/kubernetes/overhead/run.sh
+++ b/integration/kubernetes/overhead/run.sh
@@ -12,7 +12,7 @@ readonly script_dir=$(dirname $(readlink -f "$0"))
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 label_to_check="overhead"
 pre_run_check_file="./check_before_get_overhead.sh"
-samples=5
+samples=${SAMPLES:-5}
 
 usage() {
 	cat <<EOT

--- a/integration/kubernetes/overhead/run.sh
+++ b/integration/kubernetes/overhead/run.sh
@@ -64,6 +64,7 @@ main() {
 		esac
 	done
 
+	csv_file="${PWD}/ovehead.csv"
 	cd "${test}"
 	trap finish EXIT
 	"${script_dir}/steps/setup.sh"
@@ -73,7 +74,7 @@ main() {
 		"${pre_run_check_file}"
 	fi
 
-	"${script_dir}/steps/run.sh" --samples "${samples}"
+	"${script_dir}/steps/run.sh" --samples "${samples}" --csv "${csv_file}" --info "${test}"
 }
 
 main $*

--- a/integration/kubernetes/overhead/run.sh
+++ b/integration/kubernetes/overhead/run.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+readonly script_dir=$(dirname $(readlink -f "$0"))
+readonly script_name="$(basename "${BASH_SOURCE[0]}")"
+label_to_check="overhead"
+pre_run_check_file="./check_before_get_overhead.sh"
+samples=5
+
+usage() {
+	cat <<EOT
+Usage:
+${script_name} [options] <dir>
+
+<dir>: directory that has a workload.yaml
+
+       The workload.yaml should provide a pod with a label 'app'
+       The pod with a app label will be sampled to get its overhead
+       The the pod label must be the same name as "${label_to_check}"
+
+--samples: number of samples to collect, default ${samples}
+
+example:
+
+${script_name} fio
+EOT
+}
+
+finish() {
+	"${script_dir}/steps/cleanup.sh"
+}
+
+main() {
+	local test=${1:-}
+	if [ -z "${test}" ]; then
+		usage
+		exit 1
+	fi
+	while (("$#")); do
+		case "${1:-}" in
+		"-h" | "--help")
+			usage
+			exit 0
+			;;
+		"-s" | "--samples")
+			samples="${1}"
+			shift
+			;;
+		-*)
+			die "Invalid option: -${1:-}" "1"
+			shift
+			;;
+		*) # preserve positional arguments
+			#PARAMS="$PARAMS $1"
+			break
+			;;
+		esac
+	done
+
+	cd "${test}"
+	trap finish EXIT
+	"${script_dir}/steps/setup.sh"
+
+	if [ -x "${pre_run_check_file}" ]; then
+		echo "found ${pre_run_check_file}, running..."
+		"${pre_run_check_file}"
+	fi
+
+	"${script_dir}/steps/run.sh" --samples "${samples}"
+}
+
+main $*

--- a/integration/kubernetes/overhead/steps/cleanup.sh
+++ b/integration/kubernetes/overhead/steps/cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+kubectl delete --cascade -f workloads.yaml

--- a/integration/kubernetes/overhead/steps/run.sh
+++ b/integration/kubernetes/overhead/steps/run.sh
@@ -7,6 +7,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -o errtrace
+
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 samples=50
 wait_time_sec=5
@@ -42,8 +43,10 @@ get_overhead() {
 	echo "kubernetes container ID: ${cid}"
 	cid=$(echo "${cid}" | cut -d/ -f3)
 	echo "Container ID to get in kata: ${cid}"
-	if ! sudo "${RUNTIME}" list | grep "${cid}"; then
+	if ! sudo "${RUNTIME}" list | grep "${cid}" > /dev/null; then
 		sudo "${RUNTIME}" list
+		kubectl describe pod -l app="overhead"
+		kubectl logs -l app="overhead"
 		exit 1
 	fi
 	cpu_overhead_sum=0

--- a/integration/kubernetes/overhead/steps/run.sh
+++ b/integration/kubernetes/overhead/steps/run.sh
@@ -43,7 +43,7 @@ get_overhead() {
 	echo "kubernetes container ID: ${cid}"
 	cid=$(echo "${cid}" | cut -d/ -f3)
 	echo "Container ID to get in kata: ${cid}"
-	if ! sudo "${RUNTIME}" list | grep "${cid}" > /dev/null; then
+	if ! sudo "${RUNTIME}" list | grep "${cid}" >/dev/null; then
 		sudo "${RUNTIME}" list
 		kubectl describe pod -l app="overhead"
 		kubectl logs -l app="overhead"
@@ -73,16 +73,18 @@ get_overhead() {
 		info "sample $i cpu_host: ${cpu_host_sample}"
 	done
 
+	# TODO: should we take the max ovehead value or the max cpu usage from guest sample
 	cpu_overhead=$(echo "${cpu_overhead_sum} / ${samples}" | bc)
 	memory_overhead=$(echo "${memory_overhead_sum} / ${samples}" | bc)
 	cpu_host=$(echo "${cpu_host_sum} / ${samples}" | bc)
 	cpu_guest=$(echo "${cpu_guest_sum} / ${samples}" | bc)
+	vm_cpus=$(printf "%s" "${overhead_sample}" | grep "vm_cpus=" | cut -d= -f2)
 
 	if [ -n "${csv_file}" ]; then
 		if [ ! -f "${csv_file}" ]; then
-			echo "workload,cpu_host_usage,cpu_guest_usage,cpu_overhead,memory_overhead" >"${csv_file}"
+			echo "workload,cpu_host_usage,cpu_guest_usage,cpu_overhead,memory_overhead,vm_cpus" >"${csv_file}"
 		fi
-		echo "${info_test},${cpu_host},${cpu_guest},${cpu_overhead},${memory_overhead}" >>"${csv_file}"
+		echo "${info_test},${cpu_host},${cpu_guest},${cpu_overhead},${memory_overhead},${vm_cpus}" >>"${csv_file}"
 	fi
 }
 

--- a/integration/kubernetes/overhead/steps/run.sh
+++ b/integration/kubernetes/overhead/steps/run.sh
@@ -25,6 +25,19 @@ info() {
 	echo "INFO: $*" 1>&2
 }
 
+csv_headers=()
+csv_headers+=("workload")
+csv_headers+=("cpu_host_average")
+csv_headers+=("cpu_guest_average")
+csv_headers+=("cpu_overhead_average")
+csv_headers+=("max_cpu_guest")
+csv_headers+=("max_cpu_host")
+csv_headers+=("max_cpu_overhead")
+csv_headers+=("memory_overhead")
+csv_headers+=("vm_cpus")
+
+declare -A sample_csv_data
+
 get_overhead() {
 	local app_label=${1:-}
 	[ -n "${app_label}" ] || die "no app"
@@ -53,10 +66,16 @@ get_overhead() {
 	memory_overhead_sum=0
 	cpu_guest_sum=0
 	cpu_host_sum=0
+	sample_csv_data[max_cpu_host]=0
+	sample_csv_data[max_cpu_guest]=0
+	sample_csv_data[max_cpu_overhead]=0
 	for i in $(seq 1 ${samples}); do
 		overhead_sample=$(sudo "${RUNTIME}" kata-overhead "${cid}")
 
 		cpu_overhead_sample=$(printf "%s" "${overhead_sample}" | grep cpu_overhead | cut -d= -f2)
+		if (($(echo "$cpu_overhead_sample > ${sample_csv_data[max_cpu_overhead]}" | bc -l))); then
+			sample_csv_data[max_cpu_overhead]="${cpu_overhead_sample}"
+		fi
 		cpu_overhead_sum=$(echo "${cpu_overhead_sum} + ${cpu_overhead_sample}" | bc)
 		info "sample $i cpu overhead: ${cpu_overhead_sample}"
 
@@ -65,27 +84,40 @@ get_overhead() {
 		info "sample $i memory overhead: ${memory_overhead_sample}"
 
 		cpu_guest_sample=$(printf "%s" "${overhead_sample}" | grep "cpu_guest=" | cut -d= -f2)
+		if (($(echo "$cpu_guest_sample > ${sample_csv_data[max_cpu_guest]}" | bc -l))); then
+			sample_csv_data[max_cpu_guest]="${cpu_guest_sample}"
+		fi
 		cpu_guest_sum=$(echo "${cpu_guest_sum} + ${cpu_guest_sample}" | bc)
 		info "sample $i cpu_guest: ${cpu_guest_sample}"
 
 		cpu_host_sample=$(printf "%s" "${overhead_sample}" | grep "cpu_host=" | cut -d= -f2)
+		if (($(echo "$cpu_host_sample > ${sample_csv_data[max_cpu_host]}" | bc -l))); then
+			sample_csv_data[max_cpu_host]="${cpu_host_sample}"
+		fi
 		cpu_host_sum=$(echo "${cpu_host_sum} + ${cpu_host_sample}" | bc)
 		info "sample $i cpu_host: ${cpu_host_sample}"
 	done
 
 	# TODO: should we take the max ovehead value or the max cpu usage from guest sample
-	cpu_overhead=$(echo "${cpu_overhead_sum} / ${samples}" | bc)
-	memory_overhead=$(echo "${memory_overhead_sum} / ${samples}" | bc)
-	cpu_host=$(echo "${cpu_host_sum} / ${samples}" | bc)
-	cpu_guest=$(echo "${cpu_guest_sum} / ${samples}" | bc)
-	vm_cpus=$(printf "%s" "${overhead_sample}" | grep "vm_cpus=" | cut -d= -f2)
+	sample_csv_data[cpu_overhead_average]=$(echo "${cpu_overhead_sum} / ${samples}" | bc)
+	sample_csv_data[memory_overhead]=$(echo "${memory_overhead_sum} / ${samples}" | bc)
+	sample_csv_data[cpu_host_average]=$(echo "${cpu_host_sum} / ${samples}" | bc)
+	sample_csv_data[cpu_guest_average]=$(echo "${cpu_guest_sum} / ${samples}" | bc)
+	sample_csv_data[vm_cpus]=$(printf "%s" "${overhead_sample}" | grep "vm_cpus=" | cut -d= -f2)
 
 	if [ -n "${csv_file}" ]; then
 		if [ ! -f "${csv_file}" ]; then
-			echo "workload,cpu_host_usage,cpu_guest_usage,cpu_overhead,memory_overhead,vm_cpus" >"${csv_file}"
+			for h in "${csv_headers[@]}"; do
+				printf "%s," "${h}" >>"${csv_file}"
+			done
+			printf "\n" >> "${csv_file}"
 		fi
-		echo "${info_test},${cpu_host},${cpu_guest},${cpu_overhead},${memory_overhead},${vm_cpus}" >>"${csv_file}"
 	fi
+	for h in "${csv_headers[@]}"; do
+		printf "%s:%s\n" "${h}" "${sample_csv_data[${h}]}"
+		printf "%s," ${sample_csv_data[${h}]} >>"${csv_file}"
+	done
+	printf "\n" >> "${csv_file}"
 }
 
 usage() {
@@ -122,6 +154,7 @@ main() {
 			;;
 		"--info")
 			info_test="${2}"
+			sample_csv_data[workload]="${info_test}"
 			shift 2
 			;;
 		-*)

--- a/integration/kubernetes/overhead/steps/run.sh
+++ b/integration/kubernetes/overhead/steps/run.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+readonly script_name="$(basename "${BASH_SOURCE[0]}")"
+samples=50
+wait_time_sec=5
+max_tries=10
+label_to_check="overhead"
+RUNTIME=${RUNTIME:-kata-runtime}
+
+die() {
+	echo "ERROR:$*" 1>&2
+	exit 1
+}
+info() {
+	echo "INFO: $*" 1>&2
+}
+
+get_overhead() {
+	local app_label=${1:-}
+	[ -n "${app_label}" ] || die "no app"
+	cid="null"
+	try=0
+	while [ "$cid" == "null" ]; do
+		if ((try >= max_tries)); then
+			die "could not get container ID, max_tries=${max_tries} reached"
+		fi
+		cid=$(kubectl get pods -l app="${app_label}" -o json | jq -r .items[0].status.containerStatuses[0].containerID)
+		if [ -n "${cid}" ]; then
+			echo "waiting for container running ..."
+			sleep "${wait_time_sec}"
+		fi
+	done
+	echo "kubernetes container ID: ${cid}"
+	cid=$(echo "${cid}" | cut -d/ -f3)
+	echo "Container ID to get in kata: ${cid}"
+	if ! sudo "${RUNTIME}" list | grep "${cid}"; then
+		sudo "${RUNTIME}" list
+		exit 1
+	fi
+	overhead_sum=0
+	for i in $(seq 1 ${samples}); do
+		overhead_sample=$(sudo "${RUNTIME}" kata-overhead "${cid}" | grep cpu_overhead | cut -d= -f2)
+		overhead_sum=$(echo "${overhead_sum} + ${overhead_sample}" | bc)
+		info "sample $i :${overhead_sample}"
+	done
+
+	echo "${overhead_sum} / ${samples}" | bc
+}
+
+usage() {
+	cat <<EOT
+Usage:
+${script_name} [options] app-label
+
+--samples: number of samples to collect, default ${samples}
+app-label: name of the label to use to get pod overhead
+
+example:
+
+${script_name} --samples 5 nginx
+EOT
+}
+
+main() {
+	shopt -s extglob
+	while (("$#")); do
+		case "${1:-}" in
+		"-h" | "--help")
+			usage
+			exit 0
+			;;
+		"--samples")
+			samples="${2}"
+			shift 2
+			;;
+		-*)
+			die "Invalid option: ${1:-}"
+			shift
+			;;
+		*) # preserve positional arguments
+			#PARAMS="$PARAMS $1"
+			break
+			;;
+		esac
+	done
+
+	local app_label=${1:-${label_to_check}}
+	if [ -z "${app_label}" ]; then
+		usage
+		exit 1
+	fi
+	get_overhead "${app_label}"
+}
+main $*

--- a/integration/kubernetes/overhead/steps/run.sh
+++ b/integration/kubernetes/overhead/steps/run.sh
@@ -13,6 +13,8 @@ wait_time_sec=5
 max_tries=10
 label_to_check="overhead"
 RUNTIME=${RUNTIME:-kata-runtime}
+csv_file=""
+info_test="no-information"
 
 die() {
 	echo "ERROR:$*" 1>&2
@@ -32,7 +34,7 @@ get_overhead() {
 			die "could not get container ID, max_tries=${max_tries} reached"
 		fi
 		cid=$(kubectl get pods -l app="${app_label}" -o json | jq -r .items[0].status.containerStatuses[0].containerID)
-		if [ -n "${cid}" ]; then
+		if [ "${cid}" == "null" ]; then
 			echo "waiting for container running ..."
 			sleep "${wait_time_sec}"
 		fi
@@ -44,14 +46,41 @@ get_overhead() {
 		sudo "${RUNTIME}" list
 		exit 1
 	fi
-	overhead_sum=0
+	cpu_overhead_sum=0
+	memory_overhead_sum=0
+	cpu_guest_sum=0
+	cpu_host_sum=0
 	for i in $(seq 1 ${samples}); do
-		overhead_sample=$(sudo "${RUNTIME}" kata-overhead "${cid}" | grep cpu_overhead | cut -d= -f2)
-		overhead_sum=$(echo "${overhead_sum} + ${overhead_sample}" | bc)
-		info "sample $i :${overhead_sample}"
+		overhead_sample=$(sudo "${RUNTIME}" kata-overhead "${cid}")
+
+		cpu_overhead_sample=$(printf "%s" "${overhead_sample}" | grep cpu_overhead | cut -d= -f2)
+		cpu_overhead_sum=$(echo "${cpu_overhead_sum} + ${cpu_overhead_sample}" | bc)
+		info "sample $i cpu overhead: ${cpu_overhead_sample}"
+
+		memory_overhead_sample=$(printf "%s" "${overhead_sample}" | grep memory_overhead | cut -d= -f2)
+		memory_overhead_sum=$(echo "${memory_overhead_sum} + ${memory_overhead_sample}" | bc)
+		info "sample $i memory overhead: ${memory_overhead_sample}"
+
+		cpu_guest_sample=$(printf "%s" "${overhead_sample}" | grep "cpu_guest=" | cut -d= -f2)
+		cpu_guest_sum=$(echo "${cpu_guest_sum} + ${cpu_guest_sample}" | bc)
+		info "sample $i cpu_guest: ${cpu_guest_sample}"
+
+		cpu_host_sample=$(printf "%s" "${overhead_sample}" | grep "cpu_host=" | cut -d= -f2)
+		cpu_host_sum=$(echo "${cpu_host_sum} + ${cpu_host_sample}" | bc)
+		info "sample $i cpu_host: ${cpu_host_sample}"
 	done
 
-	echo "${overhead_sum} / ${samples}" | bc
+	cpu_overhead=$(echo "${cpu_overhead_sum} / ${samples}" | bc)
+	memory_overhead=$(echo "${memory_overhead_sum} / ${samples}" | bc)
+	cpu_host=$(echo "${cpu_host_sum} / ${samples}" | bc)
+	cpu_guest=$(echo "${cpu_guest_sum} / ${samples}" | bc)
+
+	if [ -n "${csv_file}" ]; then
+		if [ ! -f "${csv_file}" ]; then
+			echo "workload,cpu_host_usage,cpu_guest_usage,cpu_overhead,memory_overhead" >"${csv_file}"
+		fi
+		echo "${info_test},${cpu_host},${cpu_guest},${cpu_overhead},${memory_overhead}" >>"${csv_file}"
+	fi
 }
 
 usage() {
@@ -59,8 +88,10 @@ usage() {
 Usage:
 ${script_name} [options] app-label
 
---samples: number of samples to collect, default ${samples}
 app-label: name of the label to use to get pod overhead
+--samples <n>: number of samples to collect, default ${samples}
+--csv <file> : save data on csv
+--info       : used to for csv to identify test with other tests
 
 example:
 
@@ -78,6 +109,14 @@ main() {
 			;;
 		"--samples")
 			samples="${2}"
+			shift 2
+			;;
+		"--csv")
+			csv_file="${2}"
+			shift 2
+			;;
+		"--info")
+			info_test="${2}"
 			shift 2
 			;;
 		-*)

--- a/integration/kubernetes/overhead/steps/setup.sh
+++ b/integration/kubernetes/overhead/steps/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+RUNTIMECLASS=${RUNTIMECLASS:-kata}
+MEM_IN_MB=${MEM_IN_MB:-2048}
+CPUS=${CPUS:-4}
+
+sed -e "s,@CPUS@,${CPUS},g" \
+	-e "s,@MEM_IN_MB@,${MEM_IN_MB},g" \
+	-e "s,@RUNTIMECLASS@,${RUNTIMECLASS},g" \
+	workloads.yaml.in > workloads.yaml
+
+kubectl create -f workloads.yaml
+
+if ! kubectl wait pod -l app="overhead" --for=condition=Ready --timeout "200s"; then
+	echo "Timeout to get pods in ready"
+	kubectl describe pod -l app="overhead"
+	exit 1
+fi
+
+echo "pods are running"
+echo

--- a/integration/kubernetes/overhead/steps/setup.sh
+++ b/integration/kubernetes/overhead/steps/setup.sh
@@ -19,7 +19,7 @@ sed -e "s,@CPUS@,${CPUS},g" \
 
 kubectl create -f workloads.yaml
 
-if ! kubectl wait pod -l app="overhead" --for=condition=Ready --timeout "200s"; then
+if ! kubectl wait pod -l app="overhead" --for=condition=Ready --timeout "300s"; then
 	echo "Timeout to get pods in ready"
 	kubectl describe pod -l app="overhead"
 	exit 1

--- a/integration/kubernetes/overhead/test_busybox_sleep/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_busybox_sleep/workloads.yaml.in
@@ -1,0 +1,23 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-sleep
+  labels:
+    app: overhead
+spec:
+  runtimeClassName: @RUNTIMECLASS@
+  containers:
+  - name: busybox-sleep
+    image: busybox
+    command: [ "sh", "-c","sleep infinity" ]
+    resources:
+      #https://github.com/kata-containers/runtime/issues/1534 scale using limits request do to scale cpu in kata
+      limits:
+        cpu: @CPUS@
+        memory: @MEM_IN_MB@Mi
+  terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_fio/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_fio/workloads.yaml.in
@@ -14,9 +14,10 @@ spec:
   containers:
   - name: fio
     image: egernst/fio
-    command: [ "fio", "--runtime=60000", "--time_based", "--clocksource=clock_gettime", "--name=randread", "--numjobs=8", "--rw=randread", "--random_distribution=pareto:0.9", "--bs=8k", "--size=10g", "--filename=fio.tmp" ]
+    command: [ "fio", "--runtime=60000", "--time_based", "--clocksource=clock_gettime", "--name=randread", "--numjobs=@CPUS@", "--rw=randread", "--random_distribution=pareto:0.9", "--bs=8k", "--size=10g", "--filename=fio.tmp" ]
     resources:
-      requests:
+      #https://github.com/kata-containers/runtime/issues/1534 scale using limits request do to scale cpu in kata
+      limits:
         cpu: @CPUS@
         memory: @MEM_IN_MB@Mi
   terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_fio/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_fio/workloads.yaml.in
@@ -1,0 +1,22 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fio
+  labels:
+    app: overhead
+spec:
+  runtimeClassName: @RUNTIMECLASS@
+  containers:
+  - name: fio
+    image: egernst/fio
+    command: [ "fio", "--runtime=60000", "--time_based", "--clocksource=clock_gettime", "--name=randread", "--numjobs=8", "--rw=randread", "--random_distribution=pareto:0.9", "--bs=8k", "--size=10g", "--filename=fio.tmp" ]
+    resources:
+      requests:
+        cpu: @CPUS@
+        memory: @MEM_IN_MB@Mi
+  terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_nginx/check_before_get_overhead.sh
+++ b/integration/kubernetes/overhead/test_nginx/check_before_get_overhead.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+max_tries="180"
+try=1
+
+while ! kubectl logs ab | grep "HTTP/1.1 200 OK" >/dev/null; do
+	echo "wait until ab can request to server"
+	sleep 1
+	try=$((try + 1))
+	if ((try >= max_tries)); then
+		echo "reached max tries ${max_tries}"
+		#show output
+		kubectl logs ab
+		exit 1
+	fi
+done
+
+echo "OK"

--- a/integration/kubernetes/overhead/test_nginx/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_nginx/workloads.yaml.in
@@ -27,7 +27,8 @@ spec:
         - containerPort: 80
           name: server
         resources:
-          requests:
+          #https://github.com/kata-containers/runtime/issues/1534 scale using limits request do to scale cpu in kata
+          limits:
             cpu: @CPUS@
             memory: @MEM_IN_MB@Mi
       terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_nginx/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_nginx/workloads.yaml.in
@@ -1,0 +1,58 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overhead
+  labels:
+    app: overhead
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overhead
+  template:
+    metadata:
+      labels:
+        app: overhead
+    spec:
+      runtimeClassName: @RUNTIMECLASS@
+      containers:
+      - name: overhead
+        image: nginx
+        ports:
+        - containerPort: 80
+          name: server
+        resources:
+          requests:
+            cpu: @CPUS@
+            memory: @MEM_IN_MB@Mi
+      terminationGracePeriodSeconds: 0
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: overhead
+spec:
+  selector:
+    app: overhead
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: server
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ab
+spec:
+  containers:
+  - name: ab
+    image: httpd
+    command: [ "sh", "-c", "while true; do ab -v 2 -c 100 -s 5 -n 999999999 http://overhead:80/;done" ]
+  terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_ntttcp/check_before_get_overhead.sh
+++ b/integration/kubernetes/overhead/test_ntttcp/check_before_get_overhead.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+max_tries="180"
+try=1
+
+client="ntttcp-client"
+
+while ! kubectl logs "${client}" | grep "INFO: Network activity progressing" >/dev/null; do
+	echo "wait until can request to server"
+	sleep 1
+	try=$((try + 1))
+	if ((try >= max_tries)); then
+		echo "reached max tries ${max_tries}"
+		#show output
+		kubectl logs "${client}"
+		exit 1
+	fi
+done
+
+echo "OK"

--- a/integration/kubernetes/overhead/test_ntttcp/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_ntttcp/workloads.yaml.in
@@ -27,7 +27,8 @@ spec:
         - containerPort: 5000
           name: server
         resources:
-          requests:
+          #https://github.com/kata-containers/runtime/issues/1534 scale using limits request do to scale cpu in kata
+          limits:
             cpu: @CPUS@
             memory: @MEM_IN_MB@Mi
       terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_ntttcp/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_ntttcp/workloads.yaml.in
@@ -1,0 +1,58 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overhead
+  labels:
+    app: overhead
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: overhead
+  template:
+    metadata:
+      labels:
+        app: overhead
+    spec:
+      runtimeClassName: @RUNTIMECLASS@
+      containers:
+      - name: overhead
+        image: jcvenega/ntttcp
+        ports:
+        - containerPort: 5000
+          name: server
+        resources:
+          requests:
+            cpu: @CPUS@
+            memory: @MEM_IN_MB@Mi
+      terminationGracePeriodSeconds: 0
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: overhead
+spec:
+  selector:
+    app: overhead
+  ports:
+  - protocol: TCP
+    port: 5000
+    targetPort: server
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ntttcp-client
+spec:
+  containers:
+  - name: ntttcp-client
+    image: jcvenega/ntttcp
+    command: [ "sh", "-c", "while true; do /run/ntttcp -s$(dig +short overhead.default.svc.cluster.local) -t 5000 ;done" ]
+  terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/overhead/test_stress_ng_cpu/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_stress_ng_cpu/workloads.yaml.in
@@ -16,6 +16,7 @@ spec:
     image: polinux/stress-ng
     command: [ "sh", "-c","stress-ng --cpu @CPUS@ --timeout 99999999s --metrics-brief" ]
     resources:
+      #https://github.com/kata-containers/runtime/issues/1534 scale using limits request do to scale cpu in kata
       limits:
         cpu: @CPUS@
         memory: @MEM_IN_MB@Mi

--- a/integration/kubernetes/overhead/test_stress_ng_cpu/workloads.yaml.in
+++ b/integration/kubernetes/overhead/test_stress_ng_cpu/workloads.yaml.in
@@ -1,0 +1,22 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: stress-ng-cpu
+  labels:
+    app: overhead
+spec:
+  runtimeClassName: @RUNTIMECLASS@
+  containers:
+  - name: stress-ng-cpu
+    image: polinux/stress-ng
+    command: [ "sh", "-c","stress-ng --cpu @CPUS@ --timeout 99999999s --metrics-brief" ]
+    resources:
+      limits:
+        cpu: @CPUS@
+        memory: @MEM_IN_MB@Mi
+  terminationGracePeriodSeconds: 0

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -73,11 +73,8 @@ fi
 
 pushd "$kubernetes_dir"
 ./init.sh
-for K8S_TEST_ENTRY in ${K8S_TEST_UNION[@]}
-do
-	bats "${K8S_TEST_ENTRY}"
-done
 popd
 
+#CI only has 4 cpus cpus lets just 2 for the worloads to measure
 export CPUS=2
 "${script_dir}/overhead/run-all.sh"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -10,6 +10,7 @@ set -e
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_dir=$(dirname "$(readlink -f "$0")")
 cidir="${kubernetes_dir}/../../.ci/"
+readonly script_dir=$(dirname $(readlink -f "$0"))
 source "${cidir}/lib.sh"
 
 arch="$(uname -m)"
@@ -77,3 +78,6 @@ do
 	bats "${K8S_TEST_ENTRY}"
 done
 popd
+
+export CPUS=2
+"${script_dir}/overhead/run-all.sh"


### PR DESCRIPTION
Add workloads to stress the next areas:

- network: tttcp
- IO : fio
- webserver: nginx + apache ab

This provide examples to run workloads and how
to measure it with `kata-runtime kata-overhead` sub-command

Fixes: #1976

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>