### PR TITLE
ci: Enable priority for CentOS base repository

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -30,6 +30,13 @@ if [ -z $(yum repolist | grep "Extra Packages") ]; then
 	sudo -E rpm -ivh epel-release-latest-${centos_version}.noarch.rpm
 fi
 
+# Enable priority to CentOS Base repo in order to
+# avoid perl updating issues
+if [ "$centos_version" == "8" ]; then
+	sudo echo "priority=1" | sudo tee -a /etc/yum.repos.d/CentOS-Base.repo
+	sudo -E yum -y clean all
+fi
+
 echo "Update repositories"
 sudo -E yum -y update
 


### PR DESCRIPTION
We need to enable the priority for CentOS Base repository if we want to update
CentOS 8 without issues. This PR enables the priority and with that solves the
issues that some perl packages can not be installed.

Fixes #2223

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>