### PR TITLE
ci: skip Firecracker install when testing changes on fc repo

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -12,10 +12,7 @@ cidir=$(dirname "$0")
 arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
 KATA_DEV_MODE="${KATA_DEV_MODE:-false}"
-
-if [ "$arch" != "x86_64" ]; then
-	die "Static binaries for Firecracker only available with x86_64."
-fi
+ghprbGhRepository="${ghprbGhRepository:-}"
 
 if [ "$KATA_DEV_MODE" = true ]; then
 	die "KATA_DEV_MODE set so not running the test"
@@ -27,66 +24,83 @@ if [ "$docker_version" != "18.06" ]; then
 	die "Firecracker hypervisor only works with docker 18.06"
 fi
 
-# Get url for firecracker from runtime/versions.yaml
-firecracker_repo=$(get_version "assets.hypervisor.firecracker.url")
-[ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
-firecracker_repo=${firecracker_repo/https:\/\//}
 
-# Get version for firecracker from runtime/versions.yaml
-firecracker_version=$(get_version "assets.hypervisor.firecracker.version")
-[ -n "$firecracker_version" ] || die "failed to get firecracker version"
 
-# Get firecracker
-go get -d ${firecracker_repo} || true
-# Checkout to specific version
-pushd "${GOPATH}/src/${firecracker_repo}"
-git checkout tags/${firecracker_version}
-./tools/devtool --unattended build --release
-sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/x86_64-*-linux-musl/release/firecracker /usr/bin/
-sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/x86_64-*-linux-musl/release/jailer /usr/bin/
-popd
+install_fc() {
+	# Get url for firecracker from runtime/versions.yaml
+	firecracker_repo=$(get_version "assets.hypervisor.firecracker.url")
+	[ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
+	firecracker_repo=${firecracker_repo/https:\/\//}
 
-echo "Install and configure docker"
-docker_configuration_path="/etc/docker"
-# Check if directory exists
-[ -d "$docker_configuration_path" ] || sudo mkdir "$docker_configuration_path"
+	# Get version for firecracker from runtime/versions.yaml
+	firecracker_version=$(get_version "assets.hypervisor.firecracker.version")
+	[ -n "$firecracker_version" ] || die "failed to get firecracker version"
 
-# Check if daemon.json exists
-docker_configuration_file=$docker_configuration_path/daemon.json
+	# Get firecracker repo
+	go get -d "${firecracker_repo}" || true
+	# Checkout to specific version
+	pushd "${GOPATH}/src/${firecracker_repo}"
+	git checkout "tags/${firecracker_version}"
+	./tools/devtool --unattended build --release
+	sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/${arch}-*-linux-musl/release/firecracker /usr/bin/
+	sudo install ${GOPATH}/src/${firecracker_repo}/build/cargo_target/${arch}-*-linux-musl/release/jailer /usr/bin/
+	popd
+}
 
-# For Kata Containers and Firecracker
-# a block based driver like devicemapper
-# is required
-driver="devicemapper"
+configure_fc_for_kata_and_docker() {
+	echo "Configure docker"
+	docker_configuration_path="/etc/docker"
+	# Check if directory exists
+	[ -d "$docker_configuration_path" ] || sudo mkdir "$docker_configuration_path"
 
-path="/usr/local/bin/kata-runtime"
+	# Check if daemon.json exists
+	docker_configuration_file="${docker_configuration_path}/daemon.json"
 
-if [ -f $docker_configuration_file ]; then
-	# Check devicemapper flag
-	check_devicemapper=$(grep -w '"storage-driver": "'${driver}'"' $docker_configuration_file | wc -l)
-	[ $check_devicemapper -eq 0 ] && die "${driver} is not enabled at $docker_configuration_file"
-	# Check kata runtime flag
-	check_kata=$(grep -w '"path": "'${path}'"' $docker_configuration_file | wc -l)
-	[ $check_kata -eq 0 ] && die "Kata Runtime path not found at $docker_configuration_file"
-else
-	cat <<-EOF | sudo tee "$docker_configuration_file"
-	{
-	 "runtimes": {
-	  "kata-runtime": {
-	   "path": "${path}"
-	  }
-	 },
-	 "storage-driver": "${driver}"
-	}
-	EOF
-fi
+	# For Kata Containers and Firecracker a block based driver like devicemapper
+	# is required
+	driver="devicemapper"
 
-echo "Restart docker"
-sudo systemctl daemon-reload
-sudo systemctl restart docker
+	path="/usr/local/bin/kata-runtime"
 
-echo "Check vsock is supported"
-check_vsock=$(sudo modprobe vhost_vsock)
-if [ $? != 0 ]; then
-	die "vsock is not supported on your host system"
-fi
+	if [ -f $docker_configuration_file ]; then
+		# Check devicemapper flag
+		check_devicemapper=$(grep -cw '"storage-driver": "'${driver}'"' $docker_configuration_file)
+		[ "$check_devicemapper" -eq 0 ] && die "${driver} is not enabled at $docker_configuration_file"
+		# Check kata runtime flag
+		check_kata=$(grep -cw '"path": "'${path}'"' $docker_configuration_file)
+		[ "$check_kata" -eq 0 ] && die "Kata Runtime path not found at $docker_configuration_file"
+	else
+		cat <<-EOF | sudo tee "$docker_configuration_file"
+		{
+		 "runtimes": {
+		  "kata-runtime": {
+		   "path": "${path}"
+		  }
+		 },
+		 "storage-driver": "${driver}"
+		}
+		EOF
+	fi
+
+	echo "Restart docker"
+	sudo systemctl daemon-reload
+	sudo systemctl restart docker
+
+	echo "Check vsock is supported"
+	if ! sudo modprobe vhost_vsock; then
+		die "vsock is not supported on your host system"
+	fi
+
+}
+
+main() {
+	# Install FC only when testing changes on Kata repos.
+	# If testing changes on firecracker repo, skip installation as it is
+	# done in the CI jenkins job.
+	if [ "${ghprbGhRepository}" != "firecracker-microvm/firecracker" ]; then
+		install_fc
+	fi
+	configure_fc_for_kata_and_docker
+}
+
+main "$@"


### PR DESCRIPTION
when testing changes on firecracker repo, we don't want to
install the version of firecracker that we have in versions.yaml.
So skip the installation as it is already done in the Jenkins
job.

Fixes: #2082.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>