### PR TITLE
pipe: pipeline failed when no line selected in `grep`

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -51,9 +51,14 @@ if [ -n "$runc_container_union" ]; then
 	done <<< "${runc_container_union}"
 fi
 
+# when pipeline consists of grep, it may fail unnecessarily
+# when no line selected.
+veth_interfaces_union=$(set +o pipefail; sudo ip link | grep "veth" | awk '{print $2}' | cut -d '@' -f1)
+
 # delete stale veth interfaces, which is named after vethXXX.
-veth_interfaces_union=$(sudo ip link | grep "veth" | awk '{print $2}' | cut -d '@' -f1)
-while read veth_interface; do
-	sudo ip link set dev $veth_interface down
-	sudo ip link del $veth_interface
-done <<< "$veth_interfaces_union"
+if [ -n "$veth_interfaces_union" ]; then
+	while read veth_interface; do
+		sudo ip link set dev $veth_interface down
+		sudo ip link del $veth_interface
+	done <<< "$veth_interfaces_union"
+fi


### PR DESCRIPTION
If we have enabled pipefail option, `set -o pipefail`, the pipeline will fail when any sub-command exits with a non-zero status. 
But when pipeline consist of `grep`, it may fail unnecessarily.
For `grep` command, the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred.
In most scenario, we allow no lines being selected. just like the one in `integration/kubernetes/cleanup_bare_metal_env.sh`
```
veth_interfaces_union=$(sudo ip link | grep "veth" | awk '{print $2}' | cut -d '@' -f1)
```