### PR TITLE
ci: fix the issue of missing show error info

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -309,9 +309,9 @@ static_check_rust_arch_specific()
 		return
 	fi
 
-	find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check > /dev/null 2>&1
+	{ find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check > /dev/null 2>&1; ret=$?; } || true
 
-	[ $? -eq 0 ] || die "crate not formatted by rustfmt."
+	[ $ret -eq 0 ] || die "crate not formatted by rustfmt."
 }
 
 # Install yamllint in the different Linux distributions


### PR DESCRIPTION
When the shell cmd return non-zero, the script
would return directly and there is no chance
to do the return code check in the following
cmd.

Fixes: #2205

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>