### PR TITLE
ci: Fixes for `.ci/install_qemu_experimental.sh`

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -49,7 +49,7 @@ IMAGE_OS_VERSION_KEY="assets.${IMG_TYPE}.architecture.$(uname -m).version"
 agent_path="${GOPATH}/src/github.com/kata-containers/agent"
 osbuilder_repo="github.com/kata-containers/osbuilder"
 osbuilder_path="${GOPATH}/src/${osbuilder_repo}"
-latest_build_url="http://jenkins.katacontainers.io/job/image-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/image-nightly-$(uname -m)/${cached_artifacts_path}"
 
 install_ci_cache_image() {
 	type=${1}

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -19,8 +19,8 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-latest_build_url="http://jenkins.katacontainers.io/job/kernel-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
-experimental_latest_build_url="http://jenkins.katacontainers.io/job/kernel-experimental-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
+experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 kernel_dir="/usr/share/kata-containers"
 
 kernel_repo_name="packaging"

--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -17,7 +17,7 @@ source /etc/os-release || source /usr/lib/os-release
 
 versions_file="${cidir}/../versions.yaml"
 arch=$("${cidir}"/kata-arch.sh -d)
-latest_build_url="http://jenkins.katacontainers.io/job/nemu-nightly-${arch}/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/nemu-nightly-${arch}/${cached_artifacts_path}"
 nemu_repo=$(get_version "assets.hypervisor.nemu.url")
 nemu_version=$(get_version "assets.hypervisor.nemu.version")
 NEMU_TAR="kata-nemu-static.tar.gz"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -26,7 +26,7 @@ QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
 PACKAGING_REPO="github.com/kata-containers/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
 QEMU_TAR="kata-qemu-static.tar.gz"
-qemu_latest_build_url="http://jenkins.katacontainers.io/job/qemu-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
 
 # option "--shallow-submodules" was introduced in git v2.9.0
 GIT_SHADOW_VERSION="2.9.0"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -25,7 +25,7 @@ arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_LOCATION="/tmp/qemu-virtiofs-static/opt/kata/bin/"
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
 VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
-qemu_experimental_latest_build_url="http://jenkins.katacontainers.io/job/qemu-experimental-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-$(uname -m)/${cached_artifacts_path}"
 
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -63,6 +63,8 @@ main() {
 		die "Unsupported architecture: $arch"
 	fi
 	cached_qemu_experimental_version=$(curl -sfL "${qemu_experimental_latest_build_url}/latest") || cached_qemu_experimental_version="none"
+	info "Cached qemu experimental version: $cached_qemu_experimental_version"
+	info "Current qemu experimental version: $CURRENT_QEMU_TAG"
 	mkdir -p "${INSTALL_LOCATION}"
 	if [ "$cached_qemu_experimental_version" == "$CURRENT_QEMU_TAG" ]; then
 		install_cached_qemu_experimental || build_and_install_static_experimental_qemu

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -18,11 +18,9 @@ source /etc/os-release || source /usr/lib/os-release
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
-QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu-experimental.url")
 PACKAGING_REPO="github.com/kata-containers/packaging"
 QEMU_TAR="kata-qemu-static.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
-INSTALL_LOCATION="/tmp/qemu-virtiofs-static/opt/kata/bin/"
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
 VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
 qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-$(uname -m)/${cached_artifacts_path}"
@@ -65,7 +63,6 @@ main() {
 	cached_qemu_experimental_version=$(curl -sfL "${qemu_experimental_latest_build_url}/latest") || cached_qemu_experimental_version="none"
 	info "Cached qemu experimental version: $cached_qemu_experimental_version"
 	info "Current qemu experimental version: $CURRENT_QEMU_TAG"
-	mkdir -p "${INSTALL_LOCATION}"
 	if [ "$cached_qemu_experimental_version" == "$CURRENT_QEMU_TAG" ]; then
 		install_cached_qemu_experimental || build_and_install_static_experimental_qemu
 	else

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -36,7 +36,7 @@ install_cached_qemu_experimental() {
 	curl -fL --progress-bar "${qemu_experimental_latest_build_url}/${QEMU_TAR}" -o "${QEMU_TAR}" || return 1
 	curl -fsOL "${qemu_experimental_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
-	uncompress_static_qemu "${QEMU_TAR}"
+	uncompress_experimental_qemu "${QEMU_TAR}"
 	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
 	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
 }

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -39,15 +39,15 @@ install_cached_qemu_experimental() {
 	curl -fsOL "${qemu_experimental_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_static_qemu "${QEMU_TAR}"
-	sudo -E ln -s "${QEMU_PATH}" "/usr/bin"
-	sudo -E ln -s "${VIRTIOFS_PATH}" "/usr/bin"
+	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
+	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
 }
 
 build_and_install_static_experimental_qemu() {
 	build_experimental_qemu
 	uncompress_experimental_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
-	sudo -E ln -s "${QEMU_PATH}" "/usr/bin"
-	sudo -E ln -s "${VIRTIOFS_PATH}" "/usr/bin"
+	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
+	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
 }
 
 build_experimental_qemu() {

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -23,7 +23,7 @@ QEMU_TAR="kata-qemu-static.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
 VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
-qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-$(uname -m)/${cached_artifacts_path}"
+qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -39,6 +39,11 @@ source "${lib_script}"
 
 export KATA_OBS_REPO_BASE="http://download.opensuse.org/repositories/home:/katacontainers:/releases:/$(arch):/master"
 
+# Jenkins master URL
+jenkins_url="http://jenkins.katacontainers.io"
+# Path where cached artifacts are found.
+cached_artifacts_path="lastSuccessfulBuild/artifact/artifacts"
+
 # If we fail for any reason a message will be displayed
 die() {
 	msg="$*"


### PR DESCRIPTION

- fix the URL to get cached version of experimental qemu.
- remove unused code.
- use `ln -sf` to remove previous versions of qemu binaries
- print versions of current and cached qemu
- use variables for jenkins URL and artifacts paths.