### PR TITLE
ci: Do not install CNI binaries a second time in the CI.

### DIFF
--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -11,7 +11,16 @@ source /etc/os-release || source /usr/lib/os-release
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 ${SCRIPT_PATH}/../../../.ci/install_cri_containerd.sh
-${SCRIPT_PATH}/../../../.ci/install_cni_plugins.sh
+
+cni_bin_path="/opt/cni"
+
+# Check if cni plugin binary is already installed, if so skip installation and 
+# simply configure cni.
+if [ -f "${cni_bin_path}/bridge" ]; then
+	${SCRIPT_PATH}/../../../.ci/configure_cni.sh
+else
+	${SCRIPT_PATH}/../../../.ci/install_cni_plugins.sh
+fi
 
 export SHIMV2_TEST=true
 


### PR DESCRIPTION
CNI binaries should have already been installed by the setup.sh script.
So just check here if the "bridge" cni plugin that we use in the CI
already exists. If so just configure cni. Only install if this binary
does not exist.

Fixes #2067

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>