### PR TITLE
clh: ci: Do not build image using podman

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -28,7 +28,7 @@ init_ci_flags() {
 	# - Use true for nightly testing
 	export MINIMAL_K8S_E2E="false"
 	# Test cgroup v2
-	export TEST_CGROUPSV2="no"
+	export TEST_CGROUPSV2="false"
 	# Run crio functional test
 	export TEST_CRIO="false"
 	# Run docker functional test


### PR DESCRIPTION
On cloud-hypervisor jobs when the image is not cached, the CI scripts try to
build the image from a source, but when it does uses PODMAN, the logic of the
script installation is that if TEST_CGROUPSV2 is false, it will use docker else
podman, the clh jobs export TEST_CGROUPSV2 as no. And fallback to use
podman.On clh jobs when the image is not cached, the CI scripts try to build
the image from a source, but when it does uses PODMAN, the logic of the script
installation is that if TEST_CGROUPSV2 is false, it will use docker else
podman, the clh jobs export TEST_CGROUPSV2 as no.

Use `false` to avoid the script use podaman.

Fixes: #2604

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>