### PR TITLE
tests: let iperf server check work by let counter go

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -167,7 +167,7 @@ function check_iperf3_server() {
 	while [ 1 ]; do
 		if ! bash -c "$test_cmd" > /dev/null 2>&1; then
 			echo "waiting for server..."
-			count=$((count++))
+			(( count++ ))
 			sleep $period
 		else
 			echo "iperf3 server is up!"


### PR DESCRIPTION
Currently, count value in network-metrics-iperf3.sh freezed as
count value is assigned its original value round after round.
remove the "count=" to let it go.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
Fixes: #2090

@jodh-intel @grahamwhaley 