### PR TITLE
ci: kernel: install experimental kernel using cache

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -133,6 +133,10 @@ main() {
 	kernel_version="$(get_current_kernel_version)"
 	kata_config_version="$(get_kata_config_version)"
 	current_kernel_version="${kernel_version}-${kata_config_version}"
+	if [ "${experimental_kernel}" == "true" ]; then
+		# Experimental has an extra suffix
+		current_kernel_version="${kernel_version}-${kata_config_version}-virtiofs"
+	fi
 	if [ "${experimental_kernel}" == "false" ]; then
 		cached_kernel_version=$(curl -sfL "${latest_build_url}/latest") || cached_kernel_version="none"
 	else


### PR DESCRIPTION
Add prefix to experimental kernel to match with current cached version.

Fixes: #2442

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>