### PR TITLE
test: Skip pmem integration test on CentOS

### DIFF
--- a/integration/pmem/pmem_test.sh
+++ b/integration/pmem/pmem_test.sh
@@ -25,7 +25,7 @@ device_name=""
 TEST_INITRD="${TEST_INITRD:-no}"
 experimental_qemu="${experimental_qemu:-false}"
 
-if [ "$ID" == "fedora" ] || [ "$TEST_INITRD" == "yes" ] || [ "$experimental_qemu" == "true" ]; then
+if [ "$ID" == "fedora" ] || [ "$ID" == "centos" ] || [ "$TEST_INITRD" == "yes" ] || [ "$experimental_qemu" == "true" ]; then
 	issue="https://github.com/kata-containers/tests/issues/2437"
 	echo "Skip pmem test ${issue}"
 	exit 0


### PR DESCRIPTION
pmem test is not working on CentOS 8, we need to skip this test
in order to enable CentOS 8 CI.

Fixes #2528

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>