### PR TITLE
static_checks: fix `skip_paths` function

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -73,7 +73,7 @@ skip_paths(){
 	for p in "${paths_to_skip[@]}"; do
 		new_list=()
 		for l in "${list[@]}"; do
-			if echo "${l}" | grep -v "${p}"; then
+			if echo "${l}" | grep -qv "${p}"; then
 				new_list=("${new_list[@]}" "${l}")
 			fi
 		done


### PR DESCRIPTION
`skip_paths()` output was being contaminated with the
`grep` output inside the function. Use `grep -q` to silence
the output of `grep`.

Fixes: #2338.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>