### PR TITLE
cri: disable containerd service

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -158,6 +158,9 @@ main() {
 	info "Stop crio service"
 	systemctl is-active --quiet crio && sudo systemctl stop crio
 
+	info "Stop containerd service"
+	systemctl is-active --quiet containerd && sudo systemctl stop containerd
+
 	# Configure enviroment if running in CI
 	ci_config
 


### PR DESCRIPTION
Since the containerd cri testing cases would setup it's own containerd
daemon, which would conflict with the systemd containerd service, thus
it's better to stop it before running cri testcases.

Fixes: #2042

Signed-off-by: lifupan <lifupan@gmail.com>