### PR TITLE
ci: ci-fast-return.sh should consider vendor changes

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -127,7 +127,7 @@ can_we_skip() {
 		return 0
 	fi
 
-	filenames=$(get_pr_changed_file_details || true)
+	filenames=$(get_pr_changed_file_details_full || true)
 	# Strip off the leading status - just grab last column.
 	filenames=$(echo "$filenames"|awk '{print $NF}')
 


### PR DESCRIPTION
We should run the whole CI when there are only changes in the vendor
directory. To accomplish this, use `get_pr_changed_file_details_full`.

Fixes: #2241.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>