### PR TITLE
tests: check iperf3 before do check iperf3 server.

### DIFF
--- a/metrics/network/network-metrics-iperf3.sh
+++ b/metrics/network/network-metrics-iperf3.sh
@@ -161,7 +161,7 @@ function check_iperf3_server() {
 	local test_cmd="iperf3 -c "$server_address" -t 1"
 
 	# check tools dependencies
-	local cmds=("netstat")
+	local cmds=("netstat" "iperf3")
 	check_cmds "${cmds[@]}"
 
 	while [ 1 ]; do


### PR DESCRIPTION
there must be sure about the existence of iperf3 command before
do the server check.
if iperf3 not present in host, test_cmd will fail without warning.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
Fixes: #2091

@amshinde  @jcvenegas 