### PR TITLE
tests: Enable a minimal set for e2e k8s tests

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -160,6 +160,19 @@ case "${CI_JOB}" in
 	export CRIO="no"
 	export OPENSHIFT="no"
 	;;
+"CRI_CONTAINERD_K8S_COMPLETE")
+	export CRI_CONTAINERD="yes"
+	export KUBERNETES="yes"
+	export CRIO="no"
+	export OPENSHIFT="no"
+	;;
+"CRI_CONTAINERD_K8S_MINIMAL")
+	export MINIMAL_CONTAINERD_K8S_E2E="true"
+	export CRI_CONTAINERD="yes"
+	export KUBERNETES="yes"
+	export CRIO="no"
+	export OPENSHIFT="no"
+	;;
 "CRIO_K8S")
 	export KUBERNETES="yes"
 	export CRIO="yes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,6 +22,14 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
+	"CRI_CONTAINERD_K8S_COMPLETE")
+		echo "INFO: Running e2e kubernetes tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
+		;;
+	"CRI_CONTAINERD_K8S_MINIMAL")
+		echo "INFO: Running e2e kubernetes tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
+		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,12 @@ kubernetes:
 	bash -f .ci/install_bats.sh
 	bash -f integration/kubernetes/run_kubernetes_tests.sh
 
+kubernetes-e2e:
+	cd "integration/kubernetes/e2e_conformance" &&\
+	cat skipped_tests_e2e.yaml &&\
+	bash ./setup.sh &&\
+	bash ./run.sh
+
 ksm:
 	bash -f integration/ksm/ksm_test.sh
 

--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+jobs:
+  CRI_CONTAINERD_K8S_MINIMAL:
+    passed: 12
+  CRI_CONTAINERD_K8S_COMPLETE:
+    passed: 273
+  minimal:
+    focus:
+      - ConfigMap should be consumable from pods in volume
+      - ConfigMap should be consumable from pods in volume as non-root
+      - Kubelet when scheduling a busybox command that always fails in a pod should be possible to delete
+      - Kubectl client Kubectl apply should reuse port when apply to an existing SVC

--- a/integration/kubernetes/e2e_conformance/setup.sh
+++ b/integration/kubernetes/e2e_conformance/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Entry point to start a K8S cluster for end-to-end testing
+# If cluster is already running with Kata RuntimeClass, skip this script and
+# use run.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../../lib/common.bash"
+source "${SCRIPT_PATH}/../../../.ci/lib.sh"
+CRI_RUNTIME="${CRI_RUNTIME:-containerd}"
+
+wait_init_retry="10s"
+
+info "Setup env for K8s e2e testing"
+cd "${GOPATH}/src/github.com/kata-containers/tests/integration/kubernetes"
+if ! bash ./init.sh; then
+	info "k8s init failed trying again"
+	sudo systemctl restart "${CRI_RUNTIME}"
+	sleep "${wait_init_retry}"
+	bash ./init.sh
+fi
+crictl --version
+kubectl get pods --all-namespaces

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: pod-annotate-webhook
-          image: katadocker/kata-webhook-example:latest
+          image: fuentess/kata-webhook:20200707
           imagePullPolicy: Always
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem

--- a/kata-webhook/main.go
+++ b/kata-webhook/main.go
@@ -49,6 +49,10 @@ func annotatePodMutator(ctx context.Context, obj metav1.Object) (bool, error) {
 		return false, nil
 	}
 
+	if pod.GetNamespace() == "sonobuoy" {
+		fmt.Println("sonobuoy pods will not be changed to kata", pod.GetNamespace(), pod.GetName())
+	}
+
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].SecurityContext != nil {
 			if *pod.Spec.Containers[i].SecurityContext.Privileged {


### PR DESCRIPTION
This PR adds a minimal set for e2e k8s tests for containerd with
shimv2 for the new rust agent 2.0

Fixes #2660

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>