### PR TITLE
ci: Fix unbound variable on common.bash

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -26,6 +26,7 @@ KATA_TESTS_DATADIR="${KATA_TESTS_DATADIR:-${KATA_TESTS_BASEDIR}/data}"
 KATA_TESTS_CACHEDIR="${KATA_TESTS_CACHEDIR:-${KATA_TESTS_BASEDIR}/cache}"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+experimental_qemu="${experimental_qemu:-false}"
 
 die() {
 	local msg="$*"


### PR DESCRIPTION
This PR fixes the issue of unbound variable on common.bash for experimental qemu.

Fixes #2244

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>