### PR TITLE
ci: update the way we get crio version

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -21,7 +21,7 @@ crio_config_file="/etc/crio/crio.conf"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/kata-runtime"
 
-minor_crio_version=$(crio --version | head -1 | cut -d '.' -f2)
+minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1 | cut -d '.' -f2)
 
 if [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -149,7 +149,7 @@ popd
 echo "Set manage_ns_lifecycle to true"
 network_ns_flag="manage_ns_lifecycle"
 # Set ns_network_flag for CRI-O versions less than 1.17
-crio_version_current=$(crio --version | head -1 | cut -d ' ' -f3)
+crio_version_current=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1)
 if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
 	network_ns_flag="manage_network_ns_lifecycle"
 fi


### PR DESCRIPTION
We need to update how we get the value of the crio version
as the output of `crio --version` has changed since
crio 1.18.0.
This change now works with new and old versions of crio.

Fixes: #2506.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>