### PR TITLE
ci: fix metrics CI

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 122904.0
+midval = 135767.0
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,6 +42,6 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 49821.0
+midval = 61380.0
 minpercent = 5.0
 maxpercent = 5.0


### PR DESCRIPTION
Increase memory-footprint `midval` to consider the memory overhead added by
`CONFIG_RANDOMIZE_BASE` in the guest kernel.

fixes #2500
fixes kata-containers/ci#273

Signed-off-by: Julio Montes <julio.montes@intel.com>