### PR TITLE
ci: fix `configure_crio_for_kata.sh` script for cri-o 1.16

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -21,18 +21,14 @@ if [ "$minor_crio_version" -ge "12" ]; then
 	runc_configured=$(grep -q $runc_flag $crio_config_file; echo "$?")
 	if [[ $runc_configured -ne 0 ]]; then
 		sudo sed -i 's!runtime_path =.*!runtime_path = "/usr/local/bin/crio-runc"!' "$crio_config_file"
-		sudo sed -i '/runtime_root/d' "$crio_config_file"
-		sudo sed -i '/runtime_type/d' "$crio_config_file"
 	fi
 	echo "- Add kata-runtime to the runtimes map"
 	kata_configured=$(grep -q $kata_flag $crio_config_file; echo "$?")
 	if [[ $kata_configured -ne 0 ]]; then
-		sudo sed -i '/crio-runc/a [crio.runtime.runtimes.kata]' "$crio_config_file"
-		sudo sed -i '/crio\.runtime\.runtimes\.kata/a runtime_path = "/usr/local/bin/kata-runtime"' "$crio_config_file"
-		sudo sed -i '/kata-runtime/a runtime_root = "/run/vc"' "$crio_config_file"
+		sudo sed -i '/\/run\/runc/a [crio.runtime.runtimes.kata]' "$crio_config_file"
+		sudo sed -i '/crio\.runtime\.runtimes\.kata\]/a runtime_path = "/usr/local/bin/kata-runtime"' "$crio_config_file"
+		sudo sed -i '/kata-runtime"/a runtime_root = "/run/vc"' "$crio_config_file"
 		sudo sed -i '/\/run\/vc/a runtime_type = "oci"' "$crio_config_file"
-		sudo sed -i '/crio-runc/a runtime_type = "oci"' "$crio_config_file"
-		sudo sed -i '/crio-runc/a runtime_root = "/run/runc"' "$crio_config_file"
 	fi
 else
 	echo "Configure runtimes for trusted/untrusted annotations"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -24,6 +24,16 @@ go build
 go install
 popd
 
+echo "Install conmon"
+conmon_url=$(get_version "externals.conmon.url")
+conmon_version=$(get_version "externals.conmon.version")
+conmon_repo=${conmon_url/https:\/\/}
+go get -d "${conmon_repo}" || true
+pushd "$GOPATH/src/${conmon_repo}"
+make
+sudo -E make install
+popd
+
 echo "Get CRI-O sources"
 kubernetes_sigs_org="github.com/kubernetes-sigs"
 ghprbGhRepository="${ghprbGhRepository:-}"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -40,7 +40,8 @@ if [ "$ID" == "fedora" ]; then
 fi
 
 crio_version=$(get_version "externals.crio.version")
-crictl_version=$(get_test_version "externals.critools.version")
+crictl_repo=$(get_version "externals.critools.url")
+crictl_version=$(get_version "externals.critools.version")
 crictl_tag_prefix="v"
 
 if [ "$ghprbGhRepository" != "${crio_repo/github.com\/}" ]
@@ -62,7 +63,7 @@ then
 fi
 
 echo "Installing CRI Tools"
-crictl_url=https://github.com/kubernetes-sigs/cri-tools/releases/download/v$crictl_version/crictl-$crictl_tag_prefix$crictl_version-linux-"$(${cidir}/kata-arch.sh -g)".tar.gz
+crictl_url="${crictl_repo}/releases/download/v${crictl_version}/crictl-${crictl_tag_prefix}${crictl_version}-linux-$(${cidir}/kata-arch.sh -g).tar.gz"
 curl -Ls "$crictl_url" | sudo tar xfz - -C /usr/local/bin
 
 go get -d "$crio_repo" || true

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -14,6 +14,7 @@ source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
 export JOBS="${JOBS:-$(nproc)}"
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.
@@ -127,6 +128,7 @@ if systemctl is-active --quiet docker; then
 	sudo systemctl stop docker
 fi
 
+echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
 ./test_runner.sh ctr.bats
 
 popd

--- a/versions.yaml
+++ b/versions.yaml
@@ -63,9 +63,6 @@ externals:
     url: "https://ftp.gnu.org/gnu/parallel"
     version: "20190222"
 
-  critools:
-    version: 1.14.0
-
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"


### PR DESCRIPTION
cri-o config file changed a little bit in v1.16.0, so we need
to adjust our configuration script to work with this new version.

Fixes: #2056.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>