### PR TITLE
AArch64: enable fc tests on ARM CI

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -39,6 +39,15 @@ install_qemu(){
 	fi
 }
 
+echo "Install shim"
+"${cidir}/install_shim.sh" "${tag}"
+
+echo "Install proxy"
+"${cidir}/install_proxy.sh" "${tag}"
+
+echo "Install runtime"
+"${cidir}/install_runtime.sh" "${tag}"
+
 case "${KATA_HYPERVISOR}" in
 	"cloud-hypervisor")
 		"${cidir}/install_cloud_hypervisor.sh"
@@ -57,16 +66,11 @@ case "${KATA_HYPERVISOR}" in
 		;;
 esac
 
-echo "Install shim"
-"${cidir}/install_shim.sh" "${tag}"
-
-echo "Install proxy"
-"${cidir}/install_proxy.sh" "${tag}"
-
-echo "Install runtime"
-"${cidir}/install_runtime.sh" "${tag}"
-
 if [ "${TEST_CGROUPSV2}" == "true" ]; then
 	echo "Configure podman with kata"
 	"${cidir}/configure_podman_for_kata.sh"
 fi
+
+# Check system supports running Kata Containers
+kata_runtime_path=$(command -v kata-runtime)
+sudo -E PATH=$PATH "$kata_runtime_path" kata-check

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -88,10 +88,6 @@ else
 	sudo sed -i -e '/^initrd =/d' ${runtime_config_path}
 fi
 
-# Check system supports running Kata Containers
-kata_runtime_path=$(command -v kata-runtime)
-sudo -E PATH=$PATH "$kata_runtime_path" kata-check
-
 if [ -z "${METRICS_CI}" ]; then
 	echo "Enabling all debug options in file ${runtime_config_path}"
 	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
@@ -116,12 +112,12 @@ fi
 
 if [ "${TEST_CGROUPSV2}" == "false" ]; then
 	case "${KATA_HYPERVISOR}" in
-		"cloud-hypervisor" | "qemu")
-			echo "Add kata-runtime as a new/default Docker runtime."
+		"cloud-hypervisor" | "qemu" | "firecracker")
+			echo "Add kata-runtime as a new Docker runtime."
 			"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker configure -r kata-runtime -f
 			;;
 		*)
-			echo "Kata runtime will not set as a default in Docker"
+			echo "Kata runtime will not be set in Docker"
 			;;
 	esac
 fi

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -28,7 +28,8 @@ Options:
 	-f                         : Force action. It will replace any installation
                                      or configuration that you may have.
 	-h                         : Help, show this information.
-	-r <runtime>               : Supported runtimes: runc and cc-runtime.
+	-r <runtime>               : Supported runtimes: runc and kata-runtime.
+	-s <storage_driver>        : Supported storage driver: overlay2(default), devicemapper, etc.
 	-t <tag>                   : Tags supported: swarm, latest. If you do not specify
                                      a tag, the script will use latest as default.
                                      With this tag you can install the correct version
@@ -60,13 +61,16 @@ log_message(){
 }
 
 parse_subcommand_options(){
-	while getopts ":fr:t:" opt; do
+	while getopts ":fr:s:t:" opt; do
 		case $opt in
 			f)
 				force=true
 				;;
 			r)
 				runtime="${OPTARG}"
+				;;
+			s)
+				storage_driver="${OPTARG}"
 				;;
 			t)
 				tag="${OPTARG}"
@@ -280,6 +284,9 @@ EOF
 configure_docker(){
 	[ -z "$runtime" ] && die "please specify a runtime with -r"
 
+	# Default storage driver is overlay2
+	[ -z "$storage_driver" ] && storage_driver="overlay2"
+
 	if [ ! "$(info_docker)" ]; then
 		die "Docker is not installed. Please install it before configuring the runtime"
 	fi
@@ -293,8 +300,6 @@ configure_docker(){
 			docker_http_proxy="HTTP_PROXY=$http_proxy"
 			docker_https_proxy="HTTPS_PROXY=$https_proxy"
 		fi
-
-		storage_driver="overlay2"
 
 		if [ "$tag" == "swarm" ] ; then
 			default_runtime=$runtime


### PR DESCRIPTION
Hi~ guys
I've been trying to enable FC tests on ARM CI lately.
All tests work well in my local machine and I may need to do the following twist on upstream existing configuration.

- **configure_docker: add -s option for configuring storage driver**
When running with firecracker, docker is configured by `/etc/docker/daemon.json`, which is inconsistent with the original installation in [install_docker()](https://github.com/kata-containers/tests/blob/master/.ci/setup.sh#L49). They are using systemd service file to configure.
Let's stick with one method, and add new `-s` option to configure storage driver.

- **FC: speed up installing firecracker/jailer**
Since we only use `firecracker/jailer` in stable version, we could just download binary from their release page.Therefore we could save the time and bandwidth.
For now, fc release page only provides binaries in two archs: `aarch64` and `x86_64`.
