### PR TITLE
ci: ignore license header check for drawio files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -445,6 +445,7 @@ static_check_license_headers()
 		--exclude="*.pub" \
 		--exclude="*.service" \
 		--exclude="*.svg" \
+		--exclude="*.drawio" \
 		--exclude="*.toml" \
 		--exclude="*.txt" \
 		--exclude="vendor/*" \


### PR DESCRIPTION
This PR will ignore of chcking of drawio files.

Fixes: #2637

Signed-off-by: bin liu <bin@hyper.sh>