### PR TITLE
ci: Add missing sudo for the cache components scripts

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -121,7 +121,7 @@ create_cache_asset() {
 		echo $(basename "${path}") > "latest-${image_name}"
 		sudo cp "${path}" "${kata_dir}/osbuilder-${image_name}.yaml"  .
 	else
-		echo "${component_version}" >  "latest"
+		echo "${component_version}" | sudo tee - a "latest"
 	fi
 
 	# In the case of qemu we have the tar at a specific location


### PR DESCRIPTION
We miss sudo while performing the echo of the component version as currently
we are getting the failure of permission denied.

Fixes #2183

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>