### PR TITLE
docker: clh: Skip apt-get upgrade

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -14,4 +14,5 @@ docker:
     - run hot plug block devices
   Context:
     - check yum update
+    - check apt-get update and upgrade
   It:


### PR DESCRIPTION
apt-get upgrade is not working until no_posix_lock is enabled.
Skip test to make work the CI.

Fixes: #2444

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>