### PR TITLE
versions: Update podman version to 1.8.0 and remove port nginx test

### DIFF
--- a/.ci/podman/configuration_podman.yaml
+++ b/.ci/podman/configuration_podman.yaml
@@ -145,7 +145,6 @@ podman:
     - podman exec simple command
     - podman exec simple command with user
     - podman exec simple working directory test
-    - podman port nginx by name
     - podman mount many
     - podman wait on latest container
     - podman start multiple containers

--- a/versions.yaml
+++ b/versions.yaml
@@ -65,7 +65,7 @@ externals:
 
   podman:
     description: "An open-source Linux tool for working with containers"
-    version: "1.6.2"
+    version: "1.8.0"
 
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"


### PR DESCRIPTION
We need to update podman version to 1.8.0 as currently with version 1.6.2
we have issues trying to download the images. We also need to remove port nginx
test as has random failures with this new podman version.

Fixes #2336

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>