### PR TITLE
k8s: use `-e` to check the existence of crio.sock

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -84,7 +84,7 @@ wait_time_cri_socket_check=5
 for i in $(seq ${max_cri_socket_check}); do
 	#when the test runs two times in the CI, the second time crio takes some time to be ready
 	sleep "${wait_time_cri_socket_check}"
-	if [ -f "${cri_runtime_socket}" ]; then
+	if [ -e "${cri_runtime_socket}" ]; then
 		break
 	fi
 


### PR DESCRIPTION
File crio.sock is not a regular file, we should use `-e` to check
its existence. not `-f`.

Fixes: #2094

Signed-off-by: Penny Zheng <penny.zheng@arm.com>