### PR TITLE
integration/cri-o: run cri-o tests in firecracker CI

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -57,6 +57,7 @@ fi
 if [ "$KATA_HYPERVISOR" = "firecracker" ]; then
 	echo "Enable firecracker configuration.toml"
 	sudo mv "${PKGDEFAULTSDIR}/configuration-fc.toml" "${PKGDEFAULTSDIR}/configuration.toml"
+	sudo sed -i '/jailer_path/d' "${PKGDEFAULTSDIR}/configuration.toml"
 fi
 
 if [ "$KATA_HYPERVISOR" = "nemu" ]; then

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -40,6 +40,10 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" bash -c "make oci"
 		echo "INFO: Running networking tests"
 		sudo -E PATH="$PATH" bash -c "make network"
+		if [ "${CI_JOB}" == "FIRECRACKER" ]; then
+			echo "INFO: Running crio tests"
+			sudo -E PATH="$PATH" bash -c "make crio"
+		fi
 		;;
 	*)
 		echo "INFO: Running checks"

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -14,3 +14,12 @@ declare -a skipCRIOTests=(
 'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
 'test "additional devices permissions"'
 );
+
+if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then
+	# This is a limitation in firecracker, the maximum number
+	# of block devices supported is 8, but this test tries to attach
+	# more than 10
+	skipCRIOTests+=(
+		'test "privileged ctr device add"'
+	)
+fi


### PR DESCRIPTION
kata + crio + firecracker are more stable. Run cri-o tests in firecracker CI

fixes #2060

Signed-off-by: Julio Montes <julio.montes@intel.com>