### PR TITLE
[1.10 backport]: cri-o: Check out specific version of conmon in CI

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -30,6 +30,7 @@ conmon_version=$(get_version "externals.conmon.version")
 conmon_repo=${conmon_url/https:\/\/}
 go get -d "${conmon_repo}" || true
 pushd "$GOPATH/src/${conmon_repo}"
+git checkout "${conmon_version}"
 make
 sudo -E make install
 popd


### PR DESCRIPTION
CI today does not use conmon version specified in
version.yaml, instead builds from master.
The latest version of conmon seemed to have changed certain
exit codes for exec and introduced errors described in
https://github.com/kata-containers/runtime/issues/2352

Have the CI checkout version from versions.yaml and build conmon.

backport of b145f4ca07e4acdaa8d6d308a942ed05f9181f2e

Fixes #2170

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>