### PR TITLE
ci: Copy config file instead of moving

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -54,7 +54,7 @@ fi
 
 enable_hypervisor_config(){
 	local path=$1
-	sudo mv "$path" "${PKGDEFAULTSDIR}/configuration.toml"
+	sudo ln -f "$path" "${PKGDEFAULTSDIR}/configuration.toml"
 
 }
 

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -194,6 +194,9 @@ if [ -n "${METRICS_CI}" ]; then
 	echo "Running the metrics tests:"
 	"${tests_repo_dir}/.ci/run_metrics_PR_ci.sh"
 elif [ -n "${VFIO_CI}" ]; then
+	echo "Installing initrd image:"
+	TEST_INITRD=yes "${ci_dir_name}/install_kata_image.sh"
+
 	echo "Running VFIO tests:"
 	"${ci_dir_name}/run.sh"
 else

--- a/Makefile
+++ b/Makefile
@@ -301,10 +301,14 @@ vcpus:
 	bash -f integration/vcpus/default_vcpus_test.sh
 
 vfio:
-	bash -f functional/vfio/run.sh -s false -p qemu -m pc
-	bash -f functional/vfio/run.sh -s true -p qemu -m pc
-	bash -f functional/vfio/run.sh -s false -p qemu -m q35
-	bash -f functional/vfio/run.sh -s true -p qemu -m q35
+	bash -f functional/vfio/run.sh -s false -p qemu -m pc -i image
+	bash -f functional/vfio/run.sh -s true -p qemu -m pc -i image
+	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i image
+	bash -f functional/vfio/run.sh -s true -p qemu -m q35 -i image
+	bash -f functional/vfio/run.sh -s false -p qemu -m pc -i initrd
+	bash -f functional/vfio/run.sh -s true -p qemu -m pc -i initrd
+	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i initrd
+	bash -f functional/vfio/run.sh -s true -p qemu -m q35 -i initrd
 
 ipv6:
 	bash -f integration/ipv6/ipv6.sh


### PR DESCRIPTION
Copy config file instead of moving so that the original is still
available.

Fixes #2551

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>