### PR TITLE
clh: Enable memory hotplug test for clh

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -10,7 +10,6 @@ test:
   - docker
 docker:
   Describe:
-    - Hotplug memory when create containers
     - docker volume
     - package manager update test
     - run hot plug block devices


### PR DESCRIPTION
Memory hotplug now is enabled in clh, enable test for docker.

Fixes: #2424

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>