### PR TITLE
clh: Enable block device hotplug related tests

### DIFF
--- a/.ci/hypervisors/clh/configuration_clh.yaml
+++ b/.ci/hypervisors/clh/configuration_clh.yaml
@@ -10,8 +10,6 @@ test:
   - docker
 docker:
   Describe:
-    - docker volume
-    - run hot plug block devices
   Context:
     - check yum update
     - check dnf update

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -38,6 +38,7 @@ trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 systemctl is-active --quiet docker || sudo systemctl start docker
 
 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
+	"k8s-block-volume.bats" \
 	"k8s-configmap.bats" \
 	"k8s-copy-file.bats" \
 	"k8s-cpu-ns.bats" \
@@ -67,13 +68,10 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-hugepages.bats")
 
 if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
-	blk_issue="https://github.com/kata-containers/tests/issues/2318"
 	sysctl_issue="https://github.com/kata-containers/tests/issues/2324"
-	info "blk ${blk_issue}"
 	info "$KATA_HYPERVISOR sysctl is failing:"
 	info "sysctls: ${sysctl_issue}"
 else
-	K8S_TEST_UNION+=("k8s-block-volume.bats")
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
 fi
 # we may need to skip a few test cases when running on non-x86_64 arch


### PR DESCRIPTION
With the support of disk block device hotplug added to clh, those tests
now should pass.

Fixes: #2318

Signed-off-by: Bo Chen <chen.bo@intel.com>