### PR TITLE
static-check: Fix bug in yamllint installation check

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -330,7 +330,9 @@ install_yamllint()
 
 	have_yamllint_cmd=$(command -v "$yamllint_cmd" || true)
 
-	[ -z "$have_yamllint_cmd" ] && info "Cannot install $package" && return
+	if [ -z "$have_yamllint_cmd" ]; then
+		info "Cannot install $package" && return
+	fi
 }
 
 # Check the "versions database".


### PR DESCRIPTION
The previous check was causing the function to return false
even though yamllint is installed successfully.

Fixes #2098

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>