### PR TITLE
metrics: Get runc name

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -93,7 +93,8 @@ EOF
 		metrics_json_add_fragment "$json"
 	else
 		if [ "$RUNTIME" == "runc" ]; then
-			local output=$(docker-runc -v)
+			local get_binary=$(sudo docker info --format "{{.Runtimes.runc.Path}}")
+			local output=$("${get_binary}" -v)
 			local runcversion=$(grep version <<< "$output" | sed 's/runc version //')
 			local runccommit=$(grep commit <<< "$output" | sed 's/commit: //')
 			local json="$(cat << EOF


### PR DESCRIPTION
This PR does not hard code runc names for the metrics code, this will get
the runtime form the docker in order to avoid failures related that runc
is not found.

Fixes #1796

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>