### PR TITLE
CI: use packaging location inside kata-containers repo

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+source "${cidir}/lib.sh"
+
 CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.architecture.aarch64.version")
 PACKAGED_QEMU="qemu"
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.architecture.aarch64.tag")
@@ -47,12 +49,11 @@ install_packaged_qemu() {
 }
 
 build_and_install_qemu() {
-        PACKAGING_REPO="github.com/kata-containers/packaging"
-        QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
+        PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+        QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
 	clone_qemu_repo
-
-	go get -d "$PACKAGING_REPO" || true
+	clone_kata_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
         git fetch
@@ -60,7 +61,7 @@ build_and_install_qemu() {
         [ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git --depth 1 ui/keycodemapdb
 
         # Apply required patches
-        QEMU_PATCHES_PATH="${GOPATH}/src/${PACKAGING_REPO}/obs-packaging/qemu-aarch64/patches"
+        QEMU_PATCHES_PATH="${PACKAGING_DIR}/obs-packaging/qemu-aarch64/patches"
         for patch in ${QEMU_PATCHES_PATH}/*.patch; do
                 echo "Applying patch: $patch"
                 patch -p1 <"$patch"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -16,7 +16,6 @@ cidir=$(dirname "$0")
 arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
 # Where real kata build script exist, via docker build to avoid install all deps
-packaging_repo="github.com/kata-containers/packaging"
 latest_build_url="${jenkins_url}/job/cloud-hypervisor-nightly-$(uname -m)/${cached_artifacts_path}"
 clh_bin_name="cloud-hypervisor"
 clh_install_path="/usr/bin/${clh_bin_name}"
@@ -35,11 +34,11 @@ install_clh() {
 	# Get cloud_hypervisor repo
 	go get -d "${go_cloud_hypervisor_repo}" || true
 	# This may be downloaded before if there was a depends-on in PR, but 'go get' wont make any problem here
-	go get -d "${packaging_repo}" || true
+	clone_kata_repo
 	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
 	# packaging build script expects run in the hypervisor repo parent directory
 	# It will find the hypervisor repo and checkout to the version exported above
-	"${GOPATH}/src/${packaging_repo}/static-build/cloud-hypervisor/build-static-clh.sh"
+	"${kata_repo_dir}/static-build/cloud-hypervisor/build-static-clh.sh"
 	sudo install -D "cloud-hypervisor/${clh_bin_name}"  "${clh_install_path}"
 	popd
 }

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -24,7 +24,7 @@ QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
 # Remove 'https://' from the repo url to be able to git clone the repo
 QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
-PACKAGING_REPO="github.com/kata-containers/packaging"
+PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
 QEMU_TAR="kata-static-qemu.tar.gz"
 qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_artifacts_path}"
@@ -37,8 +37,7 @@ build_static_qemu() {
 	# only x86_64 is supported for building static QEMU
 	[ "$ARCH" != "x86_64" ] && return 1
 
-	go get -d "${PACKAGING_REPO}" || true
-	prefix="${KATA_QEMU_DESTDIR}" "${GOPATH}/src/${PACKAGING_REPO}/static-build/qemu/build-static-qemu.sh"
+	prefix="${KATA_QEMU_DESTDIR}" "${PACKAGING_DIR}/static-build/qemu/build-static-qemu.sh"
 
 	# We need to move the tar file to a specific location so we
 	# can know where it is and then we can perform the build cache
@@ -83,11 +82,11 @@ build_and_install_qemu() {
 		die "QEMU will not be installed"
 	fi
 
-	QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
+	QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
 	mkdir -p "${GOPATH}/src"
-	go get -d "$PACKAGING_REPO" || true
 
+	clone_kata_repo
 	clone_qemu_repo
 
 	pushd "${GOPATH}/src/${QEMU_REPO}"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -18,7 +18,7 @@ source /etc/os-release || source /usr/lib/os-release
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
-PACKAGING_REPO="github.com/kata-containers/packaging"
+PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
 QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 QEMU_PATH="/opt/kata/bin/qemu-virtiofs-system-x86_64"
@@ -52,8 +52,8 @@ build_and_install_static_experimental_qemu() {
 
 build_experimental_qemu() {
 	mkdir -p "${GOPATH}/src"
-	go get -d "$PACKAGING_REPO" || true
-	"${GOPATH}/src/${PACKAGING_REPO}/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
+	clone_kata_repo
+	"${PACKAGING_DIR}/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -13,7 +13,8 @@ export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo="github.com/kata-containers/kata-containers"
-export kata_default_branch="2.0-dev"
+export kata_repo_dir="${GOPATH}/src/${kata_repo}"
+export kata_default_branch="${kata_default_branch:-2.0-dev}"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
@@ -56,6 +57,18 @@ die() {
 
 info() {
 	echo -e "INFO: $*"
+}
+
+# Clone repo only if $kata_repo_dir is empty
+# Otherwise, we assume $kata_repo is cloned and in correct branch, e.g. a PR or local change
+clone_kata_repo() {
+	if [ ! -d "${kata_repo_dir}" ]; then
+		go get -d "${kata_repo}" || true
+		pushd "${kata_repo_dir}"
+		# Checkout to default branch
+		git checkout "${kata_default_branch}"
+		popd
+	fi
 }
 
 function build_version() {
@@ -135,7 +148,6 @@ function get_dep_from_yaml_db(){
 
 function get_version(){
 	dependency="$1"
-	kata_repo_dir="$GOPATH/src/${kata_repo}"
 	versions_file="${kata_repo_dir}/versions.yaml"
 	if [ ! -d "${kata_repo_dir}" ]; then
 		mkdir -p "$(dirname ${kata_repo_dir})"

--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -10,6 +10,8 @@ CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.tag")
 PACKAGED_QEMU="qemu-system-ppc"
 BUILT_QEMU="qemu-system-ppc64"
 
+source "${cidir}/lib.sh"
+
 get_packaged_qemu_version() {
         if [ "$ID" == "ubuntu" ]; then
 		#output redirected to /dev/null
@@ -48,13 +50,12 @@ build_and_install_qemu() {
         QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
         # Remove 'https://' from the repo url to be able to clone the repo using 'go get'
         QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
-        PACKAGING_REPO="github.com/kata-containers/packaging"
-        QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
+        PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+        QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
+        git clone --branch "$CURRENT_QEMU_TAG" --depth 1 "$QEMU_REPO_URL" "${GOPATH}/src/${QEMU_REPO}"
 
-	git clone --branch "$CURRENT_QEMU_TAG" --depth 1 "$QEMU_REPO_URL" "${GOPATH}/src/${QEMU_REPO}"
-
-        go get -d "$PACKAGING_REPO" || true
+        clone_kata_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
         git fetch

--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -12,7 +12,6 @@ set -o errtrace
 
 # Repositories needed for building the kata containers project.
 katacontainers_repo="${katacontainers_repo:-github.com/kata-containers/kata-containers}"
-packaging_repo="${packaging_repo:-github.com/kata-containers/packaging}"
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 
 branch=${branch:-}
@@ -68,7 +67,6 @@ apply_depends_on() {
 clone_repos() {
 	local kata_repos=(
 	"${katacontainers_repo}"
-	"${packaging_repo}"
 	"${tests_repo}")
 	for repo in "${kata_repos[@]}"
 	do

--- a/.ci/s390x/lib_install_qemu_s390x.sh
+++ b/.ci/s390x/lib_install_qemu_s390x.sh
@@ -7,6 +7,8 @@
 
 set -e
 
+source "${cidir}/lib.sh"
+
 CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.version")
 PACKAGED_QEMU="qemu"
 
@@ -35,8 +37,8 @@ build_and_install_qemu() {
 	# Remove 'https://' from the repo url to be able to clone the repo using 'go get'
 	QEMU_REPO_PATH=${QEMU_REPO/https:\/\//}
 
-	PACKAGING_REPO="github.com/kata-containers/packaging"
-	QEMU_CONFIG_SCRIPT="${GOPATH}/src/${PACKAGING_REPO}/scripts/configure-hypervisor.sh"
+	PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+	QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
 	if [ ! -d "${GOPATH}/src/${QEMU_REPO_PATH}" ]; then
 		mkdir -p "${GOPATH}/src/${QEMU_REPO_PATH}"
@@ -45,7 +47,7 @@ build_and_install_qemu() {
 		popd
 	fi
 
-	go get -d "$PACKAGING_REPO" || true
+	clone_kata_repo
 
 	pushd "${GOPATH}/src/${QEMU_REPO_PATH}"
 	git fetch


### PR DESCRIPTION
Now that `packaging` repo was merged into `kata-containers`,
use the new location to build kernel and qemu.

Fixes: #2700.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>