### PR TITLE
integration/docker: increment amount of memory in docker mem tests

### DIFF
--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -90,9 +90,9 @@ var _ = Describe("Hotplug memory when create containers", func() {
 
 			Expect(RemoveDockerContainer(id)).To(BeTrue())
 		},
-		withDockerMemory(100*1024*1024),
-		withDockerMemory(200*1024*1024),
 		withDockerMemory(500*1024*1024),
+		withDockerMemory(640*1024*1024),
+		withDockerMemory(768*1024*1024),
 		withDockerMemory(1024*1024*1024),
 	)
 })


### PR DESCRIPTION
When `sandbox_cgroup_only` is `true`, all cgroups are honoured and all kata
components (including hypervisor) are placed in the same cgroup.
Hypervisor + kata components may consume more than 100MB of RAM, hence memory
cgroup must be big enough to contain them.

fixes #2254

Signed-off-by: Julio Montes <julio.montes@intel.com>