### PR TITLE
test: Use a specific oraclelinux image for popular docker images test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -13,6 +13,9 @@ versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
 kibana_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.kibana.version")
 kibana_image="kibana:$kibana_version"
 
+oraclelinux_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.oraclelinux.version")
+oraclelinux_image="oraclelinux:$oraclelinux_version"
+
 setup() {
 	# Check that processes are not running
 	run check_processes
@@ -348,7 +351,7 @@ setup() {
 }
 
 @test "[create files] create files in an oraclelinux container" {
-	image="oraclelinux"
+	image=$oraclelinux_image
 	docker run --rm --runtime=$RUNTIME -i $image bash -c 'for NUM in `seq 1 1 10`; do touch $NUM-file.txt && ls -l /$NUM-file.txt; done'
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -35,6 +35,11 @@ docker_images:
     url: "https://hub.docker.com/_/nginx/"
     version: "1.17.0-alpine"
 
+  oraclelinux:
+    description: "Official Docker builds of Oracle Linux"
+    url: "https://hub.docker.com/_/oraclelinux/"
+    version: "8.1"
+
 externals:
   description: "Third-party projects used specifically for testing"
 


### PR DESCRIPTION
When we try to use the image oraclelinux:latest we are getting an error
saying that the manifest does not exist. This PR specifies a version of
this image which is working.

Fixes #2670

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>