### PR TITLE
debug: Increase the number of attemps to get jaeger service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,7 @@ ifeq (${CI}, true)
 endif
 
 # union for 'make test'
-UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
-	docker-stability oci netmon kubernetes swarm vm-factory \
-	entropy ramdisk shimv2 tracing time-drift
+UNION := tracing
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -73,7 +73,7 @@ get_jaeger_status()
 	local attempt=0
 	local status=""
 
-	while [ $attempt -lt 10 ]
+	while [ $attempt -lt 20 ]
 	do
 		status=$(curl -s "http://${jaeger_server}:${jaeger_ui_port}/api/traces?service=${service}" 2>/dev/null)
 		local ret=$?
@@ -160,7 +160,7 @@ check_jaeger_status()
 	local errors=0
 
 	local attempt=0
-	local attempts=3
+	local attempts=10
 
 	local trace_logfile=$(printf "%s/%s-traces.json" "$TRACE_LOG_DIR" "$service")
 


### PR DESCRIPTION
There has been some issues in opensuse when trying to get the status the
jaeger service status, this will increase the number of attemps in order
to wait to the service to be ready.

Fixes #2069

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>