### PR TITLE
test: Skip state functional test for Debian 10

### DIFF
--- a/functional/state_test.go
+++ b/functional/state_test.go
@@ -60,6 +60,10 @@ var _ = Describe("state", func() {
 			if distroID() == "centos" {
 				Skip("Issue:https://github.com/kata-containers/tests/issues/2264")
 			}
+
+			if distroID() == "debian" {
+				Skip("Issue:https://github.com/kata-containers/tests/issues/2348")
+			}
 			_, stderr, exitCode := container.Run()
 			Expect(exitCode).To(Equal(0))
 			Expect(stderr).To(BeEmpty())


### PR DESCRIPTION
Currently, we have seen random failures on state functional test. We
will investigate the root cause of this failure but in order to have
a more stable CI we need to skip it.

Fixes #2348

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>