### PR TITLE
make: docker: Run docker test in parallel for all jobs

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -14,5 +14,5 @@ docker:
     - run hot plug block devices
   Context:
     - check yum update
-    - check apt-get update and upgrade
+    - check dnf update
   It:


### PR DESCRIPTION
Running test in serial takes a long time, just qemu uses today
parallel, refactor makefile to run all as parallel.

Fixes: #2426

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>