### PR TITLE
s390x : skip dnf update

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -17,6 +17,7 @@ docker:
     - CPUs and CPU set
     - Hotplug memory
     - memory constraints
+    - check dnf update
   Context:
     - remove bind-mount source before container exits
     - run container exceeding memory constraints


### PR DESCRIPTION
The package manager dnf tries to update shadow-utils that needs to set
xattr. The option is not supported by 9p. The test is successfull using
another storage driver like devicemapper. As overlay is the default for
the CI and we don't support virtiofs on s390x yet, we can simply skip
this test.

Fixes: #2358

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>