### PR TITLE
ci: Fix cache for cloud hypervisor

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -57,9 +57,12 @@ cache_kernel_artifacts() {
 
 # This builds cloud hypervisor
 cache_cloud_hypervisor() {
-	local cloud_hypervisor_binary="/usr/bin/cloud-hypervisor"
+	local cloud_hypervisor_binary="cloud-hypervisor"
+	local cloud_hypervisor_binary_path="/usr/bin"
 	local current_cloud_hypervisor_version=$(get_version "assets.hypervisor.cloud_hypervisor.version")
+	pushd "${cloud_hypervisor_binary_path}"
 	create_cache_asset "${cloud_hypervisor_binary}" "${current_cloud_hypervisor_version}"
+	popd
 }
 
 # This builds the image by specifying the image version from


### PR DESCRIPTION
While creating the cache asset we need to pass the component name, this PR
fixes this by passing as a component name only cloud-hypervisor instead of
passing the full name and the full path.

Fixes #2177

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>