### PR TITLE
functional: apply device constraints to vfio test

### DIFF
--- a/functional/vfio/config.json.in
+++ b/functional/vfio/config.json.in
@@ -123,11 +123,18 @@
 			"uid": 0,
 			"gid": 0
 		}],
+		"cgroupsPath": "kata/vfiotest",
 		"resources": {
-			"devices": [{
-				"allow": true,
-				"access": "rwm"
-			}]
+			"devices": [
+				{"allow":false,"access":"rwm"},
+				{"allow":true,"type":"c","major":1,"minor":3,"access":"rwm"},
+				{"allow":true,"type":"c","major":1,"minor":5,"access":"rwm"},
+				{"allow":true,"type":"c","major":1,"minor":8,"access":"rwm"},
+				{"allow":true,"type":"c","major":1,"minor":9,"access":"rwm"},
+				{"allow":true,"type":"c","major":5,"minor":0,"access":"rwm"},
+				{"allow":true,"type":"c","major":5,"minor":1,"access":"rwm"},
+				{"allow": true,"access": "rwm","major": @VFIO_MAJOR@,"minor": @VFIO_MINOR@,"type": "c"}
+			]
 		},
 		"namespaces": [{
 				"type": "pid"


### PR DESCRIPTION
vfio test should not have access to all host devices, instead the runtime
should be able to identify what devices are needed and update the device
cgroup when `sandbox_cgroup_only` is true.

fixes #2486

Signed-off-by: Julio Montes <julio.montes@intel.com>