### PR TITLE
tests: replace "/var/lib/vc" with "/run/vc"

### DIFF
--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -33,7 +33,7 @@ RUNTIME_PATH=$(command -v $RUNTIME)
 # The place where virtcontainers keeps its active pod info
 # This is ultimately what 'kata-runtime list' uses to get its info, but
 # we can also check it for sanity directly
-VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
+VC_POD_DIR="${VC_POD_DIR:-/run/vc/sbs}"
 
 # let's cap the test. If you want to run until you hit the memory limit
 # then just set this to a very large number

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -8,7 +8,7 @@
 # are being used by our metrics and integration tests
 
 # Place where virtcontainers keeps its active pod info
-VC_POD_DIR="${VC_POD_DIR:-/var/lib/vc/sbs}"
+VC_POD_DIR="${VC_POD_DIR:-/run/vc/sbs}"
 
 # Sandbox runtime directory
 RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"


### PR DESCRIPTION
Fixes #2112

Checking "/run/vc" can also get active pods so we don't have to use
"/var/lib/vc", also I'm working on removing "/var/lib/vc" dir from
persistent data, we should remove "/var/lib/vc" from tests repo first.

Signed-off-by: Wei Zhang <weizhang555.zw@gmail.com>