### PR TITLE
ci: Fix ROOTFS_DIR for podman CI

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -109,7 +109,13 @@ build_image() {
 
 	pushd "${osbuilder_path}" >/dev/null
 
-	readonly ROOTFS_DIR="${PWD}/rootfs"
+	# Verify rootfs dir
+	if [ "${TEST_CGROUPSV2}" == "true" ] && [ "${TEST_INITRD}" == "yes" ]; then
+		distro_name=$(echo "${distro}" | sed 's/./\u&/')
+		readonly ROOTFS_DIR="${osbuilder_path}/rootfs-builder/rootfs-${distro_name}"
+	else
+		readonly ROOTFS_DIR="${PWD}/rootfs"
+	fi
 	export ROOTFS_DIR
 	sudo rm -rf "${ROOTFS_DIR}"
 


### PR DESCRIPTION
While trying to build the image for podman with osbuilder, we got an error
saying that the ROOTFS_DIR does not exist. The main issue is that we are
trying to find the ROOTFS_DIR at the top of osbuilder directory, but for podman
the ROOTFS_DIR is created inside the rootfs-builder directory. This PR fixes that
issue by passing the correct location of the ROOTFS_DIR that is being generated by osbuilder
with podman.

Fixes #2370

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>