### PR TITLE
tests: e2e: Update Sonobuoy to 0.17.2

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -70,4 +70,4 @@ externals:
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"
-    version: "0.16.4"
+    version: "0.17.2"


### PR DESCRIPTION
Now that we have updated our supported k8s version to 1.17,
use Sonobuoy 0.17.2 to run e2e k8s tests.

Fixes: #2361.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>