### PR TITLE
common: match more kata runtimes in generic check func

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -58,9 +58,7 @@ trap 'handle_error $LINENO' ERR
 # and recommended Kata docker runtime install names.
 is_a_kata_runtime(){
 	case "$1" in
-	"kata-runtime") ;&	# fallthrough
-	"kata-qemu") ;&		# fallthrough
-	"kata-fc")
+	"kata"*)
 		echo "1"
 		return
 		;;


### PR DESCRIPTION
We have a generic 'is_a_kata_runtime' function that was a bit
hard wired to specific names. We have a growing collection of kata
runtime names now, so let's get a little more flexible in our spotting
by just going for any runtime named 'kata*'.
Specifically, this now matches kata-qemu-virtiofs for instance.

Fixes: #2564

Signed-off-by: Graham Whaley <graham.whaley@intel.com>