### PR TITLE
ci: Enable k8s installation for fedora rust agent 2.0

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -37,7 +37,7 @@ EOF"
 	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 	chronic sudo -E apt update
 	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
-elif [ "$ID" == "centos" ]; then
+elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
 	if [ "$ID" == "centos" ]; then
 		sudo yum versionlock docker-ce
 	fi
@@ -54,7 +54,6 @@ EOF"
 
 	chronic sudo -E sed -i 's/^[ \t]*//' /etc/yum.repos.d/kubernetes.repo
 	install_kubernetes_version=$(echo $kubernetes_version | cut -d'-' -f1)
-	chronic sudo -E yum -y update
 	chronic sudo -E yum install -y kubelet-"$install_kubernetes_version" kubeadm-"$install_kubernetes_version" kubectl-"$install_kubernetes_version" --disableexcludes=kubernetes
 
 	# Disable selinux


### PR DESCRIPTION
This PR enables the k8s installation for fedora as this will be used
for testing rust agent 2.0

Fixes #2647

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>