### PR TITLE
ci: Fix runtime variable for run script for rust 2.0

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -12,7 +12,7 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-export RUNTIME="kata-runtime"
+export RUNTIME="containerd-shim-kata-v2"
 
 export CI_JOB="${CI_JOB:-default}"
 


### PR DESCRIPTION
This PR fixes the runtime variable for the run script which is being
used to run the tests for rust agent 2.0

Fixes #2641

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>