### PR TITLE
ci: Setup podman for the cgroupsv2+podman ci

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -13,6 +13,7 @@ source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 MACHINETYPE="${MACHINETYPE:-pc}"
+TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 arch=$("${cidir}"/kata-arch.sh -d)
 
@@ -113,15 +114,17 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	fi
 fi
 
-case "${KATA_HYPERVISOR}" in
-	"cloud-hypervisor" | "qemu")
-		echo "Add kata-runtime as a new/default Docker runtime."
-		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
-		;;
-	*)
-		echo "Kata runtime will not set as a default in Docker"
-		;;
-esac
+if [ "${TEST_CGROUPSV2}" == "false" ]; then
+	case "${KATA_HYPERVISOR}" in
+		"cloud-hypervisor" | "qemu")
+			echo "Add kata-runtime as a new/default Docker runtime."
+			"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
+			;;
+		*)
+			echo "Kata runtime will not set as a default in Docker"
+			;;
+	esac
+fi
 
 if [ "$MACHINETYPE" == "q35" ]; then
 	echo "Use machine_type q35"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,6 +22,7 @@ CRIO="${CRIO:-yes}"
 CRI_CONTAINERD="${CRI_CONTAINERD:-no}"
 KUBERNETES="${KUBERNETES:-yes}"
 OPENSHIFT="${OPENSHIFT:-yes}"
+TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 setup_distro_env() {
 	local setup_type="$1"
@@ -46,6 +47,11 @@ setup_distro_env() {
 }
 
 install_docker() {
+	if [ "${TEST_CGROUPSV2}" == "true" ]; then
+		info "Docker won't be installed: testing cgroups V2"
+		return
+	fi
+
 	if ! command -v docker >/dev/null; then
 		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
 	fi

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -10,9 +10,15 @@ set -e
 cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
+TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 echo "Install chronic"
 sudo -E dnf -y install moreutils
+
+if [ "${TEST_CGROUPSV2}" == "true" ]; then
+	echo "Install podman"
+	sudo -E dnf -y install podman
+fi
 
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-GB hunspell-en-US pandoc" \


### PR DESCRIPTION
This PR avoids the installation of docker and the configuration of
the runtime with docker as also uses podman to build the image.

Fixes #2250

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>