### PR TITLE
ci: Add Grafana to spelling check word list

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -25,6 +25,7 @@ GitHub/B
 GoDoc/B
 golang/B
 Golang/B
+Grafana/B
 Huawei/B
 iPerf/B
 IPerf/B


### PR DESCRIPTION
This PR will add Grafana to projects.txt in spelling check to avoid ci failings.

Fixes: #2639

Signed-off-by: bin liu <bin@hyper.sh>