### PR TITLE
 k8s: e2e: Move focus list to yaml

### DIFF
--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -15,8 +15,8 @@ jobs:
     passed: 222
   minimal:
     focus:
-      - Secrets should be consumable via the environment
       - ConfigMap should be consumable from pods in volume
-      - Projected secret should be consumable in multiple volumes
-      - Kubelet when scheduling a busybox command in a pod should printk
       - InitContainer \[NodeConformance\] should invoke init containers
+      - Kubelet when scheduling a busybox command in a pod should printk
+      - Projected secret should be consumable in multiple volumes
+      - Secrets should be consumable via the environment

--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -13,3 +13,10 @@ jobs:
     passed: 223
   CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
     passed: 222
+  minimal:
+    focus:
+      - Secrets should be consumable via the environment
+      - ConfigMap should be consumable from pods in volume
+      - Projected secret should be consumable in multiple volumes
+      - Kubelet when scheduling a busybox command in a pod should printk
+      - InitContainer \[NodeConformance\] should invoke init containers

--- a/integration/kubernetes/e2e_conformance/run.sh
+++ b/integration/kubernetes/e2e_conformance/run.sh
@@ -28,6 +28,8 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
 # Overall Sonobuoy timeout in minutes.
 WAIT_TIME=${WAIT_TIME:-180}
 
+JOBS_FILE="${SCRIPT_PATH}/e2e_k8s_jobs.yaml"
+
 create_kata_webhook() {
 	pushd "${SCRIPT_PATH}/../../../kata-webhook" >> /dev/null
 	# Create certificates for the kata webhook
@@ -52,6 +54,19 @@ get_sonobuoy() {
 
 }
 
+# Input:
+# - yaml list key
+# - yaml file
+# Output
+# - string: | separated values of the list
+yaml_list_to_str_regex() {
+	local list="${1}"
+	local yaml_file=${2:-"|"}
+	local query=".${list}"
+	query+=' | join("|")?'
+	yq -j read  "${yaml_file}" | jq -r "${query}"
+}
+
 run_sonobuoy() {
 	# Run Sonobuoy e2e tests
 	info "Starting sonobuoy execution."
@@ -59,35 +74,30 @@ run_sonobuoy() {
 
 	local skipped_tests_file="${SCRIPT_PATH}/skipped_tests_e2e.yaml"
 	local skipped_tests=$("${GOPATH}/bin/yq" read "${skipped_tests_file}" "${CRI_RUNTIME}")
-	local skipped_tests_hypervisor=$("${GOPATH}/bin/yq" read "${skipped_tests_file}" "hypervisor.${KATA_HYPERVISOR}")
 
 	# Default skipped tests for Conformance testing:
-	_skip_options=("Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]|")
-	mapfile -t _skipped_tests <<< "${skipped_tests}"
-	for entry in "${_skipped_tests[@]}"
-	do
-		_skip_options+=("${entry#- }|")
-	done
+	skip_options="Alpha|\[(Disruptive|Feature:[^\]]+|Flaky)\]"
+	local skip_list
+	skip_list=$(yaml_list_to_str_regex "\"${CRI_RUNTIME}\"" "${skipped_tests_file}")
+	if [ "${skip_list}" != "" ];then
+		skip_options+="|${skip_list}"
+	fi
 
-	mapfile -t _skipped_tests <<< "${skipped_tests_hypervisor}"
-	for entry in "${_skipped_tests[@]}"
-	do
-		_skip_options+=("${entry#- }|")
-	done
-
-	skip_options=$(IFS= ; echo "${_skip_options[*]}")
-	skip_options="${skip_options%|}"
+	skip_list=$(yaml_list_to_str_regex "hypervisor.\"${KATA_HYPERVISOR}\"" "${skipped_tests_file}")
+	if [ "${skip_list}" != "" ];then
+		skip_options+="|${skip_list}"
+	fi
 
 
 	if [ "${MINIMAL_K8S_E2E}" == "true" ]; then
-		FOCUS_TEST+="Secrets should be consumable via the environment"
-		FOCUS_TEST+="|ConfigMap should be consumable from pods in volume"
-		FOCUS_TEST+="|Projected secret should be consumable in multiple volumes"
-		FOCUS_TEST+="|Kubelet when scheduling a busybox command in a pod should printk"
-		FOCUS_TEST+="|InitContainer \[NodeConformance\] should invoke init containers"
-		sonobuoy run --e2e-focus="${FOCUS_TEST}" --e2e-skip="$skip_options" --wait="$WAIT_TIME"
+		minimal_focus=$(yaml_list_to_str_regex "jobs.minimal.focus" "${JOBS_FILE}")
+		set -x
+		sonobuoy run --e2e-focus="${minimal_focus}" --wait="$WAIT_TIME"
+		set +x
 	else
+		set -x
 		sonobuoy run --e2e-skip="$skip_options" --wait="$WAIT_TIME"
+		set +x
 	fi
 
 	e2e_result_dir="$(mktemp -d /tmp/kata_e2e_results.XXXXX)"
@@ -111,12 +121,11 @@ run_sonobuoy() {
 			if [ "$CI" == true ]; then
 				cat "$e2e_result_log"
 			fi
-			sonobuoy status --json | jq {failed_query}
+			sonobuoy status --json | jq "${failed_query}"
 			die "Found failed tests in end-to-end k8s test"
 		fi
-		local jobs_file="${SCRIPT_PATH}/e2e_k8s_jobs.yaml"
 		local expected_passed_query="jobs.${CI_JOB:-}.passed"
-		local expected_passed=$("${GOPATH}/bin/yq" read "${jobs_file}" "${expected_passed_query}")
+		local expected_passed=$("${GOPATH}/bin/yq" read "${JOBS_FILE}" "${expected_passed_query}")
 		if [ "${expected_passed}" != "" ];then
 			passed_query='.plugins | [ .[]."result-counts".passed] | add'
 			passed=$(sonobuoy status --json | jq "${passed_query}")
@@ -126,7 +135,7 @@ run_sonobuoy() {
 				info "All ${passed} tests passed as expected"
 			fi
 		else
-			info "Not found ${expected_passed_query} for job ${CI_JOB:-} in ${jobs_file}"
+			info "Not found ${expected_passed_query} for job ${CI_JOB:-} in ${JOBS_FILE}"
 		fi
 	} |  tee "${e2e_result_dir}/summary"
 }

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -16,14 +16,14 @@ crio:
 hypervisor:
   cloud-hypervisor:
     - Daemon set \[Serial\] should rollback without unnecessary restarts
-    - \[sig-storage\] Secrets optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected secret optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected downwardAPI should update labels on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Downward API volume should update annotations on modification \[NodeConformance\] \[Conformance\]
     - \[sig-scheduling\] SchedulerPredicates \[Serial\] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP \[Conformance\]
-    - \[sig-storage\] Projected downwardAPI should update annotations on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected configMap updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Downward API volume should update labels on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected configMap optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
     - \[sig-storage\] ConfigMap optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
     - \[sig-storage\] ConfigMap updates should be reflected in volume \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Downward API volume should update annotations on modification \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Downward API volume should update labels on modification \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Projected configMap optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Projected configMap updates should be reflected in volume \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Projected downwardAPI should update annotations on modification \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Projected downwardAPI should update labels on modification \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Projected secret optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
+    - \[sig-storage\] Secrets optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]


### PR DESCRIPTION
For PRs the CI runs a subset of test to make sure e2e setup works.
Then it has a job that run once a day with full list of e2e tests.

Add list to a yaml like other test that are skipped.

Fixes: #2582

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>