### PR TITLE
WIP: Fix qemu and qemu experimental jenkins jobs

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -54,7 +54,7 @@ uncompress_static_qemu() {
 
 build_and_install_static_qemu() {
 	build_static_qemu
-	uncompress_static_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
+	uncompress_static_qemu "${QEMU_TAR}"
 }
 
 install_cached_qemu() {

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -45,7 +45,7 @@ install_cached_qemu_experimental() {
 
 build_and_install_static_experimental_qemu() {
 	build_experimental_qemu
-	uncompress_experimental_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
+	uncompress_experimental_qemu "${QEMU_TAR}"
 	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
 	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
 }


### PR DESCRIPTION
While trying to uncompress cached qemu and qemu experimental, we are getting
failures as we are not passing as an argument the tar location. This PR will
fix that.

Fixes #2152

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>