### PR TITLE
ci: Missing arch on sles setup

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -10,6 +10,7 @@ set -e
 cidir=$(dirname "$0")
 source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
+arch=$("${cidir}"/kata-arch.sh -d)
 
 echo "Add repo for perl-IPC-Run"
 perl_repo="https://download.opensuse.org/repositories/devel:languages:perl/SLE_${VERSION//-/_}/devel:languages:perl.repo"


### PR DESCRIPTION
Missing arch on sles setup while trying to retry a repository.

Fixes #1992

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>