### PR TITLE
Don't create branches when building dependencies at specific versions

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -80,7 +80,7 @@ function build_version() {
 
 	if [ "$version" != "HEAD" ]; then
 		info "Using ${github_project} version ${version}"
-		git checkout -b "${version}" "${version}"
+		git checkout "${version}"
 	fi
 
 	info "Building ${github_project}"


### PR DESCRIPTION
For some dependencies we want to build a specific version, which is handled
by the build_version function in .ci/lib.sh.  It does this by creating a
new branch at the specific revision we want, then building.  However, this
new branch is left over, which means the check out will fail if we attempt
it again without manually removing the branch.

In fact, there's no real point to creating a branch: git allows us to just
checkout the commit we want directly.  That will leave the tree in
"detached HEAD" mode, which is awkward if you're developing in the tree,
but is just fine for building a dependency as we are here.

Fixes: #2650
Signed-off-by: David Gibson <david@gibson.dropbear.id.au>