### PR TITLE
rust: run installation non-interactive

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -20,7 +20,7 @@ if [ -z "${version}" ]; then
 fi
 
 if ! command -v rustup > /dev/null; then
-	curl https://sh.rustup.rs -sSf | sh
+	curl https://sh.rustup.rs -sSf | sh -s -- -y
 fi
 
 export PATH="${PATH}:${HOME}/.cargo/bin"


### PR DESCRIPTION
As we need to install rust on CI systems, we need to make
the installation non-interactive.

Fixes: #2187.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>