### PR TITLE
metrics: Note use of RUNTIME in documentation

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -14,6 +14,7 @@
         * [Density](#density)
         * [Networking](#networking)
         * [Storage](#storage)
+    * [Configuring `RUNTIME`](#configuring-runtime)
     * [Saving Results](#saving-results)
         * [JSON API](#json-api)
             * [`metrics_json_init()`](#metrics_json_init)
@@ -154,8 +155,18 @@ Tests relating to the storage (graph, volume) drivers. Measures may include:
 
 For further details see the [storage tests documentation](storage).
 
-## Saving Results
+## Configuring `RUNTIME`
 
+All metrics tests support setting the container runtime to test against by setting the
+`RUNTIME` environment variable. If unset, the default runtime used is `kata-runtime`.
+For example, to test launch times against the `kata-clh` runtime, you would:
+
+```bash
+export RUNTIME=kata-clh
+./time/launch_times.sh -i ubuntu -n 20
+```
+
+## Saving Results
 
 In order to ensure continuity, and thus testing and historical tracking of results,
 we provide a bash API to aid storing results in a uniform manner.

--- a/metrics/report/README.md
+++ b/metrics/report/README.md
@@ -28,6 +28,9 @@ Repeat this process if you want to compare multiple sets of results. Note, the
 report generation scripts process all subdirectories of `tests/metrics/results` when
 generating the report.
 
+The container runtime used for the testing can be set via the `RUNTIME` environment
+variable. The default runtime used for the tests is `kata-runtime`.
+
 > **Note:** By default, the `grabdata.sh` script tries to launch some moderately
 > large containers (i.e. 8Gbyte RAM) and may fail to produce some results on a memory
 > constrained system.


### PR DESCRIPTION
Note in the documentation that you can set `RUNTIME` in the environment to determine which container runtime the tests are run against.