### PR TITLE
tests: Backport qemu fixes for 1.9

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -29,7 +29,7 @@ cache_qemu_artifacts() {
 	pushd "${tests_repo_dir}"
 	local current_qemu_version=$(get_version "assets.hypervisor.qemu.version")
 	popd
-	local qemu_tar="kata-qemu-static.tar.gz"
+	local qemu_tar="kata-static-qemu.tar.gz"
 	create_cache_asset "$qemu_tar" "${current_qemu_version}"
 }
 

--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -38,7 +38,7 @@ cache_qemu_experimental_artifacts() {
 	pushd "${tests_repo_dir}"
 	local current_qemu_experimental_tag=$(get_version "assets.hypervisor.qemu-experimental.tag")
 	popd
-	local qemu_experimental_tar="kata-qemu-static.tar.gz"
+	local qemu_experimental_tar="kata-static-qemu-virtiofsd.tar.gz"
 	create_cache_asset "$qemu_experimental_tar" "${current_qemu_experimental_tag}"
 }
 

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -49,7 +49,7 @@ IMAGE_OS_VERSION_KEY="assets.${IMG_TYPE}.architecture.$(uname -m).version"
 agent_path="${GOPATH}/src/github.com/kata-containers/agent"
 osbuilder_repo="github.com/kata-containers/osbuilder"
 osbuilder_path="${GOPATH}/src/${osbuilder_repo}"
-latest_build_url="http://jenkins.katacontainers.io/job/image-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/image-nightly-$(uname -m)/${cached_artifacts_path}"
 
 install_ci_cache_image() {
 	type=${1}

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -19,8 +19,8 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-latest_build_url="http://jenkins.katacontainers.io/job/kernel-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
-experimental_latest_build_url="http://jenkins.katacontainers.io/job/kernel-experimental-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
+experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 kernel_dir="/usr/share/kata-containers"
 
 kernel_repo_name="packaging"

--- a/.ci/install_nemu.sh
+++ b/.ci/install_nemu.sh
@@ -17,7 +17,7 @@ source /etc/os-release || source /usr/lib/os-release
 
 versions_file="${cidir}/../versions.yaml"
 arch=$("${cidir}"/kata-arch.sh -d)
-latest_build_url="http://jenkins.katacontainers.io/job/nemu-nightly-${arch}/lastSuccessfulBuild/artifact/artifacts"
+latest_build_url="${jenkins_url}/job/nemu-nightly-${arch}/${cached_artifacts_path}"
 nemu_repo=$(get_version "assets.hypervisor.nemu.url")
 nemu_version=$(get_version "assets.hypervisor.nemu.version")
 NEMU_TAR="kata-nemu-static.tar.gz"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -26,7 +26,7 @@ QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
 PACKAGING_REPO="github.com/kata-containers/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
 QEMU_TAR="kata-qemu-static.tar.gz"
-qemu_latest_build_url="http://jenkins.katacontainers.io/job/qemu-nightly-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
 
 # option "--shallow-submodules" was introduced in git v2.9.0
 GIT_SHADOW_VERSION="2.9.0"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -25,7 +25,7 @@ QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
 PACKAGING_REPO="github.com/kata-containers/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
-QEMU_TAR="kata-qemu-static.tar.gz"
+QEMU_TAR="kata-static-qemu.tar.gz"
 qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
 
 # option "--shallow-submodules" was introduced in git v2.9.0

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -25,7 +25,7 @@ arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_LOCATION="/tmp/qemu-virtiofs-static/opt/kata/bin/"
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
 VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
-qemu_experimental_latest_build_url="http://jenkins.katacontainers.io/job/qemu-experimental-$(uname -m)/lastSuccessfulBuild/artifact/artifacts"
+qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-$(uname -m)/${cached_artifacts_path}"
 
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -20,7 +20,7 @@ KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
 QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu-experimental.url")
 PACKAGING_REPO="github.com/kata-containers/packaging"
-QEMU_TAR="kata-qemu-static.tar.gz"
+QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 INSTALL_LOCATION="/tmp/qemu-virtiofs-static/opt/kata/bin/"
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
@@ -30,7 +30,7 @@ qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-$(uname
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
-	sudo tar -xf "${qemu_tar_location}" -C /
+	sudo tar -xvf "${qemu_tar_location}" -C /
 }
 
 install_cached_qemu_experimental() {

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -39,6 +39,11 @@ source "${lib_script}"
 
 export KATA_OBS_REPO_BASE="http://download.opensuse.org/repositories/home:/katacontainers:/releases:/$(arch):/master"
 
+# Jenkins master URL
+jenkins_url="http://jenkins.katacontainers.io"
+# Path where cached artifacts are found.
+cached_artifacts_path="lastSuccessfulBuild/artifact/artifacts"
+
 # If we fail for any reason a message will be displayed
 die() {
 	msg="$*"


### PR DESCRIPTION
9e739cf  ci: Fix qemu tarball name
3134b33 ci: use variables for jenkins url and artifacts paths
af3e5a5  ci: fix install qemu-virtiofs
b24eb57 ci: Fix qemu virtiofs cache components script
