### PR TITLE
test: Change the configuration toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ endif
 # union for 'make test'
 UNION := crio \
 	compatibility \
+	configuration \
 	debug-console \
 	$(DOCKER_DEPENDENCY) \
 	docker-compose \
@@ -217,6 +218,11 @@ endif
 crio:
 	bash .ci/install_bats.sh
 	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
+
+configuration:
+	bash .ci/install_bats.sh
+	cd integration/change_configuration_toml && \
+	bats change_configuration_toml.bats
 
 docker-compose:
 	bash .ci/install_bats.sh

--- a/integration/change_configuration_toml/change_configuration_toml.bats
+++ b/integration/change_configuration_toml/change_configuration_toml.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+default_kata_config="/usr/share/defaults/kata-containers/configuration.toml"
+image="busybox"
+payload="tail -f /dev/null"
+container_name="test-configuration"
+
+tmp_data_dir="$(mktemp -d)"
+CONFIG_FILE="${tmp_data_dir}/configuration.toml"
+
+setup() {
+	clean_env
+	run check_processes
+	echo "$output"
+	cp -a "${default_kata_config}" "${CONFIG_FILE}"
+}
+
+@test "bad machine type" {
+	sudo sed -i 's|^machine_type.*|machine_type = "foo"|g' "${default_kata_config}"
+	run docker run -d --name "${container_name}" --runtime "${RUNTIME}" "${image}" sh -c "${payload}"
+	echo "$output"
+	[ "$status" -ne 0 ]
+}
+
+teardown() {
+	docker rm -f "${container_name}"
+	cp -a "${CONFIG_FILE}" "${default_kata_config}"
+	sudo rm -rf "${tmp_data_dir}"
+	clean_env
+	run check_processes
+	echo "$output"
+}


### PR DESCRIPTION
This PR is a test where we change the machine type at the configuration toml
for an invalid one and we verify that is not possible to run a container.

Fixes #2675

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>