### PR TITLE
ci: static: markdown: make list var func local

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -68,7 +68,7 @@ paths_to_skip=(
 skip_paths(){
 	local list_param="${1}"
 	[ -z "$list_param" ] && return
-	list=(${list_param})
+	local list=(${list_param})
 
 	for p in "${paths_to_skip[@]}"; do
 		new_list=()


### PR DESCRIPTION
The `list` var in the skip_paths function was not local, thus
afiact, rendering it global. Thus, when skip_paths was called
more than once, the list grew and grew, and included the unfiltered
files, including vendor files.

Fix by making it local, so it is built afresh on each function
invocation.

Fixes: #2338

Signed-off-by: Graham Whaley <graham.whaley@intel.com>