### PR TITLE
clh:docker: Enable multiple integration tests being skipped

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -11,30 +11,8 @@ test:
 docker:
   Describe:
     - Hotplug memory when create containers
-    - build with docker
-    - capabilities
-    - diff
-    - docker commit
-    - docker cp
-    - docker cp with volume attached
-    - docker env
-    - docker exec
-    - docker exit code
-    - docker privileges
-    - docker top
     - docker volume
-    - inspect
-    - load with docker
-    - memory constraints
     - package manager update test
-    - pause with docker
-    - restart
-    - run container and update its memory constraints
-    - run container with docker
     - run hot plug block devices
-    - terminal with docker
-    - ulimits
-    - users and groups
   Context:
-    - remove bind-mount source before container exits
   It:


### PR DESCRIPTION
There are many docker integration tests that are currently being skipped
for CI on clh (as tracked in #2399). With recent developments of
cloud-hypervisor driver in Kata and various fixes in the kata/tests
repo, we are expecting to have many more integration tests on docker to
be supported.

Depends-on: github.com/kata-containers/runtime#2552

Fixes: #2411

Signed-off-by: Bo Chen <chen.bo@intel.com>