### PR TITLE
ci: Bring back docker integration tests since yq v3.1

### DIFF
--- a/.ci/filter/filter_docker_test.sh
+++ b/.ci/filter/filter_docker_test.sh
@@ -25,7 +25,7 @@ filter_and_build()
 {
 	local dependency="$1"
 	local array_docker=$("${GOPATH_LOCAL}/bin/yq" read "${test_config_file}" "${dependency}")
-	[ "${array_docker}" = "null" ] && return
+	( [ "${array_docker}" = "null" ] || [ "${array_docker}" = "" ] ) && return
 	mapfile -t _array_docker <<< "${array_docker}"
 	for entry in "${_array_docker[@]}"
 	do

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -160,6 +160,7 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export OPENSHIFT="no"
 	export TEST_CRIO="false"
+	export TEST_DOCKER="true"
 	export experimental_kernel="true"
 	;;
 esac


### PR DESCRIPTION
All docker integration tests have not been running since yq was updated
to v3.1 (for at least 12 days). The root cause is that yq v3.1 is no
longer returning 'null' as empty strings. To be safe, we keep checks on
both 'null' and '""' (empty string). Also, we observed some regression
test failures with this patch (at least for CIs on ubuntu-initrd, clh,
and Fedoba31).

Fixes: #2368

Signed-off-by: Bo Chen <chen.bo@intel.com>
Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>
Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>