### PR TITLE
tests: Skip hypervisor stability kill test on SLES and openSUSE

### DIFF
--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -12,6 +12,7 @@ set -e
 cidir=$(dirname "$0")
 
 source "${cidir}/../../metrics/lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
 
 # Environment variables
 IMAGE="${IMAGE:-busybox}"
@@ -22,6 +23,12 @@ PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 RUNTIME="${RUNTIME:-kata-runtime}"
 
 HYPERVISOR_NAME=$(basename ${HYPERVISOR_PATH})
+
+if [ "$ID" == sles ] || [[ "$ID" =~ ^opensuse.*$ ]]; then
+	issue="https://github.com/kata-containers/runtime/issues/2611"
+	echo "Skip hypervisor stability kill test ${issue}"
+	exit 0
+fi
 
 setup()  {
 	clean_env


### PR DESCRIPTION
While running the hypervisor stability kill test on SLES and openSUSE Leap,
we can see that pod information is left kata-containers/runtime#2611,
we need to skip this until this is solved.

Fixes #2454

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>