### PR TITLE
ci: disable vmx-rdseed-exit only on x86_64

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -78,7 +78,7 @@ case "${KATA_HYPERVISOR}" in
 		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
 		fi
-		if [ "$CI" == true ]; then
+		if [ "$CI" == true ] && [ "$(uname -m)" == "x86_64" ]; then
 			qemu_version="$(get_version "assets.hypervisor.qemu.version")"
 			qemu_major="$(echo ${qemu_version} | cut -d. -f1)"
 			qemu_minor="$(echo ${qemu_version} | cut -d. -f2)"


### PR DESCRIPTION
Trying to disable vmx-rdseed-exit on other system than x86_64 will fail

fixes #2678

Signed-off-by: Julio Montes <julio.montes@intel.com>