### PR TITLE
ci: Enable RHEL 8 CI

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -168,7 +168,10 @@ main() {
 	sudo -E PATH=$PATH bash -c "echo 3 > /proc/sys/vm/drop_caches"
 
 	if [ "$ID" == rhel ]; then
-		sudo -E PATH=$PATH bash -c "echo 1 > /proc/sys/fs/may_detach_mounts"
+		major_version=$(echo $VERSION_ID | cut -d '.' -f1)
+		if [ "${major_version}" == "7" ]; then
+			sudo -E PATH=$PATH bash -c "echo 1 > /proc/sys/fs/may_detach_mounts"
+		fi
 	fi
 }
 

--- a/functional/state_test.go
+++ b/functional/state_test.go
@@ -57,7 +57,7 @@ var _ = Describe("state", func() {
 
 	DescribeTable("container",
 		func(status string, waitTime int) {
-			if distroID() == "centos" {
+			if distroID() == "centos" || distroID() == "rhel" {
 				Skip("Issue:https://github.com/kata-containers/tests/issues/2264")
 			}
 

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -9,6 +9,8 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+source /etc/os-release || source /usr/lib/os-release
+
 DEBUG=${DEBUG:-}
 [ -n "$DEBUG" ] && set -o xtrace
 
@@ -22,6 +24,13 @@ TRACE_LOG_DIR=${TRACE_LOG_DIR:-${KATA_TESTS_LOGDIR}/traces}
 jaeger_server=${jaeger_server:-localhost}
 jaeger_ui_port=${jaeger_ui_port:-16686}
 jaeger_docker_container_name="jaeger"
+
+issue="https://github.com/kata-containers/tests/issues/2566"
+
+if [ "$ID" == rhel ]; then
+	echo "Skip tracing test on $ID, see: $issue"
+	exit
+fi
 
 # Cleanup will remove Jaeger container and
 # disable tracing.


### PR DESCRIPTION
This PR enables rhel 8 CI. In this PR, we skipped the tests that are not running
on RHEL 8 as well as a modification in the setup.sh

Fixes #2540

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>