### PR TITLE
e2e: fix sonobuoy retrieval

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -61,3 +61,8 @@ externals:
 
   critools:
     version: 1.14.0
+
+  sonobuoy:
+    description: "Tool to run kubernetes e2e conformance tests"
+    url: "https://github.com/vmware-tanzu/sonobuoy"
+    version: "0.16.1"


### PR DESCRIPTION
instead of running `go get`, we need to download the
sonobuoy binary from the release assets.

Add a sonoboy entry in our local versions.yaml file to use
version 0.16.1 which is the latest currently.

Fixes: #2000.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>