### PR TITLE
ci: Add installation path for rust image

### DIFF
--- a/.ci/install_kata_image_rust.sh
+++ b/.ci/install_kata_image_rust.sh
@@ -46,6 +46,7 @@ build_rust_image() {
 	sudo -E USE_DOCKER=1 DISTRO="${distro}" make -e image
 
 	image_path="/usr/share/kata-containers/"
+	sudo mkdir -p "${image_path}"
 	echo "Install rust image to ${image_path}"
 	sudo install -D "${GOPATH}/src/${osbuilder_repo}/kata-containers.img" "${image_path}"
 	popd


### PR DESCRIPTION
Currently we are getting the error that the kata-containers directory is not
found while we are trying to install the rust image. This PR fixes that issue.

Fixes #2193

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>