### PR TITLE
test: Update runtime for cri integration test for rust 2.0

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -14,7 +14,7 @@ set -o errtrace
 export PATH="$PATH:/usr/local/sbin"
 
 # Runtime to be used for testing
-RUNTIME=${RUNTIME:-kata-runtime}
+RUNTIME=${RUNTIME:-containerd-shim-kata-v2}
 SHIMV2_TEST=${SHIMV2_TEST:-""}
 FACTORY_TEST=${FACTORY_TEST:-""}
 KILL_VMM_TEST=${KILL_VMM_TEST:-""}


### PR DESCRIPTION
This PR updates the runtime name for the cri integration tests used
by rust 2.0

Fixes #2633

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>