### PR TITLE
ci: do not skip virtcontainers directories with non-root users

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -182,12 +182,6 @@ test_coverage()
 	echo "INFO: Currently running as user '$(id -un)'"
 	for pkg in $test_packages; do
 		for user in $users; do
-			# Run virtcontainers tests only if user is root.
-			if [[ "$user" != "root" ]] && [[ "$pkg" = *"virtcontainers"* ]]; then
-				echo "Skip testing $pkg with user $user"
-				continue
-			fi
-
 			test_go_package "$pkg" "$user"
 		done
 	done


### PR DESCRIPTION
Currently anything under virtcontainers are skipped for non-root users.
We should just treat them the same as others instead.

Depends-on: Depends-on: github.com/kata-containers/runtime#2371

Fixes: #2197
