### PR TITLE
WIP:cri: Enable ipv6 explicitly

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -72,6 +72,11 @@ ci_config() {
 		(
 		echo "Install cni config for cri-containerd test"
 		cd "${GOPATH}/src/${cri_containerd_repo}"
+		# Below script installing CNI config for containerd 1.3.0 installs ipv6 routes, so enable ipv6
+		sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+		sudo sysctl net.ipv6.conf.default.disable_ipv6=0
+		sudo sysctl -n net.ipv6.conf.all.disable_ipv6
+		sudo sysctl -n net.ipv6.conf.default.disable_ipv6
 		./hack/install/install-cni-config.sh
 		)
 	fi

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -77,7 +77,9 @@ if ip a show "$cni_interface"; then
 fi
 
 echo "Start ${cri_runtime} service"
-sudo systemctl start ${cri_runtime}
+sudo systemctl daemon-reload
+sudo systemctl cat "${cri_runtime}.service"
+sudo systemctl restart ${cri_runtime}
 max_cri_socket_check=5
 wait_time_cri_socket_check=5
 


### PR DESCRIPTION
The script to install sample CNI config in the CRI repo now
expplicitly installs ipv6 routes for containerd 1.3.0.
So enable sysctl settingg for ipv6.

Fixes #2002

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>