### PR TITLE
test: metrics: add virtiofsd to memory measure list

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -114,6 +114,7 @@ extract_kata_env(){
 
 			HYPERVISOR_PATH=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 			HYPERVISOR_VERSION=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  Version =/ { if (foundit==1) {$1=$2=""; print $0; foundit=0} } ' <<< "$toml" | sed 's/"//g')
+			VIRTIOFSD_PATH=$(awk '/^\[Hypervisor\]$/ {foundit=1} /^  VirtioFSDaemon =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 
 			INITRD_PATH=$(awk '/^\[Initrd\]$/ {foundit=1} /^  Path =/ { if (foundit==1) {print $3; foundit=0} } ' <<< "$toml" | sed 's/"//g')
 

--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -180,14 +180,16 @@ function grab_vm_uss() {
 	proxy=$(get_proc_uss $PROXY_PATH)
 	shim=$(get_proc_uss $SHIM_PATH)
 	qemu=$(get_proc_uss $HYPERVISOR_PATH)
+	virtiofsd=$(get_proc_uss $VIRTIOFSD_PATH)
 
-	total=$((proxy + shim + qemu))
+	total=$((proxy + shim + qemu + virtiofsd))
 
 	local json="$(cat << EOF
 		"uss": {
 			"proxy": $proxy,
 			"shim": $shim,
 			"qemu": "$qemu",
+			"virtiofsd": "$virtiofsd",
 			"total": $total,
 			"Units": "KB"
 		}
@@ -202,14 +204,16 @@ function grab_vm_pss() {
 	proxy=$(get_proc_pss $PROXY_PATH)
 	shim=$(get_proc_pss $SHIM_PATH)
 	qemu=$(get_proc_pss $HYPERVISOR_PATH)
+	virtiofsd=$(get_proc_pss $VIRTIOFSD_PATH)
 
-	total=$((proxy + shim + qemu))
+	total=$((proxy + shim + qemu + virtiofsd))
 
 	local json="$(cat << EOF
 		"pss": {
 			"proxy": $proxy,
 			"shim": $shim,
 			"qemu": "$qemu",
+			"virtiofsd": "$virtiofsd",
 			"total": $total,
 			"Units": "KB"
 		}

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -168,14 +168,16 @@ function grab_vm_uss() {
 	proxy=$(get_proc_uss $PROXY_PATH)
 	shim=$(get_proc_uss $SHIM_PATH)
 	qemu=$(get_proc_uss $HYPERVISOR_PATH)
+	virtiofsd=$(get_proc_uss $VIRTIOFSD_PATH)
 
-	total=$((proxy + shim + qemu))
+	total=$((proxy + shim + qemu + virtiofsd))
 
 	local json="$(cat << EOF
 		"uss": {
 			"proxy": $proxy,
 			"shim": $shim,
 			"qemu": "$qemu",
+			"virtiofsd": "$virtiofsd",
 			"total": $total,
 			"Units": "KB"
 		}
@@ -190,14 +192,16 @@ function grab_vm_pss() {
 	proxy=$(get_proc_pss $PROXY_PATH)
 	shim=$(get_proc_pss $SHIM_PATH)
 	qemu=$(get_proc_pss $HYPERVISOR_PATH)
+	virtiofsd=$(get_proc_pss $VIRTIOFSD_PATH)
 
-	total=$((proxy + shim + qemu))
+	total=$((proxy + shim + qemu + virtiofsd))
 
 	local json="$(cat << EOF
 		"pss": {
 			"proxy": $proxy,
 			"shim": $shim,
 			"qemu": "$qemu",
+			"virtiofsd": "$virtiofsd",
 			"total": $total,
 			"Units": "KB"
 		}


### PR DESCRIPTION
As virtiofs enabled in kata, virtiofsd will run as a standalone binary.
it will contribute to memory footprint of kata so we should add
virtiofsd into metrics memory measure list.

This commit depends on if virtiofsd can be added into kata-env, whose PR is  https://github.com/kata-containers/runtime/pull/2492.
Fixes: #2321
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel  @devimc  @grahamwhaley  @Pennyzct 