### PR TITLE
ci: Set kata-runtime as Docker runtime when using cloud-hypervisor

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -111,12 +111,15 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	fi
 fi
 
-if [ "$KATA_HYPERVISOR" == "qemu"  ]; then
-       echo "Add kata-runtime as a new/default Docker runtime."
-       "${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
-else
-       echo "Kata runtime will not set as a default in Docker"
-fi
+case "${KATA_HYPERVISOR}" in
+	"cloud-hypervisor" | "qemu")
+		echo "Add kata-runtime as a new/default Docker runtime."
+		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
+		;;
+	*)
+		echo "Kata runtime will not set as a default in Docker"
+		;;
+esac
 
 if [ "$MACHINETYPE" == "q35" ]; then
 	echo "Use machine_type q35"


### PR DESCRIPTION
Currently the CI fails when cloud-hypervisor (CLH) is being used. This is
because kata-runtime is only set as default/new Docker runtime when QEMU is
being used. 

Fixes: #2189

Signed-off-by: Bo Chen <chen.bo@intel.com>