### PR TITLE
ci: Improve path for calling install_yq.sh script

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -123,10 +123,7 @@ function get_dep_from_yaml_db(){
 
 	[ ! -f "$versions_file" ] && die "cannot find $versions_file"
 
-	# directory of this script, not the caller
-	local cidir=$(dirname "${BASH_SOURCE[0]}")
-
-	${cidir}/install_yq.sh >&2
+	"${GOPATH}/src/${tests_repo}/.ci/install_yq.sh" >&2
 
 	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""


### PR DESCRIPTION
While trying to call the function get_dep_from_yaml_db from lib.sh, this
is failing while trying to run the install_yq.sh script as sometimes it does
not find the script in the current path. This PR fixes that issue by
improving the path.

Fixes #2203

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>