### PR TITLE
metrics: adjust memory KSM midval to support QEMU 5

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -42,6 +42,6 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 61380.0
+midval = 66170.0
 minpercent = 5.0
 maxpercent = 5.0


### PR DESCRIPTION
QEMU 5 KSM memory footprint is a little bit bigger than QEMU 4,
change midval from 61380.0 to 66170.0.

fixes #2690

Signed-off-by: Julio Montes <julio.montes@intel.com>