### PR TITLE
[DNM] clh: Add a ci job for crio tests

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -253,6 +253,14 @@ case "${CI_JOB}" in
 	export TEST_DOCKER="true"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export experimental_kernel="true"
+	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 	init_ci_flags
 	export CRIO="yes"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -261,6 +261,15 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CRIO")
+	init_ci_flags
+	export CRIO="yes"
+	export CRI_RUNTIME="crio"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export TEST_CRIO="true"
+	export experimental_kernel="true"
+	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 	init_ci_flags
 	export CRIO="yes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -47,12 +47,6 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" bash -c "make crio"
 		;;
 	"CLOUD-HYPERVISOR")
-		echo "INFO: Containerd checks"
-		sudo -E PATH="$PATH" bash -c "make cri-containerd"
-
-		echo "INFO: Running kubernetes tests"
-		sudo -E PATH="$PATH" bash -c "make kubernetes"
-
 		echo "INFO: Running soak test"
 		sudo -E PATH="$PATH" bash -c "make docker-stability"
 
@@ -73,6 +67,13 @@ case "${CI_JOB}" in
 END
 		echo "INFO: Running podman integration tests"
 		bash -c "make podman"
+		;;
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+		echo "INFO: Containerd checks"
+		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+
+		echo "INFO: Running kubernetes tests with containerd"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
 	"CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -75,6 +75,13 @@ END
 		echo "INFO: Running kubernetes tests with containerd"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CRIO")
+		echo "INFO: Running crio tests"
+		sudo -E PATH="$PATH" bash -c "make crio"
+
+		echo "INFO: Running kubernetes tests with cri-o"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
 	"CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"
 		;;

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -22,4 +22,8 @@ if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then
 	skipCRIOTests+=(
 		'test "privileged ctr device add"'
 	)
+elif [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
+	skipCRIOTests+=(
+		'test "privileged ctr device add"'
+	)
 fi


### PR DESCRIPTION
This patch extends the existing scripts to cover a new Jenkins job on
testing k8s with crio for cloud-hypervisor.

Fixes: #2546

Depends-on: github.com/kata-containers/runtime#2833