### PR TITLE
test: Fix mariadb popular docker images test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -16,6 +16,9 @@ kibana_image="kibana:$kibana_version"
 oraclelinux_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.oraclelinux.version")
 oraclelinux_image="oraclelinux:$oraclelinux_version"
 
+mariadb_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.mariadb.version")
+mariadb_image="mariadb:$mariadb_version"
+
 setup() {
 	# Check that processes are not running
 	run check_processes
@@ -286,7 +289,7 @@ setup() {
 }
 
 @test "[display configuration] start an instance of a mariadb container" {
-	image="mariadb"
+	image=$mariadb_image
 	docker run --rm --runtime=$RUNTIME -i -e MYSQL_ROOT_PASSWORD=secretword  $image bash -c "cat /etc/mysql/mariadb.cnf | grep character"
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -30,6 +30,11 @@ docker_images:
     url: "https://hub.docker.com/_/kibana/"
     version: "6.4.0"
 
+  mariadb:
+    description: "Fork of MySQL intended to remain free under the GNU GPL"
+    url: "https://hub.docker.com/_/mariadb/"
+    version: "10.4"
+
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"


### PR DESCRIPTION
The manifest of the latest image is not found, this pr fixes the mariadb
popular docker images test.

Fixes #2692

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>