### PR TITLE
centos: fix the missing entry in centos:latest on non-amd64 platform

### DIFF
--- a/integration/docker/docker_arch_base.go
+++ b/integration/docker/docker_arch_base.go
@@ -1,4 +1,4 @@
-// +build !s390x
+// +build !arm64,!ppc64le,!s390x
 
 // Copyright (c) 2019 IBM
 //

--- a/integration/docker/docker_arm64.go
+++ b/integration/docker/docker_arm64.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+const (
+	// For now, the latest centos:latest is only for x86-64.
+	// See https://github.com/kata-containers/ci/issues/222 for more details
+	CentosImage = "centos:7"
+)

--- a/integration/docker/docker_ppc64le.go
+++ b/integration/docker/docker_ppc64le.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2019 ARM Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+const (
+	// For now, the latest centos:latest is only for x86-64.
+	// See https://github.com/kata-containers/ci/issues/222 for more details
+	CentosImage = "centos:7"
+)


### PR DESCRIPTION
Lately, ARM CI and Power are all failing in trying to pull docker centos image.
See issue here: [kata-containers/ci#222](https://github.com/kata-containers/ci/issues/222).
That's because that the latest `centos:latest` is updated to `centos:8`, but it has only one entry for `amd64`.
```
$ export DOCKER_CLI_EXPERIMENTAL=enabled
$ docker manifest inspect centos:latest
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 529,
         "digest": "sha256:6ab380c5a5acf71c1b6660d645d2cd79cc8ce91b38e0352cbf9561e050427baf",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
}
```
I have already informed the upstream about this missing issue, and will keep track of it.
Thanks to @chavafg, we try to go back to use `centos:7` on non-amd64 platform during the waiting time.