### PR TITLE
setup: clh: do not clone more than one time.

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -36,7 +36,7 @@ install_clh() {
 	go get -d "${go_cloud_hypervisor_repo}" || true
 	# This may be downloaded before if there was a depends-on in PR, but 'go get' wont make any problem here
 	go get -d "${packaging_repo}" || true
-	pushd "${GOPATH}/src/${go_cloud_hypervisor_repo}"
+	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
 	# packaging build script expects run in the hypervisor repo parent directory
 	# It will find the hypervisor repo and checkout to the version exported above
 	${GOPATH}/src/${packaging_repo}/static-build/cloud-hypervisor/build-static-clh.sh


### PR DESCRIPTION
packaging installer script will clone the hypervisor repository,
if is not found, because test setup goes to the repository and
not the parent directory, it clones the hypervisor two times.

Fixes: #2258

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>