### PR TITLE
test:docker: Use the right hypervisor when reading from KataConfig

### DIFF
--- a/.ci/hypervisors/firecracker/configuration_firecracker.yaml
+++ b/.ci/hypervisors/firecracker/configuration_firecracker.yaml
@@ -39,6 +39,7 @@ docker:
     - memory constraints
     - Hotplug memory when create containers
     - run container and update its memory constraints
+    - vsock test
   Context:
     - remove bind-mount source before container exits
   It:

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,12 @@ endif
 
 ifeq ($(KATA_HYPERVISOR),firecracker)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP_FIRECRACKER}" \
-		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT} \
+		-hypervisor=$(KATA_HYPERVISOR)
 else ifeq ($(KATA_HYPERVISOR),cloud-hypervisor)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP_CLH}" \
-		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
+		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT} \
+		-hypervisor=$(KATA_HYPERVISOR)
 else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x ppc64le))
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}

--- a/command.go
+++ b/command.go
@@ -19,6 +19,9 @@ var Runtime string
 // Timeout specifies the time limit in seconds for each test
 var Timeout int
 
+// Hypervisor is the hypervisor currently being used with Kata
+var Hypervisor string
+
 // Command contains the information of the command to run
 type Command struct {
 	// cmd exec.Cmd
@@ -31,6 +34,7 @@ type Command struct {
 func init() {
 	flag.StringVar(&Runtime, "runtime", "", "Path of the desired Kata Runtime")
 	flag.IntVar(&Timeout, "timeout", 5, "Time limit in seconds for each test")
+	flag.StringVar(&Hypervisor, "hypervisor", "", "The hypervisor currently being used with Kata")
 
 	flag.Parse()
 }

--- a/config.go
+++ b/config.go
@@ -92,6 +92,7 @@ const (
 
 // KataConfig is the runtime configuration
 var KataConfig KataConfiguration
+var KataHypervisor string
 
 func init() {
 	var err error
@@ -112,6 +113,22 @@ func init() {
 	KataConfig, err = loadKataConfiguration(kataConfigPath)
 	if err != nil {
 		log.Fatalf("failed to load kata configuration: %v\n", err)
+	}
+
+	switch Hypervisor {
+	case "cloud-hypervisor":
+		KataHypervisor = CloudHypervisor
+	case "firecracker":
+		KataHypervisor = FirecrackerHypervisor
+	case "":
+		log.Printf("'-hypervisor' to ginkgo is not set, using 'DefaultHypervisor': '%v'\n", DefaultHypervisor)
+		KataHypervisor = DefaultHypervisor
+	default:
+		log.Fatalf("Invalid '-hypervisor' passed to ginkgo: '%v'\n", Hypervisor)
+	}
+
+	if _, ok := KataConfig.Hypervisor[KataHypervisor]; !ok {
+		log.Fatalf("No configuration found from 'KataConfig' for 'KataHypervisor': '%v'\n", KataHypervisor)
 	}
 }
 

--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Hot plug CPUs", func() {
 		waitTime = 5
 		maxTries = 5
 		args = []string{}
-		defaultVCPUs = int(KataConfig.Hypervisor[DefaultHypervisor].DefaultVCPUs)
+		defaultVCPUs = int(KataConfig.Hypervisor[KataHypervisor].DefaultVCPUs)
 		Expect(defaultVCPUs).To(BeNumerically(">", 0))
 	})
 
@@ -271,7 +271,7 @@ var _ = Describe("Update number of CPUs", func() {
 		waitTime = 5
 		maxTries = 5
 
-		defaultVCPUs = int(KataConfig.Hypervisor[DefaultHypervisor].DefaultVCPUs)
+		defaultVCPUs = int(KataConfig.Hypervisor[KataHypervisor].DefaultVCPUs)
 		Expect(defaultVCPUs).To(BeNumerically(">", 0))
 
 		runArgs = []string{}

--- a/integration/docker/mem_test.go
+++ b/integration/docker/mem_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Hotplug memory when create containers", func() {
 
 	BeforeEach(func() {
 		id = randomDockerName()
-		defaultMemSz = int64(KataConfig.Hypervisor[DefaultHypervisor].DefaultMemSz) << 20
+		defaultMemSz = int64(KataConfig.Hypervisor[KataHypervisor].DefaultMemSz) << 20
 		Expect(defaultMemSz).To(BeNumerically(">", int64(0)))
 	})
 
@@ -134,7 +134,7 @@ var _ = Describe("memory constraints", func() {
 
 		id = randomDockerName()
 
-		defaultMemSz = int(KataConfig.Hypervisor[DefaultHypervisor].DefaultMemSz)
+		defaultMemSz = int(KataConfig.Hypervisor[KataHypervisor].DefaultMemSz)
 		Expect(defaultMemSz).To(BeNumerically(">", 0))
 	})
 

--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -70,7 +70,7 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check dnf update", func() {
 		It("should not fail", func() {
-			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+			if KataConfig.Hypervisor[KataHypervisor].SharedFS == "virtio-fs" {
 				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
 			}
 
@@ -93,7 +93,7 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check yum update", func() {
 		It("should not fail", func() {
-			if KataConfig.Hypervisor[DefaultHypervisor].SharedFS == "virtio-fs" {
+			if KataConfig.Hypervisor[KataHypervisor].SharedFS == "virtio-fs" {
 				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
 			}
 			args = append(args, "--rm", "-td", "--name", id, CentosImage, "sh")

--- a/integration/docker/vsock_test.go
+++ b/integration/docker/vsock_test.go
@@ -30,7 +30,7 @@ var _ = Describe("vsock test", func() {
 
 	Context("when using vsock", func() {
 		It("should not create a kata-proxy process", func() {
-			if !KataConfig.Hypervisor[DefaultHypervisor].Vsock {
+			if !KataConfig.Hypervisor[KataHypervisor].Vsock {
 				Skip("Use of vsock not enabled")
 			}
 			args = []string{"--name", name, "-d", Image, "top"}
@@ -46,7 +46,7 @@ var _ = Describe("vsock test", func() {
 		})
 
 		It("should print the agent logs in the shim journal", func() {
-			if !KataConfig.Hypervisor[DefaultHypervisor].Vsock {
+			if !KataConfig.Hypervisor[KataHypervisor].Vsock {
 				Skip("Use of vsock not enabled")
 			}
 			if !KataConfig.Shim[DefaultShim].Debug {


### PR DESCRIPTION
All docker tests are using the 'DefaultHypervisor' (a.k.a 'qemu') as the
key when reading from KataConfig. This will cause test failures for the
tests requires information from the configuration file (e.g. cpu_test,
mem_test and vsock_test) when kata is not using qemu as its
hypervisor. This patch introduced a new global variable 'KataHypervisor'
which is initialized based on the environment variable 'KATA_HYPERVISOR'
that should be set by the CI script.

Fixes: #2383

Signed-off-by: Bo Chen <chen.bo@intel.com>