### PR TITLE
integration/docker: pull fedora 30 image before using it

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -35,6 +35,10 @@ const (
 	// FedoraImage is the fedora image
 	FedoraImage = "fedora"
 
+	// Fedora30Image is the fedora 30 image
+	// This Fedora version is used mainly because of https://github.com/kata-containers/tests/issues/2358
+	Fedora30Image = "fedora:30"
+
 	// StressImage is the vish/stress image
 	StressImage = "vish/stress"
 
@@ -103,6 +107,7 @@ func init() {
 		AlpineImage,
 		DebianImage,
 		FedoraImage,
+		Fedora30Image,
 		CentosImage,
 		StressImage,
 	}

--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -75,8 +75,7 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 			}
 
 			// This Fedora version is used mainly because of https://github.com/kata-containers/tests/issues/2358
-			fedoraVersion := "30"
-			args = append(args, "-td", "--name", id, FedoraImage+":"+fedoraVersion, "sh")
+			args = append(args, "-td", "--name", id, Fedora30Image, "sh")
 			_, _, exitCode := dockerRun(args...)
 			Expect(exitCode).To(BeZero())
 


### PR DESCRIPTION
In order to avoid random timeouts, docker images must be pulled before
running `docker run`

fixes #2366

Signed-off-by: Julio Montes <julio.montes@intel.com>