### PR TITLE
metrics: launch_times: Set capabilities for dmesg

### DIFF
--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -77,7 +77,7 @@ run_workload() {
 
 	# Run the image and command and capture the results into an array...
 	declare workload_result
-	readarray -n 0 workload_result < <(docker run --rm --runtime=${RUNTIME} ${NETWORK_OPTION} ${IMAGE} sh -c "$DATECMD $DMESGCMD")
+	readarray -n 0 workload_result < <(docker run --cap-add SYSLOG --rm --runtime=${RUNTIME} ${NETWORK_OPTION} ${IMAGE} sh -c "$DATECMD $DMESGCMD")
 
 	end_time=$($DATECMD)
 


### PR DESCRIPTION
In case the guest kernel is compiled with SECURITY_DMESG_RESTRICT=y
the test container needs to have the CAP_SYSLOG capability in order
to run dmesg.

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>