### PR TITLE
test: Sandbox cgroup test

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -30,6 +30,9 @@ case "${CI_JOB}" in
 		# remove config created by toggle_sandbox_cgroup_only.sh
 		"${cidir}/toggle_sandbox_cgroup_only.sh" false
 		sudo rm -f "/etc/kata-containers/configuration.toml"
+
+		echo "INFO: Running docker integration tests with sandbox cgroup enabled"
+		sudo -E PATH="$PATH" bash -c "make sandbox-cgroup"
 		;;
 	"FIRECRACKER" | "CLOUD-HYPERVISOR")
 		echo "INFO: Running docker integration tests"

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ kubernetes:
 ksm:
 	bash -f integration/ksm/ksm_test.sh
 
+sandbox-cgroup:
+	bash -f integration/sandbox_cgroup/sandbox_cgroup_test.sh
+
 swarm:
 	systemctl is-active --quiet docker || sudo systemctl start docker
 	bash -f .ci/install_bats.sh
@@ -222,6 +225,7 @@ help:
 	oci \
 	openshift \
 	pentest \
+	sandbox-cgroup \
 	swarm \
 	netmon \
 	network \

--- a/integration/sandbox_cgroup/sandbox_cgroup_test.sh
+++ b/integration/sandbox_cgroup/sandbox_cgroup_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This will enable the sandbox_cgroup_only
+# to true in order to test that docker is
+# working properly when this feature is
+# enabled
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+dir_path=$(dirname "$0")
+source "${dir_path}/../../lib/common.bash"
+source "${dir_path}/../../.ci/lib.sh"
+tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+TEST_SANDBOX_CGROUP_ONLY="${TEST_SANDBOX_CGROUP_ONLY:-}"
+
+if [ -z "${TEST_SANDBOX_CGROUP_ONLY}" ]; then
+	info "Skip: TEST_SANDBOX_CGROUP_ONLY variable is not set"
+	exit 0
+fi
+
+function setup() {
+	clean_env
+	check_processes
+}
+
+function test_docker() {
+	pushd "${GOPATH}/src/${tests_repo}"
+	".ci/toggle_sandbox_cgroup_only.sh" true
+	sudo -E PATH="$PATH" bash -c "make docker"
+	".ci/toggle_sandbox_cgroup_only.sh" false
+	popd
+}
+
+function teardown() {
+	clean_env
+	check_processes
+}
+
+trap teardown EXIT
+
+echo "Running setup"
+setup
+
+echo "Running docker integration tests with sandbox cgroup enabled"
+test_docker


### PR DESCRIPTION
This enables the sandbox cgroup feature at the configuration.toml and then
it runs the docker integration tests in order to ensure that this functionality
is working.

Fixes #2208

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>