### PR TITLE
spellcheck: add project works for EFK stack etc.

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -18,6 +18,7 @@ Docker/B
 dracut/B
 Facebook/B
 fio/B
+Fluentd/B
 Frakti/B
 Git/B
 GitHub/B
@@ -31,6 +32,7 @@ Istio/B
 Jenkins/B
 journald/B
 Kata/B
+Kibana/B
 Kubelet/B
 Kubernetes/B
 Launchpad/B
@@ -39,6 +41,7 @@ libcontainer/B
 libvirt/B
 Linkerd/B
 Logrus/B
+Logstash/B
 Mellanox/B
 Minikube/B
 MITRE/B


### PR DESCRIPTION
Add the relevant project names so we can type about EFK and ELK
stacks etc.

Fixes: #2333

Signed-off-by: Graham Whaley <graham.whaley@intel.com>