### PR TITLE
cri-o: Skip cri-o "ctr execsync" test.

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -13,6 +13,7 @@ declare -a skipCRIOTests=(
 'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
 'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
 'test "additional devices permissions"'
+'test "ctr execsync"'
 );
 
 if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then


### PR DESCRIPTION
While we are investigating the reason for this failure, skip this
test. None of the recent commits on the runtime seem to be an obvious
cacndidate for failure.

Fixes #2166

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>