### PR TITLE
Clean: clean up stale files under /tmp

### DIFF
--- a/.ci/aarch64/clean_up_aarch64.sh
+++ b/.ci/aarch64/clean_up_aarch64.sh
@@ -11,3 +11,6 @@ lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 
 gen_clean_arch || info "Arch cleanup scripts failed"
+
+info "clean up /tmp"
+sudo sh -c 'rm -rf /tmp/*'


### PR DESCRIPTION
# Description of problem
Stale dir `/tmp/virtc/ocibundle/` has caused recent ARM CI failure.
http://jenkins.katacontainers.io/job/kata-containers-runtime-ARM-18.04-PR/1414/ 
Related PR: kata-containers/runtime#2387
BTW,  almost ten thousand😖 stale file/dir have been accumulated on ARM CI.
We need to clean up `/tmp` on all bare-metal CI. ;)