### PR TITLE
backport fixes 1.9

### DIFF
--- a/.ci/install_bats.sh
+++ b/.ci/install_bats.sh
@@ -7,12 +7,16 @@
 
 set -e
 
-which bats && exit
-
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
 BATS_REPO="github.com/bats-core/bats-core"
+version=$(get_test_version "externals.bats.version")
 
 echo "Install BATS from sources"
 go get -d "${BATS_REPO}" || true
 pushd "${GOPATH}/src/${BATS_REPO}"
+# This is related with https://github.com/bats-core/bats-core/issues/290
+# and with https://github.com/bats-core/bats-core/issues/292
+git checkout "${version}"
 sudo -E PATH=$PATH sh -c "./install.sh /usr"
 popd

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -129,6 +129,10 @@ if systemctl is-active --quiet docker; then
 fi
 
 echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
+installed_bats_version=$(bats --version | cut -d ' ' -f2 | cut -d '.' -f1-2)
+if [[ "${installed_bats_version}" < "1.2" ]]; then
+	sudo sed -i 's/--jobs "$JOBS"//g' test_runner.sh
+fi
 ./test_runner.sh ctr.bats
 
 popd

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -14,6 +14,7 @@ source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
 export JOBS="${JOBS:-$(nproc)}"
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.
@@ -127,6 +128,7 @@ if systemctl is-active --quiet docker; then
 	sudo systemctl stop docker
 fi
 
+echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
 ./test_runner.sh ctr.bats
 
 popd

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -114,7 +114,7 @@ kubectl get nodes
 kubectl get pods
 
 # default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation
-flannel_version="bc79dd1505b0c8681ece4de4c0d86c5cd2643275"
+flannel_version="$(get_test_version "externals.flannel.version")"
 flannel_url="https://raw.githubusercontent.com/coreos/flannel/${flannel_version}/Documentation/kube-flannel.yml"
 
 arch=$("${SCRIPT_PATH}/../../.ci/kata-arch.sh")
@@ -129,14 +129,6 @@ kubectl apply -f "$network_plugin_config"
 
 # we need to ensure a few specific pods ready and running
 wait_pods_ready
-
-# Add 'cniVersion' to the flannel configuration file.
-# Fix needed just for flannel to let cni release ip addresses,
-# we should remove after https://github.com/coreos/flannel/pull/1135
-# gets merged and we update flannel_version above.
-if [ "$network_plugin_config" == "$flannel_url" ]; then
-	sudo sed -i '/cbr0/a\  "cniVersion": "0.3.1",' "${cni_config_dir}/10-flannel.conflist"
-fi
 
 runtimeclass_files_path="${SCRIPT_PATH}/runtimeclass_workloads"
 echo "Create kata RuntimeClass resource"

--- a/versions.yaml
+++ b/versions.yaml
@@ -38,6 +38,10 @@ docker_images:
 externals:
   description: "Third-party projects used specifically for testing"
 
+  flannel:
+    url: "https://github.com/coreos/flannel"
+    version: "862c448ef28fd890e2ac4e5fddc49e7fe9693b31"
+
   xurls:
     description: |
       Tool used by the CI to check URLs in documents and code comments.

--- a/versions.yaml
+++ b/versions.yaml
@@ -38,6 +38,10 @@ docker_images:
 externals:
   description: "Third-party projects used specifically for testing"
 
+  bats:
+    description: "Bats is a TAP-compliant testing framework for Bash"
+    version: "v1.1.0"
+
   flannel:
     url: "https://github.com/coreos/flannel"
     version: "862c448ef28fd890e2ac4e5fddc49e7fe9693b31"


### PR DESCRIPTION
ad13a09 ci: Do not install latest bats version
b3c2707 cri-o: tests: specify kata as CONTAINER_RUNTIME
6189a08 ci: Update flannel version
