### PR TITLE
test: Add k8s test to check number of cpus

### DIFF
--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/runtime/issues/2186"
+
+setup() {
+	skip "test not working see: ${issue}"
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="cpu-test"
+	container_name="c1"
+	get_pod_config_dir
+}
+
+@test "Check number of cpus" {
+	skip "test not working see: ${issue}"
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	retries="10"
+	max_number_cpus="3"
+
+	for _ in $(seq 1 "$retries"); do
+		# Get number of cpus
+		number_cpus=$(kubectl exec -ti pod/"$pod_name" -c "$container_name" nproc | sed 's/[[:space:]]//g')
+		# Verify number of cpus
+		[ "$number_cpus" -le "$max_number_cpus" ]
+		sleep 1
+	done
+}
+
+teardown() {
+	skip "test not working see: ${issue}"
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -60,6 +60,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-security-context.bats" \
 	"k8s-shared-volume.bats" \
 	"k8s-sysctls.bats" \
+	"k8s-number-cpus.bats" \
 	"k8s-uts+ipc-ns.bats" \
 	"k8s-volume.bats" \
 	"nginx.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cpu-test
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: c1
+    image: busybox
+    command: ["tail", "-f", "/dev/null"]
+    resources:
+      limits:
+        cpu: "1"
+  - name: c2
+    image: busybox
+    command:
+      - sleep
+      - "1"
+    resources:
+      limits:
+        cpu: "1"


### PR DESCRIPTION
This will check the number of cpus, this is related to issue
https://github.com/kata-containers/runtime/issues/2186. This
verifies that we have the correct number of cpus after ending a
container.

Fixes #2080

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>