### PR TITLE
docker: clh: Skip check yum update

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -12,7 +12,7 @@ docker:
   Describe:
     - Hotplug memory when create containers
     - docker volume
-    - package manager update test
     - run hot plug block devices
   Context:
+    - check yum update
   It:


### PR DESCRIPTION
Enable all package manager test but skip yum. `yum test is doing some file operations that break virtio-fs.

For more information see:
https://github.com/kata-containers/tests/issues/2008

Fixes: #2418

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>