### PR TITLE
k8s: e2e: Enable podOverhead feature and modify skipped tests

### DIFF
--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -8,9 +8,7 @@
 
 containerd:
   - SchedulerPredicates
-  - should ensure that all pods are removed when a namespace is deleted
+  - Daemon set \[Serial\] should rollback without unnecessary restarts
 
 crio:
-  - InitContainer
-  - Projected downwardAPI
-  - Downward API
+  - Daemon set \[Serial\] should rollback without unnecessary restarts

--- a/integration/kubernetes/kubeadm/config.yaml
+++ b/integration/kubernetes/kubeadm/config.yaml
@@ -12,3 +12,21 @@ networking:
   dnsDomain: cluster.local
   podSubnet: 10.244.0.0/16
   serviceSubnet: 10.96.0.0/12
+apiServer:
+  extraArgs:
+    feature-gates: PodOverhead=true
+scheduler:
+  extraArgs:
+    feature-gates: PodOverhead=true
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: cgroupfs
+featureGates:
+  PodOverhead: true
+systemReserved:
+  cpu: 500m
+  memory: 256Mi
+kubeReserved:
+  cpu: 500m
+  memory: 256Mi

--- a/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
@@ -3,3 +3,7 @@ apiVersion: node.k8s.io/v1beta1
 metadata:
   name: kata
 handler: kata
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"

--- a/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -15,12 +15,12 @@ spec:
     command: ["tail", "-f", "/dev/null"]
     resources:
       limits:
-        cpu: "1"
+        cpu: "500m"
   - name: c2
     image: busybox
     command:
       - sleep
-      - "1"
+      - "10"
     resources:
       limits:
-        cpu: "1"
+        cpu: "500m"


### PR DESCRIPTION
We are using k8s 1.16, so we can enable PodOverhead alpha
feature for our testing.

In addition, modify skipped tests:
- Remove `Downward API` tests from the list of skipped tests.
  These tests pass when enabling the `PodOverhead` feature on
  kubernetes.
- Add a `Daemon set` test which requires to have a cluster
  with at least two nodes.
    
Fixes: #2242.

