### PR TITLE
common: Add support for cloud hypervisor

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -144,6 +144,8 @@ extract_kata_env(){
 	PROXY_VERSION="0.0.0"
 	if [ "$KATA_HYPERVISOR" == firecracker ]; then
 		HYPERVISOR_PATH="/usr/bin/firecracker"
+	elif [ "$KATA_HYPERVISOR" == "cloud-hypervisor" ]; then
+		HYPERVISOR_PATH="/usr/bin/cloud-hypervisor"
 	elif [ "$experimental_qemu" == "true" ]; then
 		HYPERVISOR_PATH="/usr/bin/qemu-virtiofs-system-$(uname -m)"
 	else


### PR DESCRIPTION
This PR adds support for cloud hypervisor, this will help to retrieve
the correct hypervisor path while running metrics.

Fixes #2589

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>