### PR TITLE
vendor: Update github.com/onsi/ginkgo version to v1.10.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -162,7 +162,7 @@
   revision = "cc27d85e17cec9768d2ac401ea5d619a9628f16d"
 
 [[projects]]
-  digest = "1:545744762d3d6d59328a38e44f571baaeda30184b88b43a28879bedf7711afa5"
+  digest = "1:3a47e496452035d322c70191b5971cebe92863a374203240c25cec808232afa7"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -186,8 +186,8 @@
     "types",
   ]
   pruneopts = "NT"
-  revision = "eea6ad008b96acdaa524f5b409513bf062b500ad"
-  version = "v1.8.0"
+  revision = "ce5d301e555bb672c693c099ba6ca5087b06c0b4"
+  version = "v1.10.3"
 
 [[projects]]
   digest = "1:dbc32e78111432cefebd2bae8a913581ccea31c1f79547aac1c431a8e1b28c55"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"
-  version = "=1.8.0"
+  version = "=1.10.3"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/vendor/github.com/onsi/ginkgo/config/config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-const VERSION = "1.8.0"
+const VERSION = "1.10.3"
 
 type GinkgoConfigType struct {
 	RandomSeed         int64
@@ -52,13 +52,15 @@ type DefaultReporterConfigType struct {
 	Succinct          bool
 	Verbose           bool
 	FullTrace         bool
+	ReportPassed      bool
+	ReportFile        string
 }
 
 var DefaultReporterConfig = DefaultReporterConfigType{}
 
 func processPrefix(prefix string) string {
 	if prefix != "" {
-		prefix = prefix + "."
+		prefix += "."
 	}
 	return prefix
 }
@@ -98,6 +100,9 @@ func Flags(flagSet *flag.FlagSet, prefix string, includeParallelFlags bool) {
 	flagSet.BoolVar(&(DefaultReporterConfig.Verbose), prefix+"v", false, "If set, default reporter print out all specs as they begin.")
 	flagSet.BoolVar(&(DefaultReporterConfig.Succinct), prefix+"succinct", false, "If set, default reporter prints out a very succinct report")
 	flagSet.BoolVar(&(DefaultReporterConfig.FullTrace), prefix+"trace", false, "If set, default reporter prints out the full stack trace when a failure occurs")
+	flagSet.BoolVar(&(DefaultReporterConfig.ReportPassed), prefix+"reportPassed", false, "If set, default reporter prints out captured output of passed tests.")
+	flagSet.StringVar(&(DefaultReporterConfig.ReportFile), prefix+"reportFile", "", "Override the default reporter output file path.")
+
 }
 
 func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultReporterConfigType) []string {
@@ -194,6 +199,14 @@ func BuildFlagArgs(prefix string, ginkgo GinkgoConfigType, reporter DefaultRepor
 
 	if reporter.FullTrace {
 		result = append(result, fmt.Sprintf("--%strace", prefix))
+	}
+
+	if reporter.ReportPassed {
+		result = append(result, fmt.Sprintf("--%sreportPassed", prefix))
+	}
+
+	if reporter.ReportFile != "" {
+		result = append(result, fmt.Sprintf("--%sreportFile=%s", prefix, reporter.ReportFile))
 	}
 
 	return result

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -22,18 +22,15 @@ func (t TableEntry) generateIt(itBody reflect.Value) {
 		return
 	}
 
-	values := []reflect.Value{}
+	values := make([]reflect.Value, len(t.Parameters))
+	iBodyType := itBody.Type()
 	for i, param := range t.Parameters {
-		var value reflect.Value
-
 		if param == nil {
-			inType := itBody.Type().In(i)
-			value = reflect.Zero(inType)
+			inType := iBodyType.In(i)
+			values[i] = reflect.Zero(inType)
 		} else {
-			value = reflect.ValueOf(param)
+			values[i] = reflect.ValueOf(param)
 		}
-
-		values = append(values, value)
 	}
 
 	body := func() {

--- a/vendor/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/bootstrap_command.go
@@ -131,10 +131,7 @@ func determinePackageName(name string, internal bool) string {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }
 
 func generateBootstrap(agouti, noDot, internal bool, customBootstrapFile string) {

--- a/vendor/github.com/onsi/ginkgo/ginkgo/convert/import.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/convert/import.go
@@ -1,7 +1,6 @@
 package convert
 
 import (
-	"errors"
 	"fmt"
 	"go/ast"
 )
@@ -24,7 +23,7 @@ func importsForRootNode(rootNode *ast.File) (imports *ast.GenDecl, err error) {
 		}
 	}
 
-	err = errors.New(fmt.Sprintf("Could not find imports for root node:\n\t%#v\n", rootNode))
+	err = fmt.Errorf("Could not find imports for root node:\n\t%#v\n", rootNode)
 	return
 }
 

--- a/vendor/github.com/onsi/ginkgo/ginkgo/convert/package_rewriter.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/convert/package_rewriter.go
@@ -24,7 +24,6 @@ func RewritePackage(packageName string) {
 	for _, filename := range findTestsInPackage(pkg) {
 		rewriteTestsInFile(filename)
 	}
-	return
 }
 
 /*

--- a/vendor/github.com/onsi/ginkgo/ginkgo/convert/testfile_rewriter.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/convert/testfile_rewriter.go
@@ -61,7 +61,6 @@ func rewriteTestsInFile(pathToFile string) {
 	}
 
 	ioutil.WriteFile(pathToFile, buffer.Bytes(), fileInfo.Mode())
-	return
 }
 
 /*
@@ -88,7 +87,6 @@ func rewriteTestFuncAsItStatement(testFunc *ast.FuncDecl, rootNode *ast.File, de
 
 	// remove the old test func from the root node's declarations
 	rootNode.Decls = append(rootNode.Decls[:funcIndex], rootNode.Decls[funcIndex+1:]...)
-	return
 }
 
 /*

--- a/vendor/github.com/onsi/ginkgo/ginkgo/interrupthandler/interrupt_handler.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/interrupthandler/interrupt_handler.go
@@ -16,7 +16,7 @@ type InterruptHandler struct {
 func NewInterruptHandler() *InterruptHandler {
 	h := &InterruptHandler{
 		lock: &sync.Mutex{},
-		C:    make(chan bool, 0),
+		C:    make(chan bool),
 	}
 
 	go h.handleInterrupt()

--- a/vendor/github.com/onsi/ginkgo/ginkgo/main.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/main.go
@@ -153,6 +153,7 @@ func (c *Command) Matches(name string) bool {
 }
 
 func (c *Command) Run(args []string, additionalArgs []string) {
+	c.FlagSet.Usage = usage
 	c.FlagSet.Parse(args)
 	c.Command(c.FlagSet.Args(), additionalArgs)
 }
@@ -215,20 +216,21 @@ func commandMatching(name string) (*Command, bool) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Ginkgo Version %s\n\n", config.VERSION)
+	fmt.Printf("Ginkgo Version %s\n\n", config.VERSION)
 	usageForCommand(DefaultCommand, false)
 	for _, command := range Commands {
-		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Printf("\n")
 		usageForCommand(command, false)
 	}
 }
 
 func usageForCommand(command *Command, longForm bool) {
-	fmt.Fprintf(os.Stderr, "%s\n%s\n", command.UsageCommand, strings.Repeat("-", len(command.UsageCommand)))
-	fmt.Fprintf(os.Stderr, "%s\n", strings.Join(command.Usage, "\n"))
+	fmt.Printf("%s\n%s\n", command.UsageCommand, strings.Repeat("-", len(command.UsageCommand)))
+	fmt.Printf("%s\n", strings.Join(command.Usage, "\n"))
 	if command.SuppressFlagDocumentation && !longForm {
-		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(command.FlagDocSubstitute, "\n  "))
+		fmt.Printf("%s\n", strings.Join(command.FlagDocSubstitute, "\n  "))
 	} else {
+		command.FlagSet.SetOutput(os.Stdout)
 		command.FlagSet.PrintDefaults()
 	}
 }

--- a/vendor/github.com/onsi/ginkgo/ginkgo/suite_runner.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/suite_runner.go
@@ -41,7 +41,7 @@ func (r *SuiteRunner) compileInParallel(runners []*testrunner.TestRunner, numCom
 	//an array of channels - the nth runner's compilation output is sent to the nth channel in this array
 	//we read from these channels in order to ensure we run the suites in order
 	orderedCompilationOutputs := []chan compilationOutput{}
-	for _ = range runners {
+	for range runners {
 		orderedCompilationOutputs = append(orderedCompilationOutputs, make(chan compilationOutput, 1))
 	}
 

--- a/vendor/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/testrunner/test_runner.go
@@ -156,7 +156,7 @@ func (t *TestRunner) CompileTo(path string) error {
 		fmt.Println(string(output))
 	}
 
-	if fileExists(path) == false {
+	if !fileExists(path) {
 		compiledFile := t.Suite.PackageName + ".test"
 		if fileExists(compiledFile) {
 			// seems like we are on an old go version that does not support the -o flag on go test
@@ -182,7 +182,7 @@ func (t *TestRunner) CompileTo(path string) error {
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
-	return err == nil || os.IsNotExist(err) == false
+	return err == nil || !os.IsNotExist(err)
 }
 
 // copyFile copies the contents of the file named src to the file named
@@ -523,7 +523,7 @@ func (t *TestRunner) combineCoverprofiles() {
 	lines := map[string]int{}
 	lineOrder := []string{}
 	for i, coverProfile := range profiles {
-		for _, line := range strings.Split(string(coverProfile), "\n")[1:] {
+		for _, line := range strings.Split(coverProfile, "\n")[1:] {
 			if len(line) == 0 {
 				continue
 			}

--- a/vendor/github.com/onsi/ginkgo/ginkgo/watch/dependencies.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/watch/dependencies.go
@@ -77,7 +77,7 @@ func (d Dependencies) resolveAndAdd(deps []string, depth int) {
 		if err != nil {
 			continue
 		}
-		if pkg.Goroot == false && !ginkgoAndGomegaFilter.Match([]byte(pkg.Dir)) {
+		if !pkg.Goroot && !ginkgoAndGomegaFilter.Match([]byte(pkg.Dir)) {
 			d.addDepIfNotPresent(pkg.Dir, depth)
 		}
 	}

--- a/vendor/github.com/onsi/ginkgo/ginkgo/watch/package_hash.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo/watch/package_hash.go
@@ -36,7 +36,7 @@ func (p *PackageHash) CheckForChanges() bool {
 	codeHash, codeModifiedTime, testHash, testModifiedTime, deleted := p.computeHashes()
 
 	if deleted {
-		if p.Deleted == false {
+		if !p.Deleted {
 			t := time.Now()
 			p.CodeModifiedTime = t
 			p.TestModifiedTime = t

--- a/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -199,6 +199,11 @@ type Benchmarker interface {
 //	ginkgo bootstrap
 func RunSpecs(t GinkgoTestingT, description string) bool {
 	specReporters := []Reporter{buildDefaultReporter()}
+	if config.DefaultReporterConfig.ReportFile != "" {
+		reportFile := config.DefaultReporterConfig.ReportFile
+		specReporters[0] = reporters.NewJUnitReporter(reportFile)
+		return RunSpecsWithDefaultAndCustomReporters(t, description, specReporters)
+	}
 	return RunSpecsWithCustomReporters(t, description, specReporters)
 }
 
@@ -283,7 +288,7 @@ func GinkgoRecover() {
 //BeforeEach, AfterEach, JustBeforeEach, It, and Measurement blocks.
 //
 //In addition you can nest Describe, Context and When blocks.  Describe, Context and When blocks are functionally
-//equivalent.  The difference is purely semantic -- you typical Describe the behavior of an object
+//equivalent.  The difference is purely semantic -- you typically Describe the behavior of an object
 //or method and, within that Describe, outline a number of Contexts and Whens.
 func Describe(text string, body func()) bool {
 	globalSuite.PushContainerNode(text, body, types.FlagTypeNone, codelocation.New(1))
@@ -499,7 +504,7 @@ func AfterSuite(body interface{}, timeout ...float64) bool {
 //until that node is done before running.
 //
 //SynchronizedBeforeSuite accomplishes this by taking *two* function arguments.  The first is only run on parallel node #1.  The second is
-//run on all nodes, but *only* after the first function completes succesfully.  Ginkgo also makes it possible to send data from the first function (on Node 1)
+//run on all nodes, but *only* after the first function completes successfully.  Ginkgo also makes it possible to send data from the first function (on Node 1)
 //to the second function (on all the other nodes).
 //
 //The functions have the following signatures.  The first function (which only runs on node 1) has the signature:

--- a/vendor/github.com/onsi/ginkgo/internal/codelocation/code_location.go
+++ b/vendor/github.com/onsi/ginkgo/internal/codelocation/code_location.go
@@ -11,19 +11,35 @@ import (
 
 func New(skip int) types.CodeLocation {
 	_, file, line, _ := runtime.Caller(skip + 1)
-	stackTrace := PruneStack(string(debug.Stack()), skip)
+	stackTrace := PruneStack(string(debug.Stack()), skip+1)
 	return types.CodeLocation{FileName: file, LineNumber: line, FullStackTrace: stackTrace}
 }
 
+// PruneStack removes references to functions that are internal to Ginkgo
+// and the Go runtime from a stack string and a certain number of stack entries
+// at the beginning of the stack. The stack string has the format
+// as returned by runtime/debug.Stack. The leading goroutine information is
+// optional and always removed if present. Beware that runtime/debug.Stack
+// adds itself as first entry, so typically skip must be >= 1 to remove that
+// entry.
 func PruneStack(fullStackTrace string, skip int) string {
 	stack := strings.Split(fullStackTrace, "\n")
+	// Ensure that the even entries are the method names and the
+	// the odd entries the source code information.
+	if len(stack) > 0 && strings.HasPrefix(stack[0], "goroutine ") {
+		// Ignore "goroutine 29 [running]:" line.
+		stack = stack[1:]
+	}
+	// The "+1" is for skipping over the initial entry, which is
+	// runtime/debug.Stack() itself.
 	if len(stack) > 2*(skip+1) {
 		stack = stack[2*(skip+1):]
 	}
 	prunedStack := []string{}
 	re := regexp.MustCompile(`\/ginkgo\/|\/pkg\/testing\/|\/pkg\/runtime\/`)
 	for i := 0; i < len(stack)/2; i++ {
-		if !re.Match([]byte(stack[i*2])) {
+		// We filter out based on the source code file name.
+		if !re.Match([]byte(stack[i*2+1])) {
 			prunedStack = append(prunedStack, stack[i*2])
 			prunedStack = append(prunedStack, stack[i*2+1])
 		}

--- a/vendor/github.com/onsi/ginkgo/internal/leafnodes/benchmarker.go
+++ b/vendor/github.com/onsi/ginkgo/internal/leafnodes/benchmarker.go
@@ -17,7 +17,7 @@ type benchmarker struct {
 
 func newBenchmarker() *benchmarker {
 	return &benchmarker{
-		measurements: make(map[string]*types.SpecMeasurement, 0),
+		measurements: make(map[string]*types.SpecMeasurement),
 	}
 }
 

--- a/vendor/github.com/onsi/ginkgo/internal/remote/aggregator.go
+++ b/vendor/github.com/onsi/ginkgo/internal/remote/aggregator.go
@@ -54,11 +54,11 @@ func NewAggregator(nodeCount int, result chan bool, config config.DefaultReporte
 		config:       config,
 		stenographer: stenographer,
 
-		suiteBeginnings: make(chan configAndSuite, 0),
-		beforeSuites:    make(chan *types.SetupSummary, 0),
-		afterSuites:     make(chan *types.SetupSummary, 0),
-		specCompletions: make(chan *types.SpecSummary, 0),
-		suiteEndings:    make(chan *types.SuiteSummary, 0),
+		suiteBeginnings: make(chan configAndSuite),
+		beforeSuites:    make(chan *types.SetupSummary),
+		afterSuites:     make(chan *types.SetupSummary),
+		specCompletions: make(chan *types.SpecSummary),
+		suiteEndings:    make(chan *types.SuiteSummary),
 	}
 
 	go aggregator.mux()
@@ -227,7 +227,7 @@ func (aggregator *Aggregator) registerSuiteEnding(suite *types.SuiteSummary) (fi
 	aggregatedSuiteSummary.SuiteSucceeded = true
 
 	for _, suiteSummary := range aggregator.aggregatedSuiteEndings {
-		if suiteSummary.SuiteSucceeded == false {
+		if !suiteSummary.SuiteSucceeded {
 			aggregatedSuiteSummary.SuiteSucceeded = false
 		}
 

--- a/vendor/github.com/onsi/ginkgo/internal/remote/server.go
+++ b/vendor/github.com/onsi/ginkgo/internal/remote/server.go
@@ -213,7 +213,7 @@ func (server *Server) handleCounter(writer http.ResponseWriter, request *http.Re
 	c := spec_iterator.Counter{}
 	server.lock.Lock()
 	c.Index = server.counter
-	server.counter = server.counter + 1
+	server.counter++
 	server.lock.Unlock()
 
 	json.NewEncoder(writer).Encode(c)

--- a/vendor/github.com/onsi/ginkgo/internal/spec/spec.go
+++ b/vendor/github.com/onsi/ginkgo/internal/spec/spec.go
@@ -107,11 +107,11 @@ func (spec *Spec) Summary(suiteID string) *types.SpecSummary {
 		NumberOfSamples:        spec.subject.Samples(),
 		ComponentTexts:         componentTexts,
 		ComponentCodeLocations: componentCodeLocations,
-		State:        spec.getState(),
-		RunTime:      runTime,
-		Failure:      spec.failure,
-		Measurements: spec.measurementsReport(),
-		SuiteID:      suiteID,
+		State:                  spec.getState(),
+		RunTime:                runTime,
+		Failure:                spec.failure,
+		Measurements:           spec.measurementsReport(),
+		SuiteID:                suiteID,
 	}
 }
 

--- a/vendor/github.com/onsi/ginkgo/internal/spec/specs.go
+++ b/vendor/github.com/onsi/ginkgo/internal/spec/specs.go
@@ -107,11 +107,11 @@ func (e *Specs) applyRegExpFocusAndSkip(description string, focusString string, 
 		toMatch := e.toMatch(description, i)
 
 		if focusFilter != nil {
-			matchesFocus = focusFilter.Match([]byte(toMatch))
+			matchesFocus = focusFilter.Match(toMatch)
 		}
 
 		if skipFilter != nil {
-			matchesSkip = skipFilter.Match([]byte(toMatch))
+			matchesSkip = skipFilter.Match(toMatch)
 		}
 
 		if !matchesFocus || matchesSkip {

--- a/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
+++ b/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go
@@ -300,7 +300,7 @@ func (runner *SpecRunner) reportSpecWillRun(summary *types.SpecSummary) {
 }
 
 func (runner *SpecRunner) reportSpecDidComplete(summary *types.SpecSummary, failed bool) {
-	if failed && len(summary.CapturedOutput) == 0 {
+	if len(summary.CapturedOutput) == 0 {
 		summary.CapturedOutput = string(runner.writer.Bytes())
 	}
 	for i := len(runner.reporters) - 1; i >= 1; i-- {

--- a/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -62,6 +62,9 @@ func (reporter *DefaultReporter) SpecDidComplete(specSummary *types.SpecSummary)
 			reporter.stenographer.AnnounceSuccesfulSlowSpec(specSummary, reporter.config.Succinct)
 		} else {
 			reporter.stenographer.AnnounceSuccesfulSpec(specSummary)
+			if reporter.config.ReportPassed {
+				reporter.stenographer.AnnounceCapturedOutput(specSummary.CapturedOutput)
+			}
 		}
 	case types.SpecStatePending:
 		reporter.stenographer.AnnouncePendingSpec(specSummary, reporter.config.NoisyPendings && !reporter.config.Succinct)

--- a/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/onsi/ginkgo/config"
@@ -32,10 +33,15 @@ type JUnitTestSuite struct {
 type JUnitTestCase struct {
 	Name           string               `xml:"name,attr"`
 	ClassName      string               `xml:"classname,attr"`
+	PassedMessage  *JUnitPassedMessage  `xml:"passed,omitempty"`
 	FailureMessage *JUnitFailureMessage `xml:"failure,omitempty"`
 	Skipped        *JUnitSkipped        `xml:"skipped,omitempty"`
 	Time           float64              `xml:"time,attr"`
 	SystemOut      string               `xml:"system-out,omitempty"`
+}
+
+type JUnitPassedMessage struct {
+	Message string `xml:",chardata"`
 }
 
 type JUnitFailureMessage struct {
@@ -48,9 +54,10 @@ type JUnitSkipped struct {
 }
 
 type JUnitReporter struct {
-	suite         JUnitTestSuite
-	filename      string
-	testSuiteName string
+	suite          JUnitTestSuite
+	filename       string
+	testSuiteName  string
+	ReporterConfig config.DefaultReporterConfigType
 }
 
 //NewJUnitReporter creates a new JUnit XML reporter.  The XML will be stored in the passed in filename.
@@ -60,12 +67,13 @@ func NewJUnitReporter(filename string) *JUnitReporter {
 	}
 }
 
-func (reporter *JUnitReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+func (reporter *JUnitReporter) SpecSuiteWillBegin(ginkgoConfig config.GinkgoConfigType, summary *types.SuiteSummary) {
 	reporter.suite = JUnitTestSuite{
 		Name:      summary.SuiteDescription,
 		TestCases: []JUnitTestCase{},
 	}
 	reporter.testSuiteName = summary.SuiteDescription
+	reporter.ReporterConfig = config.DefaultReporterConfig
 }
 
 func (reporter *JUnitReporter) SpecWillRun(specSummary *types.SpecSummary) {
@@ -105,10 +113,20 @@ func (reporter *JUnitReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
 		ClassName: reporter.testSuiteName,
 	}
+	if reporter.ReporterConfig.ReportPassed && specSummary.State == types.SpecStatePassed {
+		testCase.PassedMessage = &JUnitPassedMessage{
+			Message: specSummary.CapturedOutput,
+		}
+	}
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		testCase.FailureMessage = &JUnitFailureMessage{
 			Type:    reporter.failureTypeForState(specSummary.State),
 			Message: failureMessage(specSummary.Failure),
+		}
+		if specSummary.State == types.SpecStatePanicked {
+			testCase.FailureMessage.Message += fmt.Sprintf("\n\nPanic: %s\n\nFull stack:\n%s",
+				specSummary.Failure.ForwardedPanic,
+				specSummary.Failure.Location.FullStackTrace)
 		}
 		testCase.SystemOut = specSummary.CapturedOutput
 	}
@@ -124,17 +142,29 @@ func (reporter *JUnitReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
 	reporter.suite.Time = math.Trunc(summary.RunTime.Seconds()*1000) / 1000
 	reporter.suite.Failures = summary.NumberOfFailedSpecs
 	reporter.suite.Errors = 0
-	file, err := os.Create(reporter.filename)
+	if reporter.ReporterConfig.ReportFile != "" {
+		reporter.filename = reporter.ReporterConfig.ReportFile
+		fmt.Printf("\nJUnit path was configured: %s\n", reporter.filename)
+	}
+	filePath, _ := filepath.Abs(reporter.filename)
+	dirPath := filepath.Dir(filePath)
+	err := os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
-		fmt.Printf("Failed to create JUnit report file: %s\n\t%s", reporter.filename, err.Error())
+		fmt.Printf("\nFailed to create JUnit directory: %s\n\t%s", filePath, err.Error())
+	}
+	file, err := os.Create(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create JUnit report file: %s\n\t%s", filePath, err.Error())
 	}
 	defer file.Close()
 	file.WriteString(xml.Header)
 	encoder := xml.NewEncoder(file)
 	encoder.Indent("  ", "    ")
 	err = encoder.Encode(reporter.suite)
-	if err != nil {
-		fmt.Printf("Failed to generate JUnit report\n\t%s", err.Error())
+	if err == nil {
+		fmt.Fprintf(os.Stdout, "\nJUnit report was created: %s\n", filePath)
+	} else {
+		fmt.Fprintf(os.Stderr,"\nFailed to generate JUnit report data:\n\t%s", err.Error())
 	}
 }
 

--- a/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -22,8 +22,9 @@ const (
 )
 
 type TeamCityReporter struct {
-	writer        io.Writer
-	testSuiteName string
+	writer         io.Writer
+	testSuiteName  string
+	ReporterConfig config.DefaultReporterConfigType
 }
 
 func NewTeamCityReporter(writer io.Writer) *TeamCityReporter {
@@ -65,6 +66,10 @@ func (reporter *TeamCityReporter) SpecWillRun(specSummary *types.SpecSummary) {
 func (reporter *TeamCityReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	testName := escape(strings.Join(specSummary.ComponentTexts[1:], " "))
 
+	if reporter.ReporterConfig.ReportPassed && specSummary.State == types.SpecStatePassed {
+		details := escape(specSummary.CapturedOutput)
+		fmt.Fprintf(reporter.writer, "%s[testPassed name='%s' details='%s']", messageId, testName, details)
+	}
 	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateTimedOut || specSummary.State == types.SpecStatePanicked {
 		message := escape(specSummary.Failure.ComponentCodeLocation.String())
 		details := escape(specSummary.Failure.Message)

--- a/vendor/github.com/onsi/ginkgo/types/types.go
+++ b/vendor/github.com/onsi/ginkgo/types/types.go
@@ -17,7 +17,7 @@ each node does not deterministically know how many specs it will end up running.
 
 Unfortunately making such a change would break backward compatibility.
 
-Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unkown fields
+Until Ginkgo 2.0 comes out we will continue to reuse this struct but populate unknown fields
 with -1.
 */
 type SuiteSummary struct {


### PR DESCRIPTION
After update golang version to 1.13.5 in runtime, got following fails
with test:
GOPATH=/home/jenkins/workspace/kata-containers-runtime-Power8-ubuntu-18-04-PR-initrd/go/src/github.com/kata-containers/tests/vendor go build ./vendor/github.com/onsi/ginkgo/ginkgo
unlink vendor/src
./ginkgo -failFast -v -focus "" -skip "Update CPU set|CPUs and CPU set|Update CPU constraints|Hotplug memory when create containers|run container and update its memory constraints|check dmesg logs errors|memory constraints|check yum update|run container exceeding memory constraints" \
	functional/ -- -runtime=kata-runtime -timeout=120
flag provided but not defined: -test.timeout
Usage of /tmp/ginkgo426003962/functional.test:

Update github.com/onsi/ginkgo version to v1.10.3 to handle this issue.

Fixes: #2174

Signed-off-by: Hui Zhu <teawater@antfin.com>