### PR TITLE
spelling: Add vhost to spell check dictionary

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -75,6 +75,7 @@ VETH/AB
 VF/AB
 VFIO/AB
 VGPU/AB
+vhost/AB
 VHOST/AB
 virtio/AB
 VirtIO/AB


### PR DESCRIPTION
Add the lowercase vhost to the spell checker dictionary.

Fixes: #2245.

Signed-off-by: Liu Xiaodong <xiaodong.liu@intel.com>