### PR TITLE
k8s: turn on k8s integration tests on aarch64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -9,6 +9,7 @@
 test:
   - functional
   - docker
+  - kubernetes
 
 # for now, not all test suites under docker integration are fully passed in aarch64.
 # some need to be tested, and some need to be refined.

--- a/.ci/aarch64/lib_setup_aarch64.sh
+++ b/.ci/aarch64/lib_setup_aarch64.sh
@@ -6,24 +6,25 @@
 
 set -e
 
-filter_test_script="${cidir}/${arch}/filter_test_aarch64.sh"
+filter_test_script="${cidir}/filter/filter_test_union.sh"
+config_file="${cidir}/aarch64/configuration_aarch64.yaml"
 
 check_test_union()
 {
-	local test_union=$(bash -f ${filter_test_script})
+	local test_union=$(${filter_test_script} ${config_file})
 	flag="$1"
 	# regex match
-	[[ ${test_union} =~ ${flag} ]] && echo "true"
+	[[ ${test_union} =~ ${flag} ]] && echo "yes" && exit 0
 
-	echo "false"
+	echo "no"
 }
 
 KUBERNETES=$(check_test_union kubernetes)
 # if we do k8s integration test, CRI-O is the default CRI runtime
 # we have specific env `CRI_CONTAINERD_K8S` for k8s running with containerd-cri.
-if [ "$KUBERNETES" == "true" ]; then
-	CRIO="true"
+if [ "$KUBERNETES" == "yes" ]; then
+	CRIO="yes"
 else
-	CRIO="false"
+	CRIO="no"
 fi
 OPENSHIFT=$(check_test_union openshift)

--- a/.ci/aarch64/lib_setup_aarch64.sh
+++ b/.ci/aarch64/lib_setup_aarch64.sh
@@ -18,6 +18,12 @@ check_test_union()
 	echo "false"
 }
 
-CRIO=$(check_test_union crio)
 KUBERNETES=$(check_test_union kubernetes)
+# if we do k8s integration test, CRI-O is the default CRI runtime
+# we have specific env `CRI_CONTAINERD_K8S` for k8s running with containerd-cri.
+if [ "$KUBERNETES" == "true" ]; then
+	CRIO="true"
+else
+	CRIO="false"
+fi
 OPENSHIFT=$(check_test_union openshift)


### PR DESCRIPTION
Let's turn on k8s integration tests on aarch64.
For now, we only support k8s running with CRI-O.

Fixes: #2114

Signed-off-by: Penny Zheng <penny.zheng@arm.com>