### PR TITLE
ci: Fix TEST_CGROUPSV2 unbound variable

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -28,6 +28,7 @@ ARCH="$(${cidir}/kata-arch.sh -d)"
 
 AGENT_INIT=${AGENT_INIT:-no}
 TEST_INITRD=${TEST_INITRD:-no}
+TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 PREFIX=${PREFIX:-/usr}
 IMAGE_DIR=${PREFIX}/share/kata-containers


### PR DESCRIPTION
We need to set the variable TEST_CGROUPSV2 as not all the jobs will have it.

Fixes #2252

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>