### PR TITLE
metrics: Fix docker memory metric json

### DIFF
--- a/metrics/density/docker_memory_usage.sh
+++ b/metrics/density/docker_memory_usage.sh
@@ -281,7 +281,7 @@ EOF
 			"Result": $mem_usage,
 			"Units" : "KB"
 		},
-		"qemus": {
+		"hypervisors": {
 			"Result": $hypervisor_mem,
 			"Units" : "KB"
 		},


### PR DESCRIPTION
Now that we have several hypervisors we should not hardcore qemu as the
only one. This PR fixes the name for the json results.

Fixes #2657

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>