### PR TITLE
k8s: failure on k8s "expose IP address" test on ARM CI

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -34,3 +34,4 @@ kubernetes:
   - k8s-cpu-ns
   - k8s-limit-range
   - k8s-number-cpus
+  - k8s-expose-ip

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -7,6 +7,9 @@
 #
 # Test that IP addresses/connections of PODS are routed/exposed correctly 
 # via a loadbalancer service.
+#
+# This test is temporarily turned off on ARM CI.
+# See detailed info in PR#2157(https://github.com/kata-containers/tests/pull/2157)
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"


### PR DESCRIPTION
The failure on k8s `expose IP address` test on ARM CI is quite strange and confused.
```
10:49:45 not ok 1 Expose IP Address
10:49:45 # (in test file k8s-expose-ip.bats, line 48)
10:49:45 #   `curl http://$svcip:$svcport/echo?msg=${echo_msg} | grep "$echo_msg"' failed
curl: (7) Failed to connect to 10.111.96.90 port 8080: Connection refused
```
I couldn't reproduce the error on local machine, or even offline ARM CI machine, no matter how many times I tried.
I'm wondering if it's that when we used jenkins to trigger test job, some sub-process occupied the service `8080` port, which leads to the error: `connection refused`.
And that's Maybe why we only got this error on ARM CI job??????😥
This commit now is only to verify my guess. If it still fails, I may should skip this test...

**Updates:**
I've tried following changes to see if it's due to occupied `8080` port.
```
      containers:
      - name: hello-world
        image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
        args: ["netexec", "--http-port", "8079"]
        ports:
        - containerPort: 8079
```
But the error is still here.
So in order to make ARM CI green again, I'll temporarily turn off this test on ARM CI.