### PR TITLE
backport-1.10: CI: do not use latest version of yq

### DIFF
--- a/.ci/install_yq.sh
+++ b/.ci/install_yq.sh
@@ -20,12 +20,9 @@ function install_yq() {
 
 	mkdir -p "${GOPATH}/bin"
 
-	# Workaround to get latest release from github (to not use github token).
-	# Get the redirection to latest release on github.
-	yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
-	# The redirected url should include the latest release version
-	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
-	yq_version=$(basename "${yq_latest_url}")
+	# Stick to a specific version. Same used in
+	# runtime and osbuilder repos.
+	yq_version=2.3.0
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"


### PR DESCRIPTION
This is backport of #2275 

latest version of `yq` is not expanding anchors correctly and
we are having failures when building the initrd.
Let's stick to version 2.3.0 which is also used in runtime
and osbuilder repos.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>