### PR TITLE
test: Remove extra character in popular test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -287,7 +287,7 @@ setup() {
 	docker run --rm --runtime=$RUNTIME -i -e MYSQL_ROOT_PASSWORD=secretword  $image bash -c "cat /etc/mysql/mariadb.cnf | grep character"
 }
 
-@test "[matomo]" run a matomo container" {
+@test "[matomo] run a matomo container" {
 	image="matomo"
 	docker run --runtime=$RUNTIME --rm -i $image bash -c "php -r 'print(\"Kata Containers\");'"
 }


### PR DESCRIPTION
There is an extra character in the popular docker hub images test, this
will remove it.

Fixes #2046

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>