### PR TITLE
ci: Enable PowerTools repository for CentOS 8

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -33,6 +33,11 @@ fi
 echo "Update repositories"
 sudo -E yum -y update
 
+if [ "$centos_version" == "8" ]; then
+	echo "Enable PowerTools repository"
+	sudo yum-config-manager --enable PowerTools
+fi
+
 echo "Install chronic"
 sudo -E yum -y install moreutils
 


### PR DESCRIPTION
We need to enable PowerTools repository for CentOS 8 in order to be
able to install packages like moreutils, libseccomp-devel, pandoc, etc.

Fixes #2214

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>