### PR TITLE
ci: Fix qemu tarball name

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -29,7 +29,7 @@ cache_qemu_artifacts() {
 	pushd "${tests_repo_dir}"
 	local current_qemu_version=$(get_version "assets.hypervisor.qemu.version")
 	popd
-	local qemu_tar="kata-qemu-static.tar.gz"
+	local qemu_tar="kata-static-qemu.tar.gz"
 	create_cache_asset "$qemu_tar" "${current_qemu_version}"
 }
 

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -25,7 +25,7 @@ QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
 PACKAGING_REPO="github.com/kata-containers/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
-QEMU_TAR="kata-qemu-static.tar.gz"
+QEMU_TAR="kata-static-qemu.tar.gz"
 qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
 
 # option "--shallow-submodules" was introduced in git v2.9.0


### PR DESCRIPTION
The qemu tarball has been renamed to kata-static-qemu.tar.gz, this PR
fixes the cache and static installation script for qemu.

Fixes #2123

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>