### PR TITLE
CI: Make static checker ignore more auto-generated code

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -441,6 +441,7 @@ static_check_license_headers()
 		--exclude="LICENSE" \
 		--exclude="*.md" \
 		--exclude="*.pb.go" \
+		--exclude="*pb_test.go" \
 		--exclude="*.png" \
 		--exclude="*.pub" \
 		--exclude="*.service" \


### PR DESCRIPTION
Add a new regex to ignore more auto-generated code.

Fixes: #2542.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>