### PR TITLE
tests: Enable debug for vcpu test

### DIFF
--- a/integration/vcpus/default_vcpus_test.sh
+++ b/integration/vcpus/default_vcpus_test.sh
@@ -7,6 +7,7 @@
 # This will test the default_vcpus
 # feature is working properly
 
+[ -n "$DEBUG" ] && set -x
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
We need to enable debug for the vcpu test in order to see why this tests
is randomly failing.

Fixes #2407

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>