### PR TITLE
tests: Fix checking status for crio service

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -91,7 +91,7 @@ for i in $(seq ${max_cri_socket_check}); do
 	echo "Waiting for cri socket ${cri_runtime_socket} (try ${i})"
 done
 
-sudo systemctl status "${cri_runtime}"
+sudo systemctl status "${cri_runtime}" --no-pager
 
 echo "Init cluster using ${cri_runtime_socket}"
 kubeadm_config_template="${SCRIPT_PATH}/kubeadm/config.yaml"


### PR DESCRIPTION
While running manually the ./init.sh, this gets stuck while doing
the systemctl status ${crio_service} and this avoids to run the script
completely. This PR fixes that option.

Fixes #2004

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>