### PR TITLE
ci: update yq to v3.1.0

### DIFF
--- a/.ci/install_yq.sh
+++ b/.ci/install_yq.sh
@@ -5,12 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -eu
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
 
 function install_yq() {
 	local cidir=$(dirname "${BASH_SOURCE[0]}")
 	# source lib.sh to make sure GOPATH is set
-	source ${cidir}/lib.sh
+	source "${cidir}/lib.sh"
 	[ -x  "${GOPATH}/bin/yq" ] && return
 
 	local yq_path="${GOPATH}/bin/yq"
@@ -22,12 +25,13 @@ function install_yq() {
 
 	# Stick to a specific version. Same used in
 	# runtime and osbuilder repos.
-	yq_version=2.3.0
+	local yq_version=3.1.0
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"
-	curl -o "${yq_path}" -LSsf ${yq_url}
-	chmod +x ${yq_path}
+	curl -o "${yq_path}" -LSsf "${yq_url}"
+	chmod +x "${yq_path}"
+	echo "Installed $(${yq_path} --version)"
 
 	if ! command -v "${yq_path}" >/dev/null; then
 		die "Cannot not get ${yq_path} executable"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -125,7 +125,7 @@ function get_dep_from_yaml_db(){
 
 	"${GOPATH}/src/${tests_repo}/.ci/install_yq.sh" >&2
 
-	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")
+	result=$("${GOPATH}/bin/yq" r -X "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""
 	echo "$result"
 }


### PR DESCRIPTION
v3.1.0 fixes reading anchors and also fixes an issue reading the
yaml file on ARM systems.
`yq` 3.1.0 now requires to pass `-X` when reading Anchors, so adding
it to our `get_dep_from_yaml_db` function.

Fixes: #2290.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>