### PR TITLE
tests: Add more e2e podman integration tests

### DIFF
--- a/.ci/podman/configuration_podman.yaml
+++ b/.ci/podman/configuration_podman.yaml
@@ -130,3 +130,24 @@ podman:
     - podman create using existing name
     - podman init latest container
     - podman run with bad healthcheck timeout
+    - podman search limit flag
+    - podman start after signal kill
+    - podman run entrypoint with user cmd overrides image cmd
+    - podman run user entrypoint overrides image entrypoint and image cmd
+    - podman run user entrypoint with command overrides image entrypoint and image cmd
+    - podman save to directory with docker format and compression
+    - podman save to directory with v2s2 docker format
+    - podman save oci flag
+    - podman kill latest container
+    - podman kill a running container by name
+    - podman kill a running container by id
+    - podman exec environment test
+    - podman exec simple command
+    - podman exec simple command with user
+    - podman exec simple working directory test
+    - podman port nginx by name
+    - podman mount many
+    - podman wait on latest container
+    - podman start multiple containers
+    - podman umount many
+    - podman init single container by name


### PR DESCRIPTION
This PR adds more e2e podman integration tests to the yaml so they
can run in the CI.

Fixes #2315

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>