### PR TITLE
ci/vfio: run teadown.sh on exit

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -272,7 +272,7 @@ elif [ -n "${VFIO_CI}" ]; then
 
 	echo "Installing initrd image:"
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
-	"${ci_dir_name}/install_kata_image.sh"
+	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
 	echo "Running VFIO tests:"
 	"${ci_dir_name}/run.sh"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -104,7 +104,7 @@ END
 		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
-		bash -c "make vfio"
+		sudo -E PATH="$PATH" bash -c "make vfio"
 		;;
 	*)
 		echo "INFO: Running checks"

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -164,7 +164,7 @@ ${environment}
         git rebase "origin/\${ghprbTargetBranch}"
     fi
 
-    .ci/jenkins_job_build.sh "\$(echo \${GIT_URL} | sed -e 's|https://||' -e 's|.git||')"
+    sudo -E PATH=\$PATH .ci/jenkins_job_build.sh "\$(echo \${GIT_URL} | sed -e 's|https://||' -e 's|.git||')"
 
   path: /home/${USER}/run.sh
   permissions: '0755'
@@ -328,7 +328,7 @@ main() {
 		kill_vms
 	done
 
-	ssh_vm "sudo /home/${USER}/run.sh"
+	ssh_vm "/home/${USER}/run.sh"
 }
 
 main $@

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -144,6 +144,11 @@ ${environment}
     export ghprbPullId
     export ghprbTargetBranch
 
+    # Make sure the packages were installed
+    # Sometimes cloud-init is unable to install them
+    sudo dnf makecache
+    sudo dnf install -y git make pciutils
+
     tests_repo_dir="\${GOPATH}/src/github.com/kata-containers/tests"
     mkdir -p "\${tests_repo_dir}"
     git clone https://github.com/kata-containers/tests.git "\${tests_repo_dir}"

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -163,6 +163,11 @@ setup_configuration_file() {
 			fi
 		fi
 	fi
+
+	# enable debug
+	sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+	       -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
+	       "${CONFIG_FILE}"
 }
 
 main() {


### PR DESCRIPTION
Run teardown.sh to generate the build artifacts, making vfio CI logs
accessible from http://jenkins.katacontainers.io

fixes #2645

Signed-off-by: Julio Montes <julio.montes@intel.com>