### PR TITLE
ci: Enable repo for perl-IPC-Run

### DIFF
--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -11,6 +11,9 @@ cidir=$(dirname "$0")
 source "/etc/os-release" || "source /usr/lib/os-release"
 source "${cidir}/lib.sh"
 
+echo "Get repo for perl-IPC-Run"
+sudo -E yum-config-manager --enable rhui-rhel-7-server-rhui-optional-rpms
+
 echo "Add epel repository"
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 sudo -E yum install -y "$epel_url"


### PR DESCRIPTION
This PR enables the repository that is needed for perl-IPC-Run for RHEL.
We need to enable this repository as perl-IPC-Run is a dependency for
moreutils package and we need moreutils because we are using chronic.

Fixes #2438

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>