### PR TITLE
virtiofs: Skip package manager test for dnf and yum

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -25,6 +25,7 @@ docker:
     - Hotplug memory when create containers
     - run container and update its memory constraints
     - Checking CPU cgroups in the host
+    - check yum update
   Context:
   It:
 

--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -26,6 +26,7 @@ docker:
     - run container and update its memory constraints
     - check dmesg logs errors
     - memory constraints
+    - check yum update
   Context:
     - run container exceeding memory constraints
   It:

--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/kata-containers/tests"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -69,6 +70,9 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check dnf update", func() {
 		It("should not fail", func() {
+			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
+			}
 			args = append(args, "-td", "--name", id, FedoraImage, "sh")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())
@@ -87,7 +91,9 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check yum update", func() {
 		It("should not fail", func() {
-			Skip("Test Failing, see: https://github.com/kata-containers/tests/issues/1270")
+			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
+			}
 			args = append(args, "--rm", "-td", "--name", id, CentosImage, "sh")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())


### PR DESCRIPTION
dnf and yum update tests are failing when running with
virtiofs. More info can be found on #2008.

While this is being fixed, lets skip it to have a green CI.

In addition, unskip the yum test running with 9p, which was
not working in the past but now behaves correctly.

Fixes: #2013.
Fixes: #1270.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>