### PR TITLE
makefile: Fix configuration file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ FILTER_FILE = .ci/filter/filter_docker_test.sh
 # skipped docker integration tests for Firecraker
 # Firecracker configuration file
 FIRECRACKER_CONFIG = .ci/hypervisors/firecracker/configuration_firecracker.yaml
-# Firecracker configuration file
+# Cloud hypervisor configuration file
 CLH_CONFIG = .ci/hypervisors/clh/configuration_clh.yaml
 ifneq ($(wildcard $(FILTER_FILE)),)
 SKIP_FIRECRACKER := $(shell bash -c '$(FILTER_FILE) $(FIRECRACKER_CONFIG)')


### PR DESCRIPTION
This PR fixes the comment about the Cloud hypervisor configuration file.

Fixes #2295

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>