### PR TITLE
ci: Fix kubernetes installation for Fedora 31

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -64,6 +64,14 @@ elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
 	gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF"
 
+	# This issue is related with https://github.com/kubernetes/kubernetes/issues/60134
+	if [ "$ID" == "fedora" ] && [ "$VERSION_ID" == "31" ]; then
+		chronic sudo -E sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/kubernetes.repo
+		chronic sudo -E rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg
+		chronic sudo -E rpm --import https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+		chronic sudo -E yum -y clean all
+	fi
+
 	chronic sudo -E sed -i 's/^[ \t]*//' /etc/yum.repos.d/kubernetes.repo
 	install_kubernetes_version=$(echo $kubernetes_version | cut -d'-' -f1)
 	chronic sudo -E yum -y update


### PR DESCRIPTION
We need to import the gpg keys and disable the gpgcheck from the
/yum/repos.d/kubernetes repository as it is not possible to perform
the installation of the kubernetes components, this issue is related
with https://github.com/kubernetes/kubernetes/issues/60134.

Fixes #2233

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>