### PR TITLE
ci: Fix ci_cache_components.sh script to locate qemu

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -121,6 +121,10 @@ create_cache_asset() {
 		echo "${component_version}" >  "latest"
 	fi
 
+	# In the case of qemu we have the tar at a specific location
+	if [ ! -z "${check_qemu}" ]; then
+		cp -a "${KATA_TESTS_CACHEDIR}/${component_name}" .
+	fi
 
 	# In the case of the kernel we have it in the kata dir
 	if [ ! -z "${check_kernel}" ]; then


### PR DESCRIPTION
In the case of qemu and qemu experimental we have the tar file in a
specific location and we need to check it. This PR fixes the regression
that was introduced by the commit 06da90d9a26a366d75b0dc56565a3d8ed2098752.

Fixes #2152

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>