### PR TITLE
AArch64: fix unstable ARM CI

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -26,8 +26,9 @@ docker:
     - Hotplug memory when create containers
     - run container and update its memory constraints
     - Checking CPU cgroups in the host
-    - check yum update
   Context:
+    - check dnf update
+    - check yum update
   It:
 
 kubernetes:

--- a/.ci/aarch64/kubernetes/init.sh
+++ b/.ci/aarch64/kubernetes/init.sh
@@ -15,8 +15,9 @@ curl -fsL $flannel_url -o $network_plugin_config_file
 memory_resource="spec.template.spec.containers[*].resources.*.memory"
 # install yq if not exist
 ${SCRIPT_PATH}/../../.ci/install_yq.sh
-# original flannel has limitation and request for memory, it may cause OOM on AArch64
-# so we delete related config on AArch64
-sudo -E ${GOPATH}/bin/yq d -i -d5 $network_plugin_config_file $memory_resource  > /dev/null
+# Default flannel config has limitation and request for memory, and it may cause OOM on AArch64.
+# Though here, we delete memory limitation for all archs, this modified-configuration
+# file will only be applied on aarch64.
+sudo -E ${GOPATH}/bin/yq d -i -d'*' $network_plugin_config_file $memory_resource  > /dev/null
 
 network_plugin_config="$network_plugin_config_file"


### PR DESCRIPTION
# Description of problem
Hi~ guys
I'm so sorry that, lately, ARM CI is quite unstable. 
I've already debugged a few issues. I'll elaborate and fix them here.

### Updates:
- [x]  **re-refine flannel config on AArch64**

On PR #1809, we edited config file for pod flannel `kube-flannel.yml`, in order to delete the default 50M memory limitation for flannel pod on AArch64.
Recently, this config file has been updated on upstream, which leads to above modification ineffective. 

- [x] **skip `check dnf update` docker test**

We have elaborated this issue in [kata-containers/ci#245](https://github.com/kata-containers/ci/issues/245).
Lately, this failure on `check dnf update` docker test occurred frequently, almost six, or seven times of ten trials. 


