### PR TITLE
ci: Enable CPU hot-plug tests for cloud-hypervisor

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -12,7 +12,6 @@ docker:
   Describe:
     - CPU constraints
     - CPUs and CPU set
-    - Hot plug CPUs
     - Hotplug memory when create containers
     - Update CPU constraints
     - Update number of CPUs


### PR DESCRIPTION
This patch brings back the docker integration tests on CPU hot-plug for our
cloud-hypervisor CI.

Fixes: #2363

Depends-on: kata-containers/runtime#2509
Depends-on: kata-containers/packaging#968

Signed-off-by: Bo Chen <chen.bo@intel.com>