### PR TITLE
ci: Fix qemu virtiofs cache components script

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -38,7 +38,7 @@ cache_qemu_experimental_artifacts() {
 	pushd "${tests_repo_dir}"
 	local current_qemu_experimental_tag=$(get_version "assets.hypervisor.qemu-experimental.tag")
 	popd
-	local qemu_experimental_tar="kata-qemu-static.tar.gz"
+	local qemu_experimental_tar="kata-static-qemu-virtiofsd.tar.gz"
 	create_cache_asset "$qemu_experimental_tar" "${current_qemu_experimental_tag}"
 }
 


### PR DESCRIPTION
The tarball name for qemu experimental has been changed, this PR updates the
tarball name to kata-static-qemu-virtiofsd.tar.gz.

Fixes #2121

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>