### PR TITLE
spellcheck: Add tracing project names

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -29,6 +29,7 @@ Huawei/B
 iPerf/B
 IPerf/B
 Istio/B
+Jaeger/B
 Jenkins/B
 journald/B
 Kata/B
@@ -47,10 +48,12 @@ Minikube/B
 MITRE/B
 Netlify/B
 Nginx/B
+OpenCensus/B
 OpenPGP/B
 OpenShift/B
 OpenSSL/B
 OpenStack/B
+OpenTelemetry/B
 OpenTracing/B
 osbuilder/B
 packagecloud/B


### PR DESCRIPTION
Add more tracing project names to the spell checker.

Fixes: #2560.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>