### PR TITLE
test: Update package manager test for Fedora

### DIFF
--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -73,7 +73,10 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
 				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
 			}
-			args = append(args, "-td", "--name", id, FedoraImage, "sh")
+
+			// This Fedora version is used mainly because of https://github.com/kata-containers/tests/issues/2358
+			fedoraVersion := "30"
+			args = append(args, "-td", "--name", id, FedoraImage+":"+fedoraVersion, "sh")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())
 


### PR DESCRIPTION
Performing a dnf -y update on a fedora container 31 is failing as
it is complaining about a missing rpm package. This PR removes the option
to use latest Fedora and use Fedora 30 which shows a stable behaviour.

Fixes #2359

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>