### PR TITLE
ci: Add qemu-virtiofs to common

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -144,6 +144,8 @@ extract_kata_env(){
 	PROXY_VERSION="0.0.0"
 	if [ "$KATA_HYPERVISOR" == firecracker ]; then
 		HYPERVISOR_PATH="/usr/bin/firecracker"
+	elif [ "$experimental_qemu" == "true" ]; then
+		HYPERVISOR_PATH="/usr/bin/qemu-virtiofs-system-$(uname -m)"
 	else
 		# We would use $(${cidir}/kata-arch.sh -d) here but we don't know
 		# that the callee has set up ${cidir} for us.


### PR DESCRIPTION
This adds qemu-virtiofs-system to common so we can extract the
path.

Fixes #2066

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>