### PR TITLE
ci: Offer no systemd kata image installation helper

### DIFF
--- a/.ci/install_kata_image_nosystemd.sh
+++ b/.ci/install_kata_image_nosystemd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+rust_agent_repo="github.com/kata-containers/kata-containers"
+osbuilder_repo="github.com/kata-containers/osbuilder"
+arch=$("${cidir}"/kata-arch.sh -d)
+
+build_image() {
+	go get -d "${osbuilder_repo}" || true
+	pushd "${GOPATH}/src/${osbuilder_repo}/rootfs-builder"
+	export ROOTFS_DIR="${GOPATH}/src/${osbuilder_repo}/rootfs-builder/rootfs"
+
+	#Currently, only alpine support no systemd"
+	distro="alpine"
+	sudo -E GOPATH="${GOPATH}" USE_DOCKER=true SECCOMP=no ./rootfs.sh "${distro}"
+	install -o root -g root -m 0550 -T ../../agent/kata-agent ${ROOTFS_DIR}/sbin/init
+	popd
+
+	pushd "${GOPATH}/src/${osbuilder_repo}"
+	sudo -E USE_DOCKER=1 DISTRO="${distro}" AGENT_INIT=yes ./image-builder/image_builder.sh ${ROOTFS_DIR}
+
+	image_path="/usr/share/kata-containers/"
+	sudo mkdir -p "${image_path}"
+	sudo install -D "${GOPATH}/src/${osbuilder_repo}/kata-containers.img" "${image_path}"
+	popd
+}
+
+main() {
+	build_image
+}
+
+main


### PR DESCRIPTION
The startup of systemd service consumes lots of time when
kata boot up. so using kata image without systemd will largely
optimize bootup time of kata.
for now, only alpine support no systemd, so alpine is the only
choice for installation of no systemd kata image.
Also using alpine will decrease the memory footprint.

Fixes: #2544
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @devimc @bergwolf 