### PR TITLE
ci: add support for installing specific version of kata

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -17,10 +17,10 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 experimental_qemu="${experimental_qemu:-false}"
 
 echo "Install kata-containers image"
-"${cidir}/install_kata_image.sh"
+"${cidir}/install_kata_image.sh" "${tag}"
 
 echo "Install Kata Containers Kernel"
-"${cidir}/install_kata_kernel.sh"
+"${cidir}/install_kata_kernel.sh" "${tag}"
 
 if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	echo "Install Firecracker"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -50,6 +50,7 @@ agent_path="${GOPATH}/src/github.com/kata-containers/agent"
 osbuilder_repo="github.com/kata-containers/osbuilder"
 osbuilder_path="${GOPATH}/src/${osbuilder_repo}"
 latest_build_url="${jenkins_url}/job/image-nightly-$(uname -m)/${cached_artifacts_path}"
+tag="${1:-""}"
 
 install_ci_cache_image() {
 	type=${1}
@@ -142,6 +143,7 @@ get_dependencies() {
 	info "Pull and install agent on host"
 	bash -f "${cidir}/install_agent.sh"
 	go get -d "${osbuilder_repo}" || true
+	[ -z "${tag}" ] || git -C "${osbuilder_path}" checkout -b "${tag}" "${tag}"
 }
 
 main() {

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -33,6 +33,7 @@ readonly tmp_dir="$(mktemp -d -t install-kata-XXXXXXXXXXX)"
 packaged_kernel="kata-linux-container"
 #Experimental kernel support. Pull from virtio-fs GitLab instead of kernel.org
 experimental_kernel="${experimental_kernel:-false}"
+tag="${1:-""}"
 
 exit_handler() {
 	rm -rf "${tmp_dir}"
@@ -44,6 +45,7 @@ download_repo() {
 	echo "Download and update ${kernel_repo}"
 	pushd ${tmp_dir}
 	go get -d -u "${kernel_repo}" || true
+	[ -z "${tag}" ] || git -C "${kernel_repo_dir}" checkout -b "${tag}" "${tag}"
 	popd
 }
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -103,8 +103,9 @@ function build_and_install() {
 	github_project="$1"
 	make_target="$2"
 	test_not_gopath_set="$3"
+	tag="$4"
 
-	build "${github_project}" "${make_target}"
+	build "${github_project}" "${make_target}" "${tag}"
 	pushd "${GOPATH}/src/${github_project}"
 	if [ "$test_not_gopath_set" = "true" ]; then
 		info "Installing ${github_project} in No GO command or GOPATH not set mode"


### PR DESCRIPTION
allow users and CI scripts install a specific version of kata using
`.ci/install_kata.sh` script, for example to build and install the versions
1.9.1, just run the following command:

`.ci/install_kata.sh 1.9.1`

fixes #2132

Signed-off-by: Julio Montes <julio.montes@intel.com>