### PR TITLE
ci: Set noninteractive on Ubuntu and Debian

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -9,6 +9,11 @@ set -e
 
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+# Run noninteractive on debian and ubuntu
+if [ "$ID" == "debian" ] || [ "$ID" == "ubuntu" ]; then
+	export DEBIAN_FRONTEND=noninteractive
+fi
+
 # Unit test issue for RHEL
 unit_issue="https://github.com/kata-containers/runtime/issues/1517"
 


### PR DESCRIPTION
This will set the noninteractive mode for Ubuntu and Debian.

Fixes #2371

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>