### PR TITLE
s390x: Disable cri-containerd testsuite

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -11,9 +11,7 @@ test:
   - docker-compose
   - docker-stability
   - entropy
-  - cri-containerd
 
-# Same model as is for aarch64
 docker:
   Describe:
     - CPUs and CPU set


### PR DESCRIPTION
The cri-containerd testsuite keeps failing for s390x. Disable it to have a
working CI for s390x.

Fixes: #2021
Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>