### PR TITLE
cleanup: delete what mktemp creates

### DIFF
--- a/.ci/aarch64/clean_up_aarch64.sh
+++ b/.ci/aarch64/clean_up_aarch64.sh
@@ -11,3 +11,12 @@ lib_script="${GOPATH}/src/${tests_repo}/.ci/lib.sh"
 source "${lib_script}"
 
 gen_clean_arch || info "Arch cleanup scripts failed"
+
+## Cleaning up stale files under $TMPDIR of last CI run
+## $TMPDIR has been set as "/tmp/kata-containers" on all ARM CI node.
+if [ "${TMPDIR}" != "/tmp" ]; then
+	if [ -n "$(ls -A "${TMPDIR}")" ]; then
+                echo "WARNING: ${TMPDIR} is Not Empty"
+                sudo -E sh -c "rm -rf "${TMPDIR}""
+        fi
+fi

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -73,6 +73,12 @@ if [ "${BAREMETAL}" == true ]; then
 	fi
 fi
 
+# $TMPDIR may be set special value on BAREMETAL CI.
+# e.g. TMPDIR="/tmp/kata-containers" on ARM CI node.
+if [ -n "${TMPDIR}" ]; then
+	mkdir -p "${TMPDIR}"
+fi
+
 pushd "${kata_repo_dir}"
 
 pr_number=

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -100,6 +100,8 @@ kubeadm_config_file="$(mktemp --tmpdir kubeadm_config.XXXXXX.yaml)"
 sed -e "s|CRI_RUNTIME_SOCKET|${cri_runtime_socket}|" "${kubeadm_config_template}" > "${kubeadm_config_file}"
 sed -i "s|KUBERNETES_VERSION|v${kubernetes_version/-*}|" "${kubeadm_config_file}"
 
+trap 'sudo -E sh -c "rm -r "${kubeadm_config_file}""' EXIT
+
 if [ "${BAREMETAL}" == true ] && [[ $(wc -l /proc/swaps | awk '{print $1}') -gt 1 ]]; then
 	sudo swapoff -a || true
 fi

--- a/integration/stability/bind_mount_linux.sh
+++ b/integration/stability/bind_mount_linux.sh
@@ -25,7 +25,7 @@ source "${cidir}/../../lib/common.bash"
 IMAGE="${IMAGE:-busybox}"
 CONTAINER_NAME="${CONTAINER_NAME:-test}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
-TMP_DIR=$(mktemp -d --tmpdir=/tmp ${testname}.XXX)
+TMP_DIR=$(mktemp -d --tmpdir ${testname}.XXX)
 MOUNT_DIR="${TMP_DIR}/mount"
 BIND_DST="${MOUNT_DIR}/dst"
 BIND_SRC="${TMP_DIR}/src"


### PR DESCRIPTION
I've found some stale files under `/tmp` on ARM CI:
 ```
-rw-------   1 root    root       384 Jan 14 02:49 kubeadm_config.0rtpew.yaml
                    .............
-rw-------   1 root    root       290 Jan 14 23:08 pod_config.1fs8Z1.yaml
                   ..............
```
`mktemp` creates a temporary file or directory under `/tmp`.
It's caller's responsibility to delete them when it is in no use.
