### PR TITLE
ci: Enable ci for CentOS8

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -9,6 +9,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source /etc/os-release || source /usr/lib/os-release
+issue="https://github.com/cri-o/cri-o/issues/3130"
+
+if [ "$ID" == "centos" ]; then
+	echo "Skip CRI-O installation on $ID, see: $issue"
+	exit
+fi
+
 crio_config_file="/etc/crio/crio.conf"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/kata-runtime"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -12,6 +12,12 @@ set -o pipefail
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
+issue="https://github.com/cri-o/cri-o/issues/3130"
+
+if [ "$ID" == "centos" ]; then
+	echo "Skip CRI-O installation on $ID, see: $issue"
+	exit
+fi
 
 echo "Install go-md2man"
 go_md2man_url=$(get_test_version "externals.go-md2man.url")

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -48,6 +48,10 @@ fi
 echo "Install chronic"
 sudo -E yum -y install moreutils
 
+if [ "$centos_version" == "8" ]; then
+	chronic sudo -E yum install pkgconf-pkg-config
+fi 
+
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-GB hunspell-en-US pandoc" \
 	[xml_validator]="libxml2" \
@@ -55,24 +59,22 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[kata_containers_dependencies]="libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 device-mapper-devel libtool-ltdl" \
+	[kata_containers_dependencies]="libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 libtool-ltdl" \
 	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel" \
 	[kernel_dependencies]="elfutils-libelf-devel flex pkgconfig" \
-	[crio_dependencies]="glibc-static libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs btrfs-progs-devel util-linux libselinux-devel" \
+	[crio_dependencies]="libassuan-devel libgpg-error-devel device-mapper-libs util-linux libselinux-devel" \
 	[bison_binary]="bison" \
 	[libgudev1-dev]="libgudev1-devel" \
 	[general_dependencies]="gpgme-devel glib2-devel glibc-devel bzip2 m4 gettext-devel automake autoconf pixman-devel coreutils" \
 	[build_tools]="python3 pkgconfig zlib-devel" \
 	[ostree]="ostree-devel" \
 	[metrics_dependencies]="jq" \
-	[cri-containerd_dependencies]="libseccomp-devel btrfs-progs-devel" \
 	[crudini]="crudini" \
 	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[gnu_parallel_dependencies]="perl bzip2 make" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
-	[versionlock]="yum-versionlock" \
 )
 
 main()

--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -8,8 +8,14 @@
 # shimv2 + containerd + cri
 
 source /etc/os-release || source /usr/lib/os-release
-
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+if [ "$ID" == "centos" ]; then
+	echo "Skip installation on $ID"
+	exit
+fi
+
+
 ${SCRIPT_PATH}/../../../.ci/install_cri_containerd.sh
 
 cni_bin_path="/opt/cni"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -16,9 +16,11 @@ arch="$(uname -m)"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-# Currently, Kubernetes tests only work on Ubuntu, Centos and Fedora.
+# Currently, Kubernetes tests only work on Ubuntu and Fedora.
 # We should delete this condition, when it works for other Distros.
-if [ "$ID" != "ubuntu" ] && [ "$ID" != "centos" ] && [ "$ID" != "fedora" ]; then
+# In the case of CentOS once that issue https://github.com/cri-o/cri-o/issues/3130
+# is being fixed we can enable Kubernetes tests.
+if [ "$ID" != "ubuntu" ] && [ "$ID" != "fedora" ]; then
 	echo "Skip Kubernetes tests on $ID"
 	echo "kubernetes tests on $ID aren't supported yet"
 	exit 0


### PR DESCRIPTION
This PR removes non-existing packages for CentOS 8 as also skips the
CRI-O, kubernetes, and shimv2 installation mainly because of missing packages as dependencies.

Fixes #2247

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>