### PR TITLE
ci: adapt scripts to consider DESTDIR when installing kata

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -31,7 +31,7 @@ TEST_INITRD=${TEST_INITRD:-no}
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 PREFIX=${PREFIX:-/usr}
-IMAGE_DIR=${PREFIX}/share/kata-containers
+IMAGE_DIR=${DESTDIR:-}${PREFIX}/share/kata-containers
 IMG_LINK_NAME="kata-containers.img"
 INITRD_LINK_NAME="kata-containers-initrd.img"
 

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -22,7 +22,7 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
 experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 PREFIX=${PREFIX:-/usr}
-kernel_dir=${PREFIX}/share/kata-containers
+kernel_dir=${DESTDIR:-}${PREFIX}/share/kata-containers
 
 kernel_repo_name="packaging"
 kernel_repo_owner="kata-containers"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -37,8 +37,8 @@ build_static_qemu() {
 	[ "$ARCH" != "x86_64" ] && return 1
 
 	go get -d "${packaging_repo}" || true
-	prefix="${KATA_QEMU_DESTDIR}" "${GOPATH}/src/${packaging_repo}/static-build/qemu/build-static-qemu.sh"
 
+	prefix="${PREFIX}" "${GOPATH}/src/${packaging_repo}/static-build/qemu/build-static-qemu.sh"
 	# We need to move the tar file to a specific location so we
 	# can know where it is and then we can perform the build cache
 	# operations
@@ -49,7 +49,7 @@ build_static_qemu() {
 uncompress_static_qemu() {
 	local qemu_tar_location="$1"
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
-	sudo tar -xf "${qemu_tar_location}" -C /
+	sudo tar -xf "${qemu_tar_location}" -C ${DESTDIR:-/}
 }
 
 build_and_install_static_qemu() {

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -20,14 +20,15 @@ KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
 QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
-QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
-VIRTIOFS_PATH="/opt/kata/bin/virtiofsd"
+QEMU_PATH="${DESTDIR:-}/opt/kata/bin/qemu-virtiofs-system-x86_64"
+VIRTIOFS_PATH="${DESTDIR:-}/opt/kata/bin/virtiofsd"
+bindir="${DESTDIR:-}/usr/bin"
 qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
-	sudo tar -xvf "${qemu_tar_location}" -C /
+	sudo tar -xvf "${qemu_tar_location}" -C ${DESTDIR:-/}
 }
 
 install_cached_qemu_experimental() {
@@ -36,8 +37,8 @@ install_cached_qemu_experimental() {
 	curl -fsOL "${qemu_experimental_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_experimental_qemu "${QEMU_TAR}"
-	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
-	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
+	sudo -E ln -sf "${QEMU_PATH}" $bindir
+	sudo -E ln -sf "${VIRTIOFS_PATH}" $bindir
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }
@@ -45,8 +46,8 @@ install_cached_qemu_experimental() {
 build_and_install_static_experimental_qemu() {
 	build_experimental_qemu
 	uncompress_experimental_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
-	sudo -E ln -sf "${QEMU_PATH}" "/usr/bin"
-	sudo -E ln -sf "${VIRTIOFS_PATH}" "/usr/bin"
+	sudo -E ln -sf "${QEMU_PATH}" $bindir
+	sudo -E ln -sf "${VIRTIOFS_PATH}" $bindir
 }
 
 build_experimental_qemu() {

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -29,10 +29,14 @@ export SYSTEM_BUILD_TYPE=kata
 # The runtimes config file should live here
 export SYSCONFDIR=/etc
 
-PREFIX=${PREFIX:-/usr}
+if [ -n "${PREFIX}" ]; then
+	SHAREDIR=${DESTDIR:-}${PREFIX}/share
+else
+	SHAREDIR=${DESTDIR:-}/usr/share
+fi
 
 # Artifacts (kernel + image) live below here
-export SHAREDIR=${PREFIX}/share
+export SHAREDIR
 
 USE_VSOCK="${USE_VSOCK:-no}"
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -20,7 +20,6 @@ export rust_agent_repo="${rust_agent_repo:-github.com/kata-containers/kata-conta
 export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
-export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 # Name of systemd service for the throttler

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -114,16 +114,21 @@ function build_and_install() {
 	make_target="$2"
 	test_not_gopath_set="$3"
 	tag="$4"
+	make_vars=""
+	[ -n "$DESTDIR" ] && make_vars+=" DESTDIR=$DESTDIR"
+	[ -n "$PREFIX" ] && make_vars+=" PREFIX=$PREFIX"
 
 	build "${github_project}" "${make_target}" "${tag}"
 	pushd "${GOPATH}/src/${github_project}"
 	if [ "$test_not_gopath_set" = "true" ]; then
 		info "Installing ${github_project} in No GO command or GOPATH not set mode"
-		sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
+		sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" \
+			make ${make_vars} install
 		[ $? -ne 0 ] && die "Fail to install ${github_project} in No GO command or GOPATH not set mode"
 	fi
 	info "Installing ${github_project}"
-	sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
+	sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" \
+		make ${make_vars} install
 	popd
 }
 


### PR DESCRIPTION
This patch series tries to fix the issue #2537

I tested those modification in the script...
https://github.com/wainersm/kc-tests/blob/master/.ci/openshift-ci/buildall_install.sh
... which will install kata and dependencies in the directory passed as argument.