### PR TITLE
Fix crio execsync issue

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -30,6 +30,7 @@ conmon_version=$(get_version "externals.conmon.version")
 conmon_repo=${conmon_url/https:\/\/}
 go get -d "${conmon_repo}" || true
 pushd "$GOPATH/src/${conmon_repo}"
+git checkout "${conmon_version}"
 make
 sudo -E make install
 popd

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -13,7 +13,6 @@ declare -a skipCRIOTests=(
 'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
 'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
 'test "additional devices permissions"'
-'test "ctr execsync"'
 );
 
 if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then


### PR DESCRIPTION
CI today does not use conmon version specified in
version.yaml, instead builds from master.
The latest version of conmon seemed to have changed certain
exit codes for exec and introduced errors described in
kata-containers/runtime#2352

Have the CI checkout version from versions.yaml and build conmon.

Fixes #2170