### PR TITLE
containerd: Skip using the config provided by cri

### DIFF
--- a/.ci/configure_cni.sh
+++ b/.ci/configure_cni.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+echo "Configure CNI"
+cni_net_config_path="/etc/cni/net.d"
+sudo mkdir -p ${cni_net_config_path}
+
+sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
+{
+	"cniVersion": "0.3.0",
+	"name": "mynet",
+	"type": "bridge",
+	"bridge": "cni0",
+	"isGateway": true,
+	"ipMasq": true,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "10.88.0.0/16",
+		"routes": [
+			{ "dst": "0.0.0.0/0"  }
+		]
+	}
+}
+EOF'
+
+sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
+{
+	"cniVersion": "0.3.0",
+	"type": "loopback"
+}
+EOF'

--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -18,14 +18,16 @@ cat << EOT | sudo tee /etc/containerd/config.toml
 [plugins]
   [plugins.cri]
     [plugins.cri.containerd]
-      [plugins.cri.containerd.runtimes.runc]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        [plugins.cri.containerd.runtimes.runc.options]
-          Runtime = "runc"
-          RuntimeRoot = "${runc_path}"
-      [plugins.cri.containerd.runtimes.kata]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        [plugins.cri.containerd.runtimes.kata.options]
-          Runtime = "kata-runtime"
-          RuntimeRoot = "${kata_runtime_path}"
+      [plugins.cri.containerd.runtimes]
+        [plugins.cri.containerd.runtimes.runc]
+           runtime_type = "io.containerd.runc.v1"
+           [plugins.cri.containerd.runtimes.runc.options]
+             BinaryName = "${runc_path}"
+             Root = ""
+        [plugins.cri.containerd.runtimes.kata]
+           runtime_type = "io.containerd.runc.v1"
+           pod_annotations = ["io.kata-containers.*"]
+           [plugins.cri.containerd.runtimes.kata.options]
+             BinaryName = "${kata_runtime_path}"
+             Root = ""
 EOT

--- a/.ci/install_cni_plugins.sh
+++ b/.ci/install_cni_plugins.sh
@@ -24,33 +24,6 @@ cni_bin_path="/opt/cni"
 sudo mkdir -p ${cni_bin_path}
 sudo cp -a bin ${cni_bin_path}
 
-echo "Configure CNI"
-cni_net_config_path="/etc/cni/net.d"
-sudo mkdir -p ${cni_net_config_path}
-
-sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
-{
-	"cniVersion": "0.3.0",
-	"name": "mynet",
-	"type": "bridge",
-	"bridge": "cni0",
-	"isGateway": true,
-	"ipMasq": true,
-	"ipam": {
-		"type": "host-local",
-		"subnet": "10.88.0.0/16",
-		"routes": [
-			{ "dst": "0.0.0.0/0"  }
-		]
-	}
-}
-EOF'
-
-sudo sh -c 'cat >/etc/cni/net.d/99-loopback.conf <<-EOF
-{
-	"cniVersion": "0.3.0",
-	"type": "loopback"
-}
-EOF'
-
 popd
+
+${cidir}/configure_cni.sh

--- a/.ci/install_cni_plugins.sh
+++ b/.ci/install_cni_plugins.sh
@@ -7,11 +7,6 @@
 
 set -e
 
-if [ "${CI_JOB}" == "CRI_CONTAINERD_K8S" ];then
-	echo "CRI_CONTAINERD_K8S: cri-o cni config will not be installed"
-	exit 0;
-fi
-
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -68,6 +68,14 @@ ci_config() {
 			sudo -E PATH=$PATH "$RUNTIME" factory init
 		fi
 	fi
+
+	if [ -n "${CI}" ]; then
+		(
+		echo "Install cni config"
+		SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+		${SCRIPT_PATH}/../../../.ci/configure_cni.sh
+		)
+	fi
 }
 
 ci_cleanup() {

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -68,13 +68,6 @@ ci_config() {
 			sudo -E PATH=$PATH "$RUNTIME" factory init
 		fi
 	fi
-	if [ -n "${CI}" ]; then
-		(
-		echo "Install cni config for cri-containerd test"
-		cd "${GOPATH}/src/${cri_containerd_repo}"
-		./hack/install/install-cni-config.sh
-		)
-	fi
 }
 
 ci_cleanup() {


### PR DESCRIPTION
The cni config used for tests from the cri repo has ipv6 routes.
Skip this and use a cni config used for crio as well.

Depends-on: github.com/kata-containers/runtime#2100

Fixes #2002

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>