### PR TITLE
ci: Do not install and run kubernetes on Fedora

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -16,11 +16,11 @@ arch="$(uname -m)"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-# Currently, Kubernetes tests only work on Ubuntu and Fedora.
+# Currently, Kubernetes tests only work on Ubuntu.
 # We should delete this condition, when it works for other Distros.
 # In the case of CentOS once that issue https://github.com/cri-o/cri-o/issues/3130
 # is being fixed we can enable Kubernetes tests.
-if [ "$ID" != "ubuntu" ] && [ "$ID" != "fedora" ]; then
+if [ "$ID" != "ubuntu" ]; then
 	echo "Skip Kubernetes tests on $ID"
 	echo "kubernetes tests on $ID aren't supported yet"
 	exit 0


### PR DESCRIPTION
We have seen random failures when we are trying to enable kubernetes repository
in Fedora 31. There are some times that the Fedora CI is failing when we
try to import the gpgkey from the kubernetes repository
(https://packages.cloud.google.com/yum/doc/yum-key.gpg). This PR removes
that we install and run kubernetes on Fedora.

Fixes #2302

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>