### PR TITLE
ci: Get package dependencies in alphabetical order

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -50,7 +50,7 @@ sudo -E yum -y install moreutils
 
 if [ "$centos_version" == "8" ]; then
 	chronic sudo -E yum install pkgconf-pkg-config
-fi 
+fi
 
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-GB hunspell-en-US pandoc" \
@@ -59,21 +59,21 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[kata_containers_dependencies]="libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 libtool-ltdl" \
-	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel libpmem-devel" \
-	[kernel_dependencies]="elfutils-libelf-devel flex pkgconfig patch" \
-	[crio_dependencies]="libassuan-devel libgpg-error-devel device-mapper-libs util-linux libselinux-devel" \
 	[bison_binary]="bison" \
-	[libgudev1-dev]="libgudev1-devel" \
-	[general_dependencies]="xfsprogs gpgme-devel glib2-devel glibc-devel bzip2 m4 gettext-devel automake autoconf pixman-devel coreutils" \
-	[build_tools]="python3 pkgconfig zlib-devel" \
-	[ostree]="ostree-devel" \
-	[metrics_dependencies]="jq" \
+	[build_tools]="pkgconfig python3 zlib-devel" \
+	[crio_dependencies]="device-mapper-libs libassuan-devel libgpg-error-devel libselinux-devel util-linux" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
+	[general_dependencies]="autoconf automake bzip2 coreutils gettext-devel glibc-devel glib2-devel gpgme-devel m4 pixman-devel xfsprogs" \
+	[gnu_parallel_dependencies]="bzip2 make perl" \
 	[haveged]="haveged" \
-	[gnu_parallel_dependencies]="perl bzip2 make" \
+	[kata_containers_dependencies]="device-mapper-persistent-data libtool libtool-ltdl libtool-ltdl-devel lvm2" \
+	[kernel_dependencies]="elfutils-libelf-devel flex patch pkgconfig" \
+	[libgudev1-dev]="libgudev1-devel" \
 	[libsystemd]="systemd-devel" \
+	[metrics_dependencies]="jq" \
+	[ostree]="ostree-devel" \
+	[procenv]="procenv" \
+	[qemu_dependencies]="flex libcap-devel libcap-ng-devel libattr-devel librbd1-devel libfdt-devel libpmem-devel" \
 	[redis]="redis" \
 )
 

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -22,23 +22,23 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[general_dependencies]="curl git xfsprogs" \
-	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils parted" \
-	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev libpmem-dev" \
-	[kernel_dependencies]="libelf-dev flex" \
-	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev go-md2man thin-provisioning-tools" \
 	[bison_binary]="bison" \
-	[libudev-dev]="libudev-dev" \
-	[build_tools]="build-essential python pkg-config zlib1g-dev" \
-	[crio_dependencies_for_debian]="libdevmapper-dev btrfs-tools util-linux" \
-	[os_tree]="libostree-dev" \
-	[metrics_dependencies]="jq" \
-	[cri-containerd_dependencies]="libseccomp-dev libapparmor-dev btrfs-tools libbtrfs-dev make gcc pkg-config" \
+	[build_tools]="build-essential pkg-config python zlib1g-dev" \
+	[cri-containerd_dependencies]="btrfs-tools gcc libapparmor-dev libbtrfs-dev libseccomp-dev make pkg-config" \
+	[crio_dependencies]="go-md2man libapparmor-dev libglib2.0-dev libgpgme11-dev libseccomp-dev thin-provisioning-tools" \
+	[crio_dependencies_for_debian]="btrfs-tools libdevmapper-dev util-linux" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
-	[haveged]="haveged" \
+	[general_dependencies]="curl git xfsprogs" \
 	[gnu_parallel]="parallel" \
-	[libsystemd]="libsystemd-dev"\
+	[haveged]="haveged" \
+	[kata_containers_dependencies]="autoconf automake autotools-dev bc coreutils libpixman-1-dev libtool parted" \
+	[kernel_dependencies]="flex libelf-dev" \
+	[libsystemd]="libsystemd-dev" \
+	[libudev-dev]="libudev-dev" \
+	[metrics_dependencies]="jq" \
+	[os_tree]="libostree-dev" \
+	[procenv]="procenv" \
+	[qemu_dependencies]="libattr1-dev libcap-dev libcap-ng-dev librbd-dev libpmem-dev" \
 	[redis]="redis-server" \
 )
 

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -28,20 +28,20 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[general_dependencies]="xfsprogs dnf-plugins-core python pkgconfig util-linux libgpg-error-devel" \
-	[kata_containers_dependencies]="libtool automake autoconf bc pixman numactl-libs" \
-	[qemu_dependencies]="libcap-devel libattr-devel libcap-ng-devel zlib-devel pixman-devel librbd-devel libpmem-devel" \
-	[kernel_dependencies]="elfutils-libelf-devel flex" \
-	[crio_dependencies]="btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libseccomp-devel libselinux-devel" \
 	[bison_binary]="bison" \
-	[os_tree]="ostree-devel" \
-	[metrics_dependencies]="jq" \
-	[cri-containerd_dependencies]="libseccomp-devel btrfs-progs-devel libseccomp-static" \
+	[cri-containerd_dependencies]="btrfs-progs-devel libseccomp-devel libseccomp-static" \
+	[crio_dependencies]="btrfs-progs-devel device-mapper-devel glibc-devel glibc-static glib2-devel gpgme-devel libassuan-devel libseccomp-devel libselinux-devel" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
-	[haveged]="haveged" \
+	[general_dependencies]="dnf-plugins-core libgpg-error-devel pkgconfig python util-linux xfsprogs" \
 	[gnu_parallel]="parallel" \
+	[haveged]="haveged" \
+	[kata_containers_dependencies]="autoconf automake bc libtool numactl-libs pixman" \
+	[kernel_dependencies]="elfutils-libelf-devel flex" \
 	[libsystemd]="systemd-devel" \
+	[metrics_dependencies]="jq" \
+	[os_tree]="ostree-devel" \
+	[procenv]="procenv" \
+	[qemu_dependencies]="libattr-devel libcap-devel libcap-ng-devel librbd-devel libpmem-devel pixman-devel zlib-devel" \
 	[redis]="redis" \
 	[versionlock]="python3-dnf-plugin-versionlock" \
 )

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -30,21 +30,21 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[general_dependencies]="curl git libcontainers-common libdevmapper1_03 util-linux" \
-	[kata_containers_dependencies]="libtool automake autoconf bc perl-Alien-SDL libpixman-1-0-devel coreutils python2-pkgconfig" \
-	[qemu_dependencies]="libcap-devel libattr1 libcap-ng-devel librbd-devel libpmem-devel" \
-	[kernel_dependencies]="patch libelf-devel flex glibc-devel-static thin-provisioning-tools" \
-	[crio_dependencies]="libglib-2_0-0 libseccomp-devel libapparmor-devel libgpg-error-devel go-md2man libgpgme-devel libassuan-devel glib2-devel glibc-devel" \
 	[bison_binary]="bison" \
-	[build_tools]="gcc python pkg-config zlib-devel" \
-	[os_tree]="libostree-devel" \
-	[libudev-dev]="libudev-devel" \
-	[metrics_dependencies]="smemstat jq" \
-	[cri-containerd_dependencies]="libseccomp-devel libapparmor-devel make pkg-config libbtrfs-devel patterns-base-apparmor" \
+	[build_tools]="gcc pkg-config python zlib-devel" \
+	[cri-containerd_dependencies]="libapparmor-devel libbtrfs-devel libseccomp-devel make patterns-base-apparmor pkg-config" \
+	[crio_dependencies]="glibc-devel glib2-devel go-md2man libassuan-devel libapparmor-devel libgpg-error-devel libglib-2_0-0 libgpgme-devel libseccomp-devel" \
 	[crudini]="crudini" \
-	[haveged]="haveged" \
+	[general_dependencies]="curl git libcontainers-common libdevmapper1_03 util-linux" \
 	[gnu_parallel]="gnu_parallel" \
+	[haveged]="haveged" \
+	[kata_containers_dependencies]="autoconf automake bc coreutils libpixman-1-0-devel libtool perl-Alien-SDL python2-pkgconfig" \
+	[kernel_dependencies]="flex glibc-devel-static libelf-devel patch thin-provisioning-tools" \
 	[libsystemd]="systemd-devel" \
+	[libudev-dev]="libudev-devel" \
+	[metrics_dependencies]="jq smemstat" \
+	[os_tree]="libostree-devel" \
+	[qemu_dependencies]="libattr1 libcap-devel libcap-ng-devel libpmem-devel librbd-devel" \
 	[redis]="redis" \
 )
 

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -31,21 +31,21 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=(
-	[kata_containers_dependencies]="libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 device-mapper-devel libtool-ltdl bzip2 m4 patch gettext-devel automake autoconf bc pixman-devel coreutils" \
-	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel libpmem-devel" \
-	[kernel_dependencies]="elfutils-libelf-devel flex" \
-	[crio_dependencies]="glibc-static libseccomp-devel libassuan-devel libgpg-error-devel device-mapper-libs btrfs-progs-devel util-linux gpgme-devel glib2-devel glibc-devel libselinux-devel pkgconfig" \
 	[bison_binary]="bison" \
-	[build_tools]="python pkgconfig zlib-devel" \
-	[os_tree]="ostree-devel" \
+	[build_tools]="pkgconfig python zlib-devel" \
+	[cri-containerd_dependencies]="btrfs-progs-devel libseccomp-devel" \
+	[crio_dependencies]="btrfs-progs-devel device-mapper-libs glibc-devel glibc-static glib2-devel gpgme-devel libassuan-devel libgpg-error-devel libseccomp-devel libselinux-devel pkgconfig util-linux" \
+	[crudini]="crudini" \
+	[gnu_parallel_dependencies]="bzip2 make perl" \
+	[haveged]="haveged" \
+	[kata_containers_dependencies]="autconf automake bc bzip2 coreutils device-mapper-devel device-mapper-persistent-data gettext-devel libtool libtool-ltdl-devel lvm2 m4 patch pixman-devel" \
+	[kernel_dependencies]="elfutils-libelf-devel flex" \
+	[libsystemd]="systemd-devel" \
 	[libudev-dev]="libgudev1-devel" \
 	[metrics_dependencies]="jq" \
-	[cri-containerd_dependencies]="libseccomp-devel btrfs-progs-devel" \
-	[crudini]="crudini" \
+	[os_tree]="ostree-devel" \
 	[procenv]="procenv" \
-	[haveged]="haveged" \
-	[gnu_parallel_dependencies]="perl bzip2 make" \
-        [libsystemd]="systemd-devel" \
+	[qemu_dependencies]="flex libattr-devel libcap-devel libcap-ng-devel libfdt-devel librbd1-devel libpmem-devel" \
 	[redis]="redis" \
 )
 

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -49,19 +49,19 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[general_dependencies]="curl git patch"
-	[kata_containers_dependencies]="libtool automake autoconf bc libpixman-1-0-devel coreutils" \
-	[qemu_dependencies]="libcap-devel libattr1 libcap-ng-devel librbd-devel libpmem-devel" \
-	[kernel_dependencies]="patch libelf-devel flex" \
-	[crio_dependencies]="libglib-2_0-0 libseccomp-devel libapparmor-devel libgpg-error-devel glibc-devel-static libgpgme-devel libassuan-devel glib2-devel glibc-devel util-linux" \
 	[bison_binary]="bison" \
-	[libudev-dev]="libudev-devel" \
 	[build_tools]="gcc python zlib-devel" \
-	[metrics_dependencies]="jq" \
-	[cri-containerd_dependencies]="libseccomp-devel libapparmor-devel make pkg-config" \
+	[cri-containerd_dependencies]="libapparmor-devel libseccomp-devel make pkg-config" \
+	[crio_dependencies]="glibc-devel glibc-devel-static glib2-devel libapparmor-devel libgpg-error-devel libglib-2_0-0 libgpgme-devel libseccomp-devel libassuan-devel util-linux" \
+	[general_dependencies]="curl git patch" \
+	[gnu_parallel]="gnu_parallel" \
 	[haveged]="haveged" \
- 	[gnu_parallel]="gnu_parallel" \
+	[kata_containers_dependencies]="autoconf automake bc coreutils libpixman-1-0-devel libtool" \
+	[kernel_dependencies]="flex libelf-devel patch" \
 	[libsystemd]="systemd-devel" \
+	[libudev-dev]="libudev-devel" \
+	[metrics_dependencies]="jq" \
+	[qemu_dependencies]="libattr1 libcap-devel libcap-ng-devel libpmem-devel librbd-devel" \
 )
 
 main()

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -24,21 +24,21 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[kata_containers_dependencies]="xfsprogs libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils" \
-	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev" \
-	[kernel_dependencies]="libelf-dev flex" \
-	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev thin-provisioning-tools" \
 	[bison_binary]="bison" \
-	[libudev-dev]="libudev-dev" \
-	[build_tools]="build-essential python pkg-config zlib1g-dev" \
-	[crio_dependencies_for_ubuntu]="libdevmapper-dev btrfs-tools util-linux" \
-	[metrics_dependencies]="smem jq" \
-	[cri-containerd_dependencies]="libseccomp-dev libapparmor-dev btrfs-tools  make gcc pkg-config" \
+	[build_tools]="build-essential pkg-config python zlib1g-dev" \
+	[cri-containerd_dependencies]="btrfs-tools gcc libapparmor-dev libseccomp-dev make pkg-config" \
+	[crio_dependencies]="libapparmor-dev libglib2.0-dev libseccomp-dev libgpgme11-dev thin-provisioning-tools" \
+	[crio_dependencies_for_ubuntu]="btrfs-tools libdevmapper-dev util-linux" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
-	[haveged]="haveged" \
 	[gnu_parallel]="parallel" \
+	[haveged]="haveged" \
+	[kata_containers_dependencies]="autoconf automake autotools-dev bc coreutils libtool libpixman-1-dev xfsprogs" \
+	[kernel_dependencies]="flex libelf-dev" \
 	[libsystemd]="libsystemd-dev" \
+	[libudev-dev]="libudev-dev" \
+	[metrics_dependencies]="jq smem" \
+	[procenv]="procenv" \
+	[qemu_dependencies]="libattr1-dev libcap-dev libcap-ng-dev librbd-dev" \
 	[redis]="redis-server" \
 )
 


### PR DESCRIPTION
This PR orders the package dependencies for the different distros in alphabetical order
in order to make easier to add or remove packages.

Fixes #2477

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>