### PR TITLE
ci: Fix cache experimental qemu jenkins job

### DIFF
--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -39,6 +39,8 @@ install_cached_qemu_experimental() {
 	uncompress_experimental_qemu "${QEMU_TAR}"
 	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
 	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
+	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
+	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }
 
 build_and_install_static_experimental_qemu() {


### PR DESCRIPTION
This will avoid that the cache experimental qemu jenkins job failed because
the kata-qemu-static.tar.gz is not being found.

Fixes #2075

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>