### PR TITLE
ci: Skip running unit tests with podman

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -168,6 +168,8 @@ if [ -z "${METRICS_CI}" ]; then
 	if [ "${kata_repo}" != "${tests_repo}" ]; then
 		if [ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ]; then
 			echo "INFO: issue ${unit_issue}"
+		elif [ "${CI_JOB}" == "PODMAN" ]; then
+			echo "INFO: Unit tests skipped when running with podman"
 		else
 			echo "INFO: Running unit tests for repo $kata_repo"
 			make test


### PR DESCRIPTION
As we are not doing the setup and installation of virtcontainers, we need
to skip running the unit tests for podman CI.

Depends-on: github.com/kata-containers/runtime#2452

Fixes #2298 

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>