### PR TITLE
ci: Update docker version for openSUSE and SLES

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -138,7 +138,7 @@ install_docker(){
 			sudo -E apt-get -y install "${pkg_name}=${docker_version_full}"
 		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
 			sudo zypper removelock docker
-			sudo zypper -n  install 'docker<18.09'
+			sudo zypper -n  install 'docker<19.03'
 			sudo zypper addlock docker
 		fi
 	elif [ "$tag" == "swarm" ]; then


### PR DESCRIPTION
openSUSE Leap and SLES does not longer support docker 18.06, they required
as a minimum docker 18.09. This PR updates that version without affecting anything,
as docker 18.09 in openSUSE and SLES supports devicemapper.

Fixes #2342

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>