### PR TITLE
containerd: be able to build from source when version is a commit

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -30,7 +30,7 @@ cri_containerd_tarball_version=$(get_version "externals.cri-containerd.version")
 cri_containerd_repo=$(get_version "externals.cri-containerd.url")
 
 echo "Get cri_containerd version"
-cri_containerd_version_url="https://raw.githubusercontent.com/containerd/containerd/v${cri_containerd_tarball_version}/vendor.conf"
+cri_containerd_version_url="https://raw.githubusercontent.com/containerd/containerd/${cri_containerd_tarball_version}/vendor.conf"
 cri_containerd_version=$(curl -sL $cri_containerd_version_url | grep "github.com/containerd/cri" | awk '{print $2}')
 
 echo "Set up environment"
@@ -56,6 +56,7 @@ install_from_source() {
 install_from_static_tarball() {
 	echo "Trying to install containerd from static tarball"
 	local tarball_url=$(get_version "externals.cri-containerd.tarball_url")
+	cri_containerd_tarball_version="${cri_containerd_tarball_version/v/}"
 
 	local tarball_name="cri-containerd-${cri_containerd_tarball_version}.${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
 	local url="${tarball_url}/${tarball_name}"


### PR DESCRIPTION
Enhances the `install_cri_containerd.sh` script to be able to build and
install containerd using a commit SHA as the version.

The script should now work when containerd versions are:
- a release number, e.g. `v1.3.3`
- a commit SHA, e.g. `3a4acfbc99aa976849f51a8edd4af20ead51d8d7`

Fixes: #2414.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>