### PR TITLE
k8s: skip cpu hotplug related test

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -33,3 +33,4 @@ docker:
 kubernetes:
   - k8s-cpu-ns
   - k8s-limit-range
+  - k8s-number-cpus

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -17,6 +17,7 @@ setup() {
 	get_pod_config_dir
 }
 
+# Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
 	skip "test not working see: ${issue}"
 	# Create pod


### PR DESCRIPTION
Since AArch64 doesn't support cpu hotplug on kata containers, we need to skip related k8s tests for now.

Fixes: #2126
Depends-on: github.com/kata-containers/tests/#2117

Signed-off-by: Penny Zheng <penny.zheng@arm.com>