### PR TITLE
ci: Do not install latest bats version

### DIFF
--- a/.ci/install_bats.sh
+++ b/.ci/install_bats.sh
@@ -7,12 +7,16 @@
 
 set -e
 
-which bats && exit
-
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
 BATS_REPO="github.com/bats-core/bats-core"
+version=$(get_test_version "externals.bats.version")
 
 echo "Install BATS from sources"
 go get -d "${BATS_REPO}" || true
 pushd "${GOPATH}/src/${BATS_REPO}"
+# This is related with https://github.com/bats-core/bats-core/issues/290
+# and with https://github.com/bats-core/bats-core/issues/292
+git checkout "${version}"
 sudo -E PATH=$PATH sh -c "./install.sh /usr"
 popd

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -129,6 +129,10 @@ if systemctl is-active --quiet docker; then
 fi
 
 echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
+installed_bats_version=$(bats --version | cut -d ' ' -f2 | cut -d '.' -f1-2)
+if [[ "${installed_bats_version}" < "1.2" ]]; then
+	sudo sed -i 's/--jobs "$JOBS"//g' test_runner.sh
+fi
 ./test_runner.sh ctr.bats
 
 popd

--- a/versions.yaml
+++ b/versions.yaml
@@ -38,6 +38,10 @@ docker_images:
 externals:
   description: "Third-party projects used specifically for testing"
 
+  bats:
+    description: "Bats is a TAP-compliant testing framework for Bash"
+    version: "v1.1.0"
+
   flannel:
     url: "https://github.com/coreos/flannel"
     version: "862c448ef28fd890e2ac4e5fddc49e7fe9693b31"


### PR DESCRIPTION
We should not install the latest bats version as it has issues
when we skip tests https://github.com/bats-core/bats-core/issues/292
and when we are running in parallel https://github.com/bats-core/bats-core/issues/290.

Fixes #2483

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>