### PR TITLE
ci: Move configuration-qemu-virtiofs.toml to correct path

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -65,7 +65,10 @@ if [ "$KATA_HYPERVISOR" = "nemu" ]; then
 fi
 
 if [ "$KATA_HYPERVISOR" = "qemu" ] && [ "$experimental_qemu" == "true" ]; then
+	runtime_repo="github.com/kata-containers/runtime"
+
 	echo "Enable qemu virtiofs configuration.toml"
+	sudo mv "$GOPATH/src/${runtime_repo}/cli/config/configuration-qemu-virtiofs.toml" "${PKGDEFAULTSDIR}"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-qemu-virtiofs.toml" "${PKGDEFAULTSDIR}/configuration.toml"
 fi
 


### PR DESCRIPTION
This will move the configuration-qemu-virtiofs.toml to the correct path.

Fixes #1981

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>