### PR TITLE
ci: split docker test for clh

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -168,6 +168,16 @@ case "${CI_JOB}" in
 	export TEST_DOCKER="true"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-DOCKER")
+	export CRIO="no"
+	export CRI_CONTAINERD="no"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="no"
+	export OPENSHIFT="no"
+	export TEST_CRIO="false"
+	export TEST_DOCKER="true"
+	export experimental_kernel="true"
+	;;
 esac
 "${ci_dir_name}/setup.sh"
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -53,9 +53,6 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 
-		echo "INFO: Running docker integration tests"
-		sudo -E PATH="$PATH" bash -c "make docker"
-
 		echo "INFO: Running soak test"
 		sudo -E PATH="$PATH" bash -c "make docker-stability"
 
@@ -64,6 +61,10 @@ case "${CI_JOB}" in
 
 		echo "INFO: Running networking tests"
 		sudo -E PATH="$PATH" bash -c "make network"
+		;;
+	"CLOUD-HYPERVISOR-DOCKER")
+		echo "INFO: Running docker integration tests"
+		sudo -E PATH="$PATH" bash -c "make docker"
 		;;
 	"PODMAN")
 		export TRUSTED_GROUP="kvm"


### PR DESCRIPTION
Make docker test run in its own job for clh.

Fixes: #2428

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>