### PR TITLE
kata-webhook: Update README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ginkgo
 !/**/ginkgo
 /cmd/log-parser/kata-log-parser
 functional/vfio/config.json
+kata-webhook/vendor

--- a/kata-webhook/README.md
+++ b/kata-webhook/README.md
@@ -10,6 +10,7 @@ Kubernetes YAML files required to instantiate the admission
 controller.
 
 ```bash
+$ cp -a ../vendor .
 $ docker build -t katadocker/kata-webhook-example:latest .
 $ ./create_certs.sh
 ```


### PR DESCRIPTION
The whole vendor directory has to be copied under the kata-webhook
directoy, otherwise we'll face failures such as:
```
fidencio@laerte ~/go/src/github.com/kata-containers/tests/kata-webhook $ docker build -t katadocker/kata-webhook-example:latest .
Sending build context to Docker daemon  13.82kB
Step 1/7 : FROM golang:latest AS builder
 ---> 2421885b04da
Step 2/7 : WORKDIR /go/src/kata-pod-annotate
 ---> Using cache
 ---> 2fbde962f238
Step 3/7 : COPY . ./
 ---> Using cache
 ---> 20cf32a11a54
Step 4/7 : RUN CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate
 ---> Running in a90ab84e36bc
main.go:18:2: cannot find package "github.com/slok/kubewebhook/pkg/http" in any of:
	/usr/local/go/src/github.com/slok/kubewebhook/pkg/http (from $GOROOT)
	/go/src/github.com/slok/kubewebhook/pkg/http (from $GOPATH)
main.go:19:2: cannot find package "github.com/slok/kubewebhook/pkg/log" in any of:
	/usr/local/go/src/github.com/slok/kubewebhook/pkg/log (from $GOROOT)
	/go/src/github.com/slok/kubewebhook/pkg/log (from $GOPATH)
main.go:20:2: cannot find package "github.com/slok/kubewebhook/pkg/webhook/context" in any of:
	/usr/local/go/src/github.com/slok/kubewebhook/pkg/webhook/context (from $GOROOT)
	/go/src/github.com/slok/kubewebhook/pkg/webhook/context (from $GOPATH)
main.go:21:2: cannot find package "github.com/slok/kubewebhook/pkg/webhook/mutating" in any of:
	/usr/local/go/src/github.com/slok/kubewebhook/pkg/webhook/mutating (from $GOROOT)
	/go/src/github.com/slok/kubewebhook/pkg/webhook/mutating (from $GOPATH)
main.go:15:2: cannot find package "k8s.io/api/core/v1" in any of:
	/usr/local/go/src/k8s.io/api/core/v1 (from $GOROOT)
	/go/src/k8s.io/api/core/v1 (from $GOPATH)
main.go:16:2: cannot find package "k8s.io/apimachinery/pkg/apis/meta/v1" in any of:
	/usr/local/go/src/k8s.io/apimachinery/pkg/apis/meta/v1 (from $GOROOT)
	/go/src/k8s.io/apimachinery/pkg/apis/meta/v1 (from $GOPATH)
The command '/bin/sh -c CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate' returned a non-zero code: 1
```

Fixes: #2479

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>