### PR TITLE
test: fix "find: /tmp/...: Permission denied" error

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -171,7 +171,7 @@ collect_logs()
 		rm -f *".log"
 
 		# Copy results from K8s end-to-end testing
-		result_dir=$(find "/tmp" -name 'kata_e2e_results*')
+		result_dir=$(sudo find "/tmp" -name 'kata_e2e_results*')
 		e2e_result_tar=$(sudo find "${result_dir}" -name '*.tar.gz')
 		sudo cp "${e2e_result_tar}" .
 


### PR DESCRIPTION
Arm CI and ppc64 travis ci logs were all flooded with `find: /tmp/...: Permission denied` error.
And that's due to not giving find command root permission, based on most of files/dirs under ``/tmp were owned by root.

