### PR TITLE
ci: `install_rust.sh` fixes

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -9,6 +9,8 @@ set -e
 [ -n "${KATA_DEV_MODE:-}" ] && exit 0
 
 cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
 rustarch=$(${cidir}/kata-arch.sh --rust)
 # release="nightly"
 # recent functional version

--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -23,6 +23,8 @@ if ! command -v rustup > /dev/null; then
 	curl https://sh.rustup.rs -sSf | sh
 fi
 
+export PATH="${PATH}:${HOME}/.cargo/bin"
+
 rustup toolchain install ${version}
 rustup default ${version}
 rustup target install ${rustarch}-unknown-linux-musl


### PR DESCRIPTION
`get_version` is a function that lives in `.ci/lib.sh`, so we need
to source that file in order to use the function.

In addition, after `rust` is installed, we need to source the `$HOME/.profile`
which adds the `$HOME/.cargo/bin` directory to the `PATH`.