### PR TITLE
test: Skip entropy time test on SLES

### DIFF
--- a/integration/entropy/entropy_time.bats
+++ b/integration/entropy/entropy_time.bats
@@ -10,7 +10,7 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 issue="https://github.com/kata-containers/tests/issues/2351"
 
 setup() {
-	[ "${ID}" == "opensuse-leap" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "opensuse-leap" ] || [ "${ID}" == sles ] && skip "test not working see: ${issue}"
 	clean_env
 	# Check that processes are not running
 	run check_processes
@@ -19,7 +19,7 @@ setup() {
 }
 
 @test "measured time for /dev/random" {
-	[ "${ID}" == "opensuse-leap" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "opensuse-leap" ] || [ "${ID}" == sles ] && skip "test not working see: ${issue}"
 	output_file=$(mktemp)
 	block_size="4b"
 	expected_time="40"
@@ -33,7 +33,7 @@ setup() {
 }
 
 teardown() {
-	[ "${ID}" == "opensuse-leap" ] && skip "test not working see: ${issue}"
+	[ "${ID}" == "opensuse-leap" ] || [ "${ID}" == sles ] && skip "test not working see: ${issue}"
 	clean_env
 	rm "$output_file"
 	# Check that processes are not running


### PR DESCRIPTION
We have seen random failures on SLES CI for the entropy time test, currently
we are trying to debug this issue and reproduce it locally. This PR skips
meanwhile this test in order to have a more stable CI.

Fixes #2538

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>