### PR TITLE
k8s: kata-webhook: use apps/v1 API for Deployment

### DIFF
--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pod-annotate-webhook
   labels:
     app: pod-annotate-webhook
 spec:
+  selector:
+    matchLabels:
+      app: pod-annotate-webhook
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
`extensions/v1beta1` is deprecated on k8s 1.16. The recommendation
is to migrate to use the `apps/v1` API.

See:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Fixes: #2073.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>