### PR TITLE
ci: Allow to overwrite the repositories

### DIFF
--- a/.ci/install_agent.sh
+++ b/.ci/install_agent.sh
@@ -12,4 +12,4 @@ tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/agent" "" "" "${tag}"
+build_and_install "${agent_repo}" "" "" "${tag}"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -16,7 +16,6 @@ cidir=$(dirname "$0")
 arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
 # Where real kata build script exist, via docker build to avoid install all deps
-packaging_repo="github.com/kata-containers/packaging"
 latest_build_url="${jenkins_url}/job/cloud-hypervisor-nightly-$(uname -m)/${cached_artifacts_path}"
 clh_bin_name="cloud-hypervisor"
 clh_install_path="/usr/bin/${clh_bin_name}"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -48,8 +48,7 @@ fi
 IMAGE_OS_KEY="assets.${IMG_TYPE}.architecture.$(uname -m).name"
 IMAGE_OS_VERSION_KEY="assets.${IMG_TYPE}.architecture.$(uname -m).version"
 
-agent_path="${GOPATH}/src/github.com/kata-containers/agent"
-osbuilder_repo="github.com/kata-containers/osbuilder"
+agent_path="${GOPATH}/src/${agent_repo}"
 osbuilder_path="${GOPATH}/src/${osbuilder_repo}"
 latest_build_url="${jenkins_url}/job/image-nightly-$(uname -m)/${cached_artifacts_path}"
 tag="${1:-""}"

--- a/.ci/install_kata_image_rust.sh
+++ b/.ci/install_kata_image_rust.sh
@@ -11,8 +11,7 @@ set -o pipefail
 set -o errtrace
 
 cidir=$(dirname "$0")
-rust_agent_repo="github.com/kata-containers/kata-containers"
-osbuilder_repo="github.com/kata-containers/osbuilder"
+source "${cidir}/lib.sh"
 arch=$("${cidir}"/kata-arch.sh -d)
 
 install_rust() {

--- a/.ci/install_proxy.sh
+++ b/.ci/install_proxy.sh
@@ -12,4 +12,4 @@ tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/proxy" "" "" "${tag}"
+build_and_install "${proxy_repo}" "" "" "${tag}"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -24,7 +24,6 @@ QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
 # Remove 'https://' from the repo url to be able to git clone the repo
 QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
-PACKAGING_REPO="github.com/kata-containers/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
 QEMU_TAR="kata-static-qemu.tar.gz"
 qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
@@ -37,8 +36,8 @@ build_static_qemu() {
 	# only x86_64 is supported for building static QEMU
 	[ "$ARCH" != "x86_64" ] && return 1
 
-	go get -d "${PACKAGING_REPO}" || true
-	prefix="${KATA_QEMU_DESTDIR}" "${GOPATH}/src/${PACKAGING_REPO}/static-build/qemu/build-static-qemu.sh"
+	go get -d "${packaging_repo}" || true
+	prefix="${KATA_QEMU_DESTDIR}" "${GOPATH}/src/${packaging_repo}/static-build/qemu/build-static-qemu.sh"
 
 	# We need to move the tar file to a specific location so we
 	# can know where it is and then we can perform the build cache
@@ -83,10 +82,10 @@ build_and_install_qemu() {
 		die "QEMU will not be installed"
 	fi
 
-	QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
+	QEMU_CONFIG_SCRIPT="${GOPATH}/src/${packaging_repo}/scripts/configure-hypervisor.sh"
 
 	mkdir -p "${GOPATH}/src"
-	go get -d "$PACKAGING_REPO" || true
+	go get -d "$packaging_repo" || true
 
 	clone_qemu_repo
 
@@ -97,7 +96,7 @@ build_and_install_qemu() {
 
 	# Apply required patches
 	QEMU_PATCHES_TAG=$(echo "${CURRENT_QEMU_VERSION}" | cut -d '.' -f1-2)
-	QEMU_PATCHES_PATH="${GOPATH}/src/${PACKAGING_REPO}/qemu/patches/${QEMU_PATCHES_TAG}.x"
+	QEMU_PATCHES_PATH="${GOPATH}/src/${packaging_repo}/qemu/patches/${QEMU_PATCHES_TAG}.x"
 	for patch in ${QEMU_PATCHES_PATH}/*.patch; do
 		echo "Applying patch: $patch"
 		git apply "$patch"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -18,7 +18,6 @@ source /etc/os-release || source /usr/lib/os-release
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
-PACKAGING_REPO="github.com/kata-containers/packaging"
 QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
@@ -52,8 +51,8 @@ build_and_install_static_experimental_qemu() {
 
 build_experimental_qemu() {
 	mkdir -p "${GOPATH}/src"
-	go get -d "$PACKAGING_REPO" || true
-	"${GOPATH}/src/${PACKAGING_REPO}/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
+	go get -d "$packaging_repo" || true
+	"${GOPATH}/src/${packaging_repo}/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -41,7 +41,7 @@ runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
-build_and_install "github.com/kata-containers/runtime" "" "true" "${tag}"
+build_and_install "${runtime_repo}" "" "true" "${tag}"
 experimental_qemu="${experimental_qemu:-false}"
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then

--- a/.ci/install_shim.sh
+++ b/.ci/install_shim.sh
@@ -12,4 +12,4 @@ tag="$1"
 
 source "${cidir}/lib.sh"
 
-build_and_install "github.com/kata-containers/shim" "" "" "${tag}"
+build_and_install "${shim_repo}" "" "" "${tag}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -6,6 +6,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Repositories needed for building the kata containers project.
+export agent_repo="${agent_repo:-github.com/kata-containers/agent}"
+export proxy_repo="${proxy_repo:-github.com/kata-containers/proxy}"
+export runtime_repo="${runtime_repo:-github.com/kata-containers/runtime}"
+export shim_repo="${shim_repo:-github.com/kata-containers/shim}"
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+export packaging_repo="${packaging_repo:-github.com/kata-containers/packaging}"
+export osbuilder_repo="${osbuilder_repo:-github.com/kata-containers/osbuilder}"
+export katacontainers_repo="${katacontainers_repo:-github.com/kata-containers/kata-containers}"
+export rust_agent_repo="${rust_agent_repo:-github.com/kata-containers/kata-containers}"
+
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
@@ -33,7 +44,6 @@ else
 	export GOPATH="${GOPATH:-$HOME/go}"
 fi
 
-tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"
 
@@ -132,7 +142,6 @@ function get_dep_from_yaml_db(){
 
 function get_version(){
 	dependency="$1"
-	runtime_repo="github.com/kata-containers/runtime"
 	runtime_repo_dir="$GOPATH/src/${runtime_repo}"
 	versions_file="${runtime_repo_dir}/versions.yaml"
 	mkdir -p "$(dirname ${runtime_repo_dir})"

--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -7,15 +7,9 @@
 
 set -e
 
-# Repositories needed for building the kata containers project.
-agent_repo="${agent_repo:-github.com/kata-containers/agent}"
-proxy_repo="${proxy_repo:-github.com/kata-containers/proxy}"
-runtime_repo="${runtime_repo:-github.com/kata-containers/runtime}"
-shim_repo="${shim_repo:-github.com/kata-containers/shim}"
-tests_repo="${tests_repo:-github.com/kata-containers/tests}"
-packaging_repo="${packaging_repo:-github.com/kata-containers/packaging}"
-osbuilder_repo="${osbuilder_repo:-github.com/kata-containers/osbuilder}"
-katacontainers_repo="${katacontainers_repo:-github.com/kata-containers/kata-containers}"
+cidir=$(dirname "$0")
+source /etc/os-release || source /usr/lib/os-release
+source "${cidir}/lib.sh"
 
 apply_depends_on() {
 	# kata_repo variable is set by the jenkins_job_build.sh

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -15,7 +15,6 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="${GOPATH}/src/${tests_repo}"
 
 # List of files to delete on exit

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -73,8 +73,7 @@ create_user_data() {
 		fi
 	fi
 
-	test_repo="github.com/kata-containers/tests"
-	tests_go_path="/home/${USER}/go/src/${test_repo}"
+	tests_go_path="/home/${USER}/go/src/${tests_repo}"
 
 	cat <<EOF > "${file}"
 #cloud-config


### PR DESCRIPTION
The resolve-kata-dependencies.sh allows to overwrite
the kata-containers repositories, this results in
cloning them from arbitrary locations (usually a fork). Other
scripts,however, does not allow that because they have
hard-coded in values. One example is install_proxy.sh
which always clone and build from
github.com/kata-containers/proxy

So this change adapt those scripts to allow cloning and
building from arbitrary locations too.

Fixes #2535

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>