### PR TITLE
ci: Allow to run unit tests

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -168,8 +168,6 @@ if [ -z "${METRICS_CI}" ]; then
 	if [ "${kata_repo}" != "${tests_repo}" ]; then
 		if [ "${ID}" == "rhel" ] && [ "${kata_repo}" == "${runtime_repo}" ]; then
 			echo "INFO: issue ${unit_issue}"
-		elif [ "${CI_JOB}" == "PODMAN" ]; then
-			echo "INFO: Unit tests skipped when running with podman"
 		else
 			echo "INFO: Running unit tests for repo $kata_repo"
 			make test


### PR DESCRIPTION
In some of the kata repositories is possible to run the unit tests,
this PR allows to run them.

Fixes #2306

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>