### PR TITLE
ci/install_kata: Allow to not run kata-check

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -17,6 +17,7 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 experimental_qemu="${experimental_qemu:-false}"
 TEST_RUST_AGENT="${TEST_RUST_AGENT:-false}"
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
+RUN_KATA_CHECK="${RUN_KATA_CHECK:-true}"
 
 if [ "${TEST_RUST_AGENT}" == true ]; then
 	echo "Install rust agent image"
@@ -72,5 +73,7 @@ if [ "${TEST_CGROUPSV2}" == "true" ]; then
 fi
 
 # Check system supports running Kata Containers
-kata_runtime_path=$(command -v kata-runtime)
-sudo -E PATH=$PATH "$kata_runtime_path" kata-check
+if [ "${RUN_KATA_CHECK}" == "true" ]; then
+	kata_runtime_path=$(command -v kata-runtime)
+	sudo -E PATH=$PATH "$kata_runtime_path" kata-check
+fi

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -36,6 +36,8 @@ init_ci_flags() {
 	# Use experimental kernel
 	# Values: true|false
 	export experimental_kernel="false"
+	# Run the kata-check checks
+	export RUN_KATA_CHECK="true"
 }
 
 source "/etc/os-release" || source "/usr/lib/os-release"


### PR DESCRIPTION
This change belongs to the context of issue #2527 , which in order to work needs to have kata-containers binaries (+ QEMU) installed in a well-known path (e.g. /opt/kata) inside a container image. I'm using this `.ci/install_kata.sh` script so that binaries are built and installed, and cached-on-jenkins artifacts (e.g. QEMU) are pulled in together. That script runs `kata-check` in the end, but I would like to not run it (makes no sense for my use case).

Since I'm sending it as an RFC I didn't create an related issue and the static checks of for this patch are expected to fail. 

----
The .ci/install_kata.sh script runs the kata-check by the end of the
installation process.

This change makes the script look at the RUN_KATA_CHECK environment variable
which can be set to "false" and then the checking is skipped.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>