### PR TITLE
golangci-lint: fix `invalid pseudo-version` error on ARM CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
     - os: osx
 
 language: go
+# The Go compiler in travis ci testing environment should be 
+# consistent with the tested project.
+go:
+  - 1.13.x
 go_import_path: github.com/kata-containers/tests
 
 env:
@@ -27,7 +31,6 @@ env:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then .ci/setup.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew install bash yamllint gnu-getopt; fi
-  - bash .ci/install_go.sh -p -f
 
 script:
   - bash .ci/static-checks.sh github.com/kata-containers/tests

--- a/versions.yaml
+++ b/versions.yaml
@@ -56,7 +56,7 @@ externals:
   golangci-lint:
     description: "utility to run various golang linters"
     url: "github.com/golangci/golangci-lint"
-    version: "v1.16.0"
+    version: "v1.18.0"
 
   parallel:
     description: "GNU parallel tool"


### PR DESCRIPTION
With golang updated to v1.13, we found golangci-lint build error on ARM CI.
```
08:55:44 go build -o golangci-lint ./cmd/golangci-lint
08:55:49 go: github.com/go-critic/go-critic@v0.0.0-20181204210945-ee9bf5809ead: invalid pseudo-version: does not match version-control timestamp (2019-02-10T22:04:43Z)
```
Taking advices here(https://github.com/filecoin-project/go-filecoin/issues/3486#issuecomment-534858459), we need to update `golangci-lint` to `v1.18.0` to get Go `1.13` support.

Fixes: #2434

Signed-off-by: Penny Zheng <penny.zheng@arm.com>