### PR TITLE
ci: add SNAP to the list of CI jobs

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -106,6 +106,19 @@ END
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" bash -c "make vfio"
 		;;
+	"SNAP")
+		echo "INFO: Running docker tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make docker"
+
+		echo "INFO: Running crio tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make crio"
+
+		echo "INFO: Running kubernetes tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+
+		echo "INFO: Running shimv2 tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make shimv2"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -34,8 +34,8 @@ readonly runc_runtime_bin=$(command -v "runc")
 readonly CRITEST=${GOPATH}/bin/critest
 
 # Flag to do tasks for CI
-SNAP_CI=${SNAP_CI:-""}
 CI=${CI:-""}
+CI_JOB=${CI_JOB:-""}
 
 containerd_shim_path="$(command -v containerd-shim)"
 readonly cri_containerd_repo="github.com/containerd/cri"
@@ -97,7 +97,7 @@ ci_cleanup() {
 
 	ID=${ID:-""}
 	if [ "$ID" == ubuntu ]; then
-		if [ -n "${SNAP_CI}" ]; then
+		if [ "${CI_JOB}" == "SNAP" ]; then
 			# restore default configuration
 			sudo cp "${default_kata_config}" "${kata_config}"
 		elif [ -n "${CI}" ] ;then


### PR DESCRIPTION
Reduce snap-ci build time by running only the following tests:
* docker
* crio
* shimv2
* kubernetes

fixes #2706

Signed-off-by: Julio Montes <julio.montes@intel.com>