### PR TITLE
setup: Fix clh cache installer

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -47,10 +47,12 @@ install_clh() {
 install_prebuilt_clh() {
 	local checksum_file="sha256sum-cloud-hypervisor"
 	go get -d "${go_cloud_hypervisor_repo}" || true
-	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
+	pushd  "${GOPATH}/src/${go_cloud_hypervisor_repo}"
 
-	curl -fsOL --progress-bar "${latest_build_url}/${clh_bin_name}" || return 1
-	curl -fsOL "${latest_build_url}/${checksum_file}" || return 1
+	info "Downloading hypervisor binary"
+	curl -fOL --progress-bar "${latest_build_url}/${clh_bin_name}" || return 1
+	info "Downloading hypervisor binary checksum"
+	curl -fOL --progress-bar "${latest_build_url}/${checksum_file}" || return 1
 
 	info "Verify download checksum"
 	sudo sha256sum -c "${checksum_file}" || return 1


### PR DESCRIPTION
    
    Script installer always install cloud-hypervisor from source.
    When it tries install from binary this fails when it does curl.
    
    curl fails because it downloads the binary called cloud-hypervisor
    in a path with a directory with the same name. Fix by moving
    to the rigth path. Aditonally remove silent download to
    allow see errors from curl and progress-bar.
    
    Fixes: #2432
    
    Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>