### PR TITLE
clh:docker: Enable CPU tests

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -10,12 +10,7 @@ test:
   - docker
 docker:
   Describe:
-    - CPU constraints
-    - CPUs and CPU set
-    - Hot plug CPUs
     - Hotplug memory when create containers
-    - Update CPU constraints
-    - Update number of CPUs
     - build with docker
     - capabilities
     - diff


### PR DESCRIPTION
The regression we had on CPU releated tests was caused by the bug
reported in issue #2383. With that bug being fixed, we are bring back
CPU related tests back to the CI.

Depends-on: kata-containers/runtime/pull/2552

Fixes: #2363

Signed-off-by: Bo Chen <chen.bo@intel.com>