### PR TITLE
integration/kubernetes: unskip k8s-number-cpus test

### DIFF
--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -7,10 +7,8 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/runtime/issues/2186"
 
 setup() {
-	skip "test not working see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="cpu-test"
 	container_name="c1"
@@ -18,7 +16,6 @@ setup() {
 }
 
 @test "Check number of cpus" {
-	skip "test not working see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
 
@@ -38,6 +35,5 @@ setup() {
 }
 
 teardown() {
-	skip "test not working see: ${issue}"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
Run the test that checks the number of cpus after killing a
container

Depends-on: github.com/kata-containers/runtime#2251

fixes #2116

Signed-off-by: Julio Montes <julio.montes@intel.com>