### PR TITLE
clh: docker: Skip CPU hotplug test

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -12,6 +12,7 @@ docker:
   Describe:
     - CPU constraints
     - CPUs and CPU set
+    - Hot plug CPUs
     - Hotplug memory when create containers
     - Update CPU constraints
     - Update number of CPUs


### PR DESCRIPTION
Skip test that got a regression while docker tests were skipped.

Fixes: #2376

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>