### PR TITLE
test: Fix script location for the tracing test

### DIFF
--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -27,7 +27,7 @@ jaeger_docker_container_name="jaeger"
 # disable tracing.
 cleanup(){
 	stop_jaeger 2>/dev/null || true
-	.ci/configure_tracing_for_kata.sh disable
+	"${SCRIPT_PATH}/../.ci/configure_tracing_for_kata.sh" disable
 }
 
 trap cleanup EXIT
@@ -257,7 +257,7 @@ main()
 
 	start_jaeger
 
-	.ci/configure_tracing_for_kata.sh enable
+	"${SCRIPT_PATH}/../.ci/configure_tracing_for_kata.sh" enable
 
 	info "Checking runtime spans"
 	run_test "$runtime_min_spans" "$runtime_service"


### PR DESCRIPTION
While running the tracing test locally and on the tracing directory, it fails
to locate the configure_tracing_for_kata.sh. This improves and fixes that issue
so no matter if you are running it using the Makefile or on the tracing directory
that will not fail.

Fixes #2025

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>