### PR TITLE
ci/vfio: fix not a valid identifier

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -58,7 +58,7 @@ create_user_data() {
 	dnf_proxy=""
 	environment=$(env | egrep "ghprb|WORK|KATA|GIT|JENKINS|_PROXY|_proxy" | \
 	                    sed -e "s/'/'\"'\"'/g" \
-	                        -e "s/\(^.*\)=/\1='/" \
+	                        -e "s/\(^[[:alnum:]_]\+\)=/\1='/" \
 	                        -e "s/$/'/" \
 	                        -e 's/^/    export /')
 


### PR DESCRIPTION
the sed expression used to replace the first `=` with `='` is incorrect,
look for the variable name using [[:alnum:]_]+ not .*

fixes #2606

Signed-off-by: Julio Montes <julio.montes@intel.com>