### PR TITLE
test: Check sudo before running kata-runtime list

### DIFF
--- a/integration/docker/run_test.go
+++ b/integration/docker/run_test.go
@@ -316,6 +316,11 @@ var _ = Describe("run and check kata-runtime list", func() {
 		stdout          string
 	)
 
+	if os.Getuid() != 0 {
+		GinkgoT().Skip("only root user can run kata-runtime list")
+		return
+	}
+
 	BeforeEach(func() {
 		id = randomDockerName()
 	})


### PR DESCRIPTION
kata-runtime list needs sudo to run correctly, this will fix the issue, this will ensure that only sudo can run kata-runtime list.

Fixes #2088

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>