### PR TITLE
ci: static check: spellcheck: check all docs

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -760,10 +760,13 @@ static_check_docs()
 	# Now, spell check the docs
 	cmd="${tests_repo_dir}/cmd/check-spelling/kata-spell-check.sh"
 
+	local docs_failed=0
 	for doc in $docs
 	do
-		"$cmd" check "$doc" || die "spell check failed for document $doc"
+		"$cmd" check "$doc" || { info "spell check failed for document $doc" && docs_failed=1; }
 	done
+
+	[ $docs_failed -ne 0 ] && die "spell check failed, See https://github.com/kata-containers/documentation/blob/master/Documentation-Requirements.md#spelling for more information."
 }
 
 # Tests to apply to all files.


### PR DESCRIPTION
Rather than fail the spell check on the first failure, continue to
check all the changed documents, and report the global fail at the
end. This may help reduce CI/review cycle time if/when multiple docs
are submitted in a single PR.

Also spit out a URL link to the documentation repo docs in the case
of failure, to help direct authors to guidance docs.

Fixes: #2227

Signed-off-by: Graham Whaley <graham.whaley@intel.com>