### PR TITLE
tests: Fixes for k8s tests on kata 2.0

### DIFF
--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -20,6 +20,9 @@ setup() {
 }
 
 @test "Running with postStart and preStop handlers" {
+	wait_time=20
+	sleep_time=2
+
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/lifecycle-events.yaml" > "${pod_config_dir}/test-lifecycle-events.yaml"
@@ -28,7 +31,8 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test-lifecycle-events.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check postStart message
 	display_message="cat /usr/share/message"
@@ -38,4 +42,7 @@ setup() {
 teardown(){
 	rm -f "${pod_config_dir}/test-lifecycle-events.yaml"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -79,4 +79,8 @@ teardown() {
 	# Remove image and loop device
 	sudo losetup -d "$loop_dev"
 	rm -f "$tmp_disk_image"
+
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -16,6 +16,8 @@ setup() {
 @test "ConfigMap for a pod" {
 	config_name="test-configmap"
 	pod_name="config-env-test-pod"
+	wait_time=20
+	sleep_time=2
 
 	# Create ConfigMap
 	kubectl create -f "${pod_config_dir}/configmap.yaml"
@@ -27,7 +29,8 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check env
 	cmd="env"
@@ -38,4 +41,7 @@ setup() {
 teardown() {
 	kubectl delete pod "$pod_name"
 	kubectl delete configmap "$config_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -58,4 +58,7 @@ teardown() {
 	skip "test not working - see: ${issue}"
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -56,4 +56,7 @@ setup() {
 teardown() {
 	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -17,6 +17,8 @@ setup() {
 	secret_name="test-secret"
 	pod_name="secret-test-pod"
 	second_pod_name="secret-envars-test-pod"
+	wait_time=20
+	sleep_time=2
 
 	# Create the secret
 	kubectl create -f "${pod_config_dir}/inject_secret.yaml"
@@ -28,7 +30,8 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# List the files
 	cmd="ls /tmp/secret-volume"
@@ -50,4 +53,7 @@ setup() {
 teardown() {
 	kubectl delete pod "$pod_name" "$second_pod_name"
 	kubectl delete secret "$secret_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -16,11 +16,15 @@ setup() {
 }
 
 @test "Check custom dns" {
+	wait_time=20
+	sleep_time=2
+
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check dns config at /etc/resolv.conf
 	kubectl exec -it "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"
@@ -29,4 +33,7 @@ setup() {
 
 teardown() {
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -32,4 +32,7 @@ setup() {
 teardown() {
 	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -15,11 +15,15 @@ setup() {
 }
 
 @test "Environment variables" {
+	wait_time=20
+	sleep_time=2
+
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Print environment variables
 	cmd="printenv"
@@ -28,4 +32,7 @@ setup() {
 
 teardown() {
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -16,7 +16,7 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	deployment="hello-world"
 	service="my-service"
@@ -24,7 +24,7 @@ setup() {
 }
 
 @test "Expose IP Address" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	wait_time=20
 	sleep_time=2
 
@@ -61,7 +61,10 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	kubectl delete services ${service}
 	kubectl delete deployment ${deployment}
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-footloose.bats
+++ b/integration/kubernetes/k8s-footloose.bats
@@ -64,4 +64,7 @@ teardown() {
 	sudo rm -rf "$public_key_path"
 	sudo rm -rf "$key_path"
 	sudo rm -rf "$configmap_yaml"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -59,4 +59,8 @@ teardown() {
 
 	# Disable hugepages
 	sudo sed -i 's/enable_hugepages = true/#enable_hugepages = true/g' ${RUNTIME_CONFIG_PATH}
+
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-job.bats
+++ b/integration/kubernetes/k8s-job.bats
@@ -53,4 +53,8 @@ teardown() {
 	run kubectl get jobs
 	echo "$output"
 	[[ "$output" =~ "No resources found" ]]
+
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-limit-range.bats
+++ b/integration/kubernetes/k8s-limit-range.bats
@@ -16,6 +16,9 @@ setup() {
 }
 
 @test "Limit range for storage" {
+	wait_time=20
+	sleep_time=2
+
 	# Create namespace
 	kubectl create namespace "$namespace_name"
 
@@ -26,7 +29,8 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-cpu-defaults.yaml" --namespace=${namespace_name}
 
 	# Get pod specification
-	kubectl wait --for=condition=Ready pod "$pod_name" --namespace="$namespace_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name --namespace=$namespace_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check limits
 	# Find the 500 millicpus specified at the yaml
@@ -36,4 +40,7 @@ setup() {
 teardown() {
 	kubectl delete pod "$pod_name"
 	kubectl delete namespaces "$namespace_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -75,4 +75,7 @@ setup() {
 teardown() {
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -17,11 +17,15 @@ setup() {
 
 # Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
+	wait_time=20
+	sleep_time=2
+
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	retries="10"
 	max_number_cpus="3"
@@ -37,4 +41,7 @@ setup() {
 
 teardown() {
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -7,8 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2705"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 	job_name="jobtest"
@@ -16,6 +18,7 @@ setup() {
 }
 
 @test "Parallel jobs" {
+	skip "test not working - see: ${issue}"
 	# Create yaml files
 	for i in "${names[@]}"; do
 		sed "s/\$ITEM/$i/" ${pod_config_dir}/job-template.yaml > ${pod_config_dir}/job-$i.yaml
@@ -39,6 +42,7 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	# Delete jobs
 	kubectl delete jobs -l jobgroup=${job_name}
 
@@ -46,4 +50,8 @@ teardown() {
 	for i in "${names[@]}"; do
 		rm -f ${pod_config_dir}/job-$i.yaml
 	done
+
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -39,4 +39,7 @@ setup() {
 teardown() {
 	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -36,4 +36,7 @@ teardown() {
 	skip "test not working - see: ${issue}"
 	kubectl delete resourcequota "$resource_name"
 	kubectl delete deployment "$deployment_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -69,4 +69,7 @@ teardown() {
 	skip "test not working see: ${issue}"
 	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -7,13 +7,16 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2705"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Projected volume" {
+	skip "test not working - see: ${issue}"
 	password="1f2d1e2e67df"
 	username="admin"
 	pod_name="test-projected-volume"
@@ -49,7 +52,11 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	rm -f $TMP_FILE $SECOND_TMP_FILE
 	kubectl delete pod "$pod_name"
 	kubectl delete secret pass user
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -64,4 +64,7 @@ setup() {
 teardown() {
 	skip "test not working see: ${issue}, ${memory_issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -54,4 +54,7 @@ teardown() {
 	rm -f "${pod_config_dir}/test-replication-controller.yaml"
 	kubectl delete pod "$pod_name"
 	kubectl delete rc "$replication_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -7,8 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2705"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
 	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
 	nginx_image="nginx:$nginx_version"
@@ -20,6 +22,7 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
+	skip "test not working - see: ${issue}"
 	wait_time=30
 	sleep_time=3
 
@@ -35,7 +38,11 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	rm -f "${pod_config_dir}/test-${deployment}.yaml"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -14,13 +14,16 @@ setup() {
 }
 
 @test "Security context" {
+	wait_time=20
+	sleep_time=2
 	pod_name="security-context-test"
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check user
 	cmd="ps --user 1000 -f"
@@ -30,4 +33,7 @@ setup() {
 
 teardown() {
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-shared-volume.bats
+++ b/integration/kubernetes/k8s-shared-volume.bats
@@ -51,4 +51,7 @@ setup() {
 teardown() {
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -33,4 +33,7 @@ setup() {
 teardown() {
 	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -7,8 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2705"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	busybox_image="busybox"
 	export KUBECONFIG="$HOME/.kube/config"
 	first_pod_name="first-test"
@@ -29,6 +31,7 @@ setup() {
 }
 
 @test "Check UTS and IPC namespaces" {
+	skip "test not working - see: ${issue}"
 	# Run the first pod
 	kubectl create -f "$first_pod_config"
 	kubectl wait --for=condition=Ready pod "$first_pod_name"
@@ -47,8 +50,12 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	kubectl delete pod "$first_pod_name"
 	kubectl delete pod "$second_pod_name"
 	rm -rf "$first_pod_config"
 	rm -rf "$second_pod_config"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -63,4 +63,7 @@ teardown() {
 	kubectl delete pv "$volume_name"
 	rm -f "$pod_yaml"
 	rm -rf "$tmp_file"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -10,7 +10,7 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
 	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
 	nginx_image="nginx:$nginx_version"
@@ -25,7 +25,7 @@ setup() {
 }
 
 @test "Verify nginx connectivity between pods" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	wait_time=30
 	sleep_time=3
 
@@ -47,9 +47,12 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
+	skip "test not working - see: ${issue}"
 	rm -f "${pod_config_dir}/test-${deployment}.yaml"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
 	kubectl delete pod "$busybox_pod"
+	run check_pods
+	echo "$output"
+	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
We should check that pod no information is left after running
each k8s test for kata 2.0. This PR also gives time to check
that the pods are running as we have random failures in the pod
creation and also skips tests where pod information is left
at virtcontainers directory.

Fixes #2702

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>