### PR TITLE
ci: fix install qemu-virtiofs

### DIFF
--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -19,7 +19,7 @@ KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
 PACKAGING_REPO="github.com/kata-containers/packaging"
-QEMU_TAR="kata-qemu-static.tar.gz"
+QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
 VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
@@ -28,7 +28,7 @@ qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
-	sudo tar -xf "${qemu_tar_location}" -C /
+	sudo tar -xvf "${qemu_tar_location}" -C /
 }
 
 install_cached_qemu_experimental() {


### PR DESCRIPTION
Now the tarball provides a different name
On untar be more verbose to see what got installed