### PR TITLE
ci: Fix kernel symlink for experimental kernel

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -94,7 +94,11 @@ install_cached_kernel(){
 	else
 		sudo -E curl -fL --progress-bar "${latest_build_url}/${kernel_binary_name}" -o "${kernel_binary_path}" || return 1
 	fi
-	kernel_symlink="${kernel_dir}/${kernel_binary}.container"
+	if [ ${experimental_kernel} == "true" ]; then
+		kernel_symlink="${kernel_dir}/${kernel_binary}-virtiofs.container"
+	else
+		kernel_symlink="${kernel_dir}/${kernel_binary}.container"
+	fi
 	info "Installing ${kernel_binary_path} and symlink ${kernel_symlink}"
 	sudo -E ln -sf "${kernel_binary_path}" "${kernel_symlink}"
 }


### PR DESCRIPTION
This will rename the kernel experimental with the appropiate sufix
`virtiofs.container`

Fixes #1979

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>