### PR TITLE
ci: Fix checkout for ci entry point

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -51,7 +51,7 @@ git clone "https://${tests_repo}.git" "${tests_repo_dir}"
 cd "${tests_repo_dir}"
 
 # Checkout to target branch: master, stable-X.Y, 2.0-dev etc
-git rebase "origin/${ghprbTargetBranch}"
+git checkout "origin/${ghprbTargetBranch}"
 
 # If the changes are in the repository to test:
 # Update the repository first so we can catch most of changes


### PR DESCRIPTION
While running the ci entry point script, we have the following error that is
not possible to perform the git rebase as that should be a git checkout of
the target branch.

Fixes #2663

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>