### PR TITLE
metrics: report: make fio percentile x-axis readable

### DIFF
--- a/metrics/report/report_dockerfile/fio-reads.R
+++ b/metrics/report/report_dockerfile/fio-reads.R
@@ -231,7 +231,12 @@ render_fio_reads <- function() {
 			legend.title=element_text(size=5),
 			legend.text=element_text(size=5),
 			legend.background = element_rect(fill=alpha('blue', 0.2))
-		)
+		) +
+		# We know this is a 0-100% x-axis, so make nice divisions, as the interesting results
+		# tend to be scrunched up at the 95+% end, and it's just easier to eyball them than with
+		# the default. Hard wire to 10 divisions (instead of the default of 8).
+		scale_x_continuous(breaks=seq(0, 100, by=10))
+
 
 	# Output the pretty pictures
 	graphics_plot = grid.arrange(

--- a/metrics/report/report_dockerfile/fio-writes.R
+++ b/metrics/report/report_dockerfile/fio-writes.R
@@ -224,7 +224,12 @@ render_fio_writes <- function() {
 			legend.title=element_text(size=5),
 			legend.text=element_text(size=5),
 			legend.background = element_rect(fill=alpha('blue', 0.2))
-		)
+		) +
+		# We know this is a 0-100% x-axis, so make nice divisions, as the interesting results
+		# tend to be scrunched up at the 95+% end, and it's just easier to eyball them than with
+		# the default. Hard wire to 10 divisions (instead of the default of 8).
+		scale_x_continuous(breaks=seq(0, 100, by=10))
+
 
 	master_plot = grid.arrange(
 		write_bw_line_plot,


### PR DESCRIPTION
The x-axis on the fio latency percentile graphs was using the default
divisons, which was 'divide into 8', which placed each division tickmark
at 12.5% intervals. That's not useful for visually assessing the data.
Fix the intervals at 10%, which although a touch dense and noisy, does
make it much easier to assess the graph, particularly at the 'knee'
point, which tends to be crammed into the top 10% of the data.

Fixes: #2558

Signed-off-by: Graham Whaley <graham.whaley@intel.com>