### PR TITLE
ci: Enable podman cloud hypervisor CI

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -174,6 +174,11 @@ fi
 # - If the repo is not "tests", call the repo-specific script (which is
 #   expected to call the script of the same name in the "tests" repo).
 case "${CI_JOB}" in
+"CLOUD-HYPERVISOR-PODMAN")
+        export KATA_HYPERVISOR="cloud-hypervisor"
+        export TEST_CGROUPSV2="true"
+        export experimental_kernel="true"
+        ;;
 "CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s
 	export CRI_CONTAINERD="yes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -66,6 +66,14 @@ case "${CI_JOB}" in
 		echo "INFO: Running docker integration tests"
 		sudo -E PATH="$PATH" bash -c "make docker"
 		;;
+	"CLOUD-HYPERVISOR-PODMAN")
+		export TRUSTED_GROUP="kvm"
+		newgrp "${TRUSTED_GROUP}" << END
+		echo "This is running as group $(id -gn)"
+END
+		echo "INFO: Running podman integration tests"
+		bash -c "make podman"
+		;;
 	"CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"
 		;;


### PR DESCRIPTION
This PR enables the posiblity to run a podman cloud hypervisor CI.

Fixes #2547

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>