### PR TITLE
ci/ci_cache_components: Remove the tests_repo variable

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -20,7 +20,6 @@ source "${cidir}/lib.sh"
 script_name=${0##*/}
 WORKSPACE=${WORKSPACE:-$(pwd)}
 kata_dir="/usr/share/kata-containers"
-tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 tests_repo_dir="${GOPATH}/src/${tests_repo}"
 
 # This builds qemu by specifying the qemu version from the


### PR DESCRIPTION
The tests_repo variable no longer need to be defined in the script
since it is now exported by lib.sh

Fixes #2535

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>