### PR TITLE
clh: enable missing end-to-end tests

### DIFF
--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -6,9 +6,9 @@
 
 jobs:
   CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL:
-    passed: 14
+    passed: 15
   CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-MINIMAL:
-    passed: 14
+    passed: 15
   CLOUD-HYPERVISOR-K8S-E2E-CRIO-FULL:
     passed: 223
   CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
@@ -20,3 +20,4 @@ jobs:
       - Kubelet when scheduling a busybox command in a pod should printk
       - Projected secret should be consumable in multiple volumes
       - Secrets should be consumable via the environment
+      - \[sig-storage\] Downward API volume should update annotations on modification \[NodeConformance\] \[Conformance\]

--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -10,9 +10,9 @@ jobs:
   CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-MINIMAL:
     passed: 15
   CLOUD-HYPERVISOR-K8S-E2E-CRIO-FULL:
-    passed: 223
+    passed: 278
   CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
-    passed: 222
+    passed: 273
   minimal:
     focus:
       - ConfigMap should be consumable from pods in volume

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -12,18 +12,3 @@ containerd:
 
 crio:
   - Daemon set \[Serial\] should rollback without unnecessary restarts
-
-hypervisor:
-  cloud-hypervisor:
-    - Daemon set \[Serial\] should rollback without unnecessary restarts
-    - \[sig-scheduling\] SchedulerPredicates \[Serial\] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP \[Conformance\]
-    - \[sig-storage\] ConfigMap optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] ConfigMap updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Downward API volume should update annotations on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Downward API volume should update labels on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected configMap optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected configMap updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected downwardAPI should update annotations on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected downwardAPI should update labels on modification \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Projected secret optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]
-    - \[sig-storage\] Secrets optional updates should be reflected in volume \[NodeConformance\] \[Conformance\]


### PR DESCRIPTION
Enable virtiofs CACHE=auto for k8s end-to-end this feature is required by some tests in k8s but is always by default.