### PR TITLE
ci: fix retrieval of cached experimental kernel 

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -50,6 +50,7 @@ download_repo() {
 get_current_kernel_version() {
 	if [ "$experimental_kernel" == "true" ]; then
 		kernel_version=$(get_version "assets.kernel-experimental.tag")
+		echo "${kernel_version}"
 	else
 		kernel_version=$(get_version "assets.kernel.version")
 		echo "${kernel_version/v/}"
@@ -97,7 +98,6 @@ install_cached_kernel(){
 	info "Installing ${kernel_binary_path} and symlink ${kernel_symlink}"
 	sudo -E ln -sf "${kernel_binary_path}" "${kernel_symlink}"
 }
-
 
 install_prebuilt_kernel() {
 	info "Install pre-built kernel version"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -108,7 +108,11 @@ install_prebuilt_kernel() {
 
 	pushd "${kernel_dir}" >/dev/null
 	info "Verify download checksum"
-	sudo -E curl -fsOL "${latest_build_url}/sha256sum-kernel" || return 1
+	if [ ${experimental_kernel} == "true" ]; then
+		sudo -E curl -fsOL "${experimental_latest_build_url}/sha256sum-kernel" || return 1
+	else
+		sudo -E curl -fsOL "${latest_build_url}/sha256sum-kernel" || return 1
+        fi
 	sudo sha256sum -c "sha256sum-kernel" || return 1
 	popd >/dev/null
 }


### PR DESCRIPTION
- ci: fix `get_current_kernel_version` for experimental kernel.
echo the value of `kernel_version` on `get_current_kernel_version`
function.

- ci: use experimental_latest_build_url to verify the checksum.
Instead of using the `latest_build_url` for experimental kernel,
use the correct url which is `experimental_latest_build_url`.
This will verify the integrity of the kernel with the correct
checksum.

Fixes: #1977.