### PR TITLE
CI: Hide libcontainer logs from log-parser

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -240,7 +240,15 @@ check_log_files()
 		file="${component}.log"
 		args="--no-pager -q -o cat -a -t \"${component}\""
 
-		cmd="sudo journalctl ${args} > ${file}"
+		# grab the component logs and exclude all log entries that
+		# don't appear to come from Kata.
+		#
+		# This reduces the effectiveness of the log parser checking
+		# slightly but is the only semi-reasonable way to exclude log
+		# messages from libcontainer whose API unfortunately does not
+		# accept a logger to perform logging.
+		cmd="sudo journalctl ${args} | grep -v name=kata > ${file}"
+
 		eval "$cmd" || true
 	done
 

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -251,7 +251,7 @@ check_log_files()
 		file="${unit}.log"
 		args="--no-pager -q -o cat -a -u \"${unit}\""
 
-		cmd="sudo journalctl ${args} |grep ^time= > ${file}"
+		cmd="sudo journalctl ${args} | grep ^time= > ${file}"
 		eval "$cmd" || true
 	done
 


### PR DESCRIPTION
Filter out libcontainer log messages (which get logged by the agent) as they trigger errors from the the log-parser that runs in the CI. The reason for the errors is that the log-parser expects all log entries to provide a standard set of fields, but libcontainer does not provide a way to pass a logger object into it, so it logs in its own format, which does not include mandatory fields like "pid".

See: https://github.com/kata-containers/tests/tree/master/cmd/log-parser#logfile-requirements

Fixes: #2470.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>