### PR TITLE
Add container restart case

### DIFF
--- a/integration/containerd/cri/container_restart_test.go.patch
+++ b/integration/containerd/cri/container_restart_test.go.patch
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 The containerd Authors.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test to verify container can be restarted
+func TestContainerRestart(t *testing.T) {
+	t.Logf("Create a pod config and run sandbox container")
+	sbConfig := PodSandboxConfig("sandbox1", "restart")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+	t.Logf("Create a container config and run container in a pod")
+	containerConfig := ContainerConfig(
+		"container1",
+		pauseImage,
+		WithTestLabels(),
+		WithTestAnnotations(),
+	)
+	cn, err := runtimeService.CreateContainer(sb, containerConfig, sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.RemoveContainer(cn))
+	}()
+	require.NoError(t, runtimeService.StartContainer(cn))
+	defer func() {
+		assert.NoError(t, runtimeService.StopContainer(cn, 10))
+	}()
+
+	t.Logf("Restart the container with same config")
+	require.NoError(t, runtimeService.StopContainer(cn, 10))
+	require.NoError(t, runtimeService.RemoveContainer(cn))
+
+	cn, err = runtimeService.CreateContainer(sb, containerConfig, sbConfig)
+	require.NoError(t, err)
+	require.NoError(t, runtimeService.StartContainer(cn))
+}

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -69,10 +69,10 @@ ci_config() {
 		fi
 	fi
 
+	SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 	if [ -n "${CI}" ]; then
 		(
 		echo "Install cni config"
-		SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 		${SCRIPT_PATH}/../../../.ci/configure_cni.sh
 		)
 	fi
@@ -169,6 +169,7 @@ main() {
 	rm -f "${CRITEST}"
 
 	pushd "${GOPATH}/src/${cri_containerd_repo}"
+	cp "${SCRIPT_PATH}/container_restart_test.go.patch" ./integration/container_restart_test.go
 
 	# Make sure the right artifacts are going to be built
 	make clean
@@ -192,6 +193,7 @@ main() {
 
 	passing_test=(
 	TestContainerStats
+	TestContainerRestart
 	TestContainerListStatsWithIdFilter
 	TestContainerListStatsWithSandboxIdFilter
 	TestContainerListStatsWithIdSandboxIdFilter

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -191,10 +191,9 @@ main() {
 	info "containerd(cri): Running test-integration"
 
 	passing_test=(
-	TestClearContainersCreate
 	TestContainerStats
 	TestContainerListStatsWithIdFilter
-	TestContainerListStatsWithSandboxIdFilterd
+	TestContainerListStatsWithSandboxIdFilter
 	TestContainerListStatsWithIdSandboxIdFilter
 	TestDuplicateName
 	TestImageLoad


### PR DESCRIPTION
This PR mainly adds a ~~crictl~~ cri integration test patch based container restart case as well as fix two cases that doesn't exist in the cri integration test.
I think it's better to add such case to https://github.com/containerd/cri/tree/master/integration and I'll try to raise a PR there about this later. If that case is merged then we can use it in future after vendor update :)

Fixes: #2138, #2139
Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>