### PR TITLE
ci: add backward and forward compatibility tests

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -29,7 +29,8 @@ ARCH="$(${cidir}/kata-arch.sh -d)"
 AGENT_INIT=${AGENT_INIT:-no}
 TEST_INITRD=${TEST_INITRD:-no}
 
-IMAGE_DIR="/usr/share/kata-containers"
+PREFIX=${PREFIX:-/usr}
+IMAGE_DIR=${PREFIX}/share/kata-containers
 IMG_LINK_NAME="kata-containers.img"
 INITRD_LINK_NAME="kata-containers-initrd.img"
 

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -21,7 +21,8 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 
 latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
 experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
-kernel_dir="/usr/share/kata-containers"
+PREFIX=${PREFIX:-/usr}
+kernel_dir=${PREFIX}/share/kata-containers
 
 kernel_repo_name="packaging"
 kernel_repo_owner="kata-containers"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -126,7 +126,7 @@ main() {
 			# When testing initrd, build qemu instead of using the cached qemu
 			# as there seems to be an issue with the statically built qemu when
 			# running the factory-vm tests.
-			if [ "${AGENT_INIT:-}" == "yes" ]; then
+			if [ "${AGENT_INIT:-}" == "yes" ] || [ -n "${FORCE_BUILD_QEMU:-}" ]; then
 				build_and_install_qemu
 			elif [ "$cached_qemu_version" == "$CURRENT_QEMU_VERSION" ]; then
 				# If installing cached QEMU fails,

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -15,6 +15,7 @@ source "${cidir}/lib.sh"
 source "${cidir}/../lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
+PREFIX=${PREFIX:-/usr}
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.version")
@@ -103,7 +104,7 @@ build_and_install_qemu() {
 	done
 
 	echo "Build QEMU"
-	"${QEMU_CONFIG_SCRIPT}" "qemu" | xargs ./configure
+	"${QEMU_CONFIG_SCRIPT}" "qemu" | xargs ./configure --prefix=${PREFIX}
 	make -j $(nproc)
 
 	echo "Install QEMU"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -28,8 +28,10 @@ export SYSTEM_BUILD_TYPE=kata
 # The runtimes config file should live here
 export SYSCONFDIR=/etc
 
+PREFIX=${PREFIX:-/usr}
+
 # Artifacts (kernel + image) live below here
-export SHAREDIR=/usr/share
+export SHAREDIR=${PREFIX}/share
 
 USE_VSOCK="${USE_VSOCK:-no}"
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # union for 'make test'
 UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
 	docker-stability oci netmon kubernetes swarm vm-factory \
-	entropy ramdisk shimv2 tracing time-drift
+	entropy ramdisk shimv2 tracing time-drift compatibility
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh
@@ -185,6 +185,9 @@ tracing:
 time-drift:
 	bats integration/time_drift/time_drift.bats
 
+compatibility:
+	bash -f integration/compatibility/run.sh
+
 test: ${UNION}
 
 check: checkcommits log-parser
@@ -201,6 +204,7 @@ help:
 
 # PHONY in alphabetical order
 .PHONY: \
+	compatibility \
 	check \
 	checkcommits \
 	crio \

--- a/integration/compatibility/run.sh
+++ b/integration/compatibility/run.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -x
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+
+source "${cidir}/../../lib/common.bash"
+
+TEST_COMPATIBILITY=${TEST_COMPATIBILITY:-}
+
+RUNTIME=${RUNTIME:-kata-runtime}
+
+runtime_url=https://github.com/kata-containers/runtime
+
+# directory where different versions of kata are installed
+kata_versions_dir="/tmp/kata"
+
+runtime_path=""
+runtime_backup_path=""
+
+cleanup() {
+	sudo rm -rf "${kata_versions_dir}"
+
+	if [ -n "${runtime_backup_path}" ] && [ -n "${runtime_path}" ]; then
+		sudo mv "${runtime_backup_path}" "${runtime_path}"
+	fi
+}
+
+trap cleanup EXIT QUIT KILL
+
+install_kata() {
+	kata_dir="$1"
+
+	# create a new and temporal GOPATH to build kata
+	tmp_gopath="$(mktemp -d)"
+	kata_gopath="src/github.com/kata-containers"
+	mkdir -p "${tmp_gopath}/${kata_gopath}"
+	cp -a "${GOPATH}/${kata_gopath}/tests" "${tmp_gopath}/${kata_gopath}"
+
+	# build and install kata from the new and temporal GOPATH
+	pushd  "${tmp_gopath}/${kata_gopath}/tests"
+	GOPATH="${tmp_gopath}" PREFIX="${kata_dir}" FORCE_BUILD_QEMU=1 ".ci/install_kata.sh"
+	popd
+	sudo rm -rf "${tmp_gopath}"
+}
+
+test_backward_compatibility() {
+	info "Running backward compatibility test"
+
+	runtime_path="$1"
+	master_runtime_path="$2"
+
+	# create a backup for the current runtime
+	runtime_backup_path="${runtime_path}.backup"
+	sudo cp "${runtime_path}" "${runtime_backup_path}"
+
+	# run a container with the current runtime
+	cont_name="backward_test"
+	docker run -d --name "${cont_name}" --runtime="${RUNTIME}" busybox tail -f /dev/null
+
+	# switch to master runtime
+	sudo cp -a "${master_runtime_path}" "${runtime_path}" && sync
+
+	# exec
+	docker exec "${cont_name}" true
+
+	# stop and remove container
+	docker rm -f "${cont_name}"
+
+	# restore runtime
+	sudo cp "${runtime_backup_path}" "${runtime_path}"
+}
+
+test_forward_compatibility() {
+	info "Running forward compatibility test"
+
+	runtime_path="$1"
+	master_runtime_path="$2"
+
+	# create a backup for the current runtime
+	runtime_backup_path="${runtime_path}.backup"
+	sudo cp "${runtime_path}" "${runtime_backup_path}"
+
+	# switch to master runtime
+	sudo cp -a "${master_runtime_path}" "${runtime_path}" && sync
+
+	# Now, let's run a container with master
+	cont_name="forward_test"
+	docker run -d --name "${cont_name}" --runtime="${RUNTIME}" busybox tail -f /dev/null
+
+	# switch to original runtime
+	sudo cp "${runtime_backup_path}" "${runtime_path}"
+
+	# exec
+	docker exec "${cont_name}" true
+
+	# stop and remove container
+	docker rm -f "${cont_name}"
+}
+
+main() {
+	if [ -z "${TEST_COMPATIBILITY}" ]; then
+		info "SKIP: TEST_COMPATIBILITY variable is not set"
+		return 0
+	fi
+
+	runtime_path=$(get_docker_kata_path ${RUNTIME})
+	if [ -z "${runtime_path}" ] || [ "${runtime_path}" = "null" ]; then
+		die "${RUNTIME} has not been configured as a runtime in docker"
+	fi
+
+	# Install master version of kata.
+	# current code that is being tested must be
+	# compatible at least with code in master
+	kata_dir="${kata_versions_dir}/master" && sudo rm -rf "${kata_dir}"
+	install_kata "${kata_dir}"
+
+	test_backward_compatibility "${runtime_path}" "${kata_dir}/bin/kata-runtime"
+
+	test_forward_compatibility "${runtime_path}" "${kata_dir}/bin/kata-runtime"
+}
+
+main


### PR DESCRIPTION
Backward compatibility test checks if docker exec (create and start) and
rm (stop and delete) work in a kata container started with the current
installed version (PR) and modified with the master version of kata.
Forward compatibility test does the same but starting a container with the
master version of kata and modifying it with the current installed version (PR)

fixes #2134

Signed-off-by: Julio Montes <julio.montes@intel.com>