### PR TITLE
tests: set terminationGracePeriodSeconds to zero

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: busybox
 spec:
+  terminationGracePeriodSeconds: 0
   shareProcessNamespace: true
   runtimeClassName: kata
   containers:

--- a/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: NAME
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   shareProcessNamespace: true
   containers:

--- a/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
@@ -18,6 +18,7 @@ spec:
         app: hello-world
         run: load-balancer-example
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: hello-world

--- a/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: initcontainer-shared-volume
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   initContainers:
   - name: first

--- a/integration/kubernetes/runtimeclass_workloads/job-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job-template.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         jobgroup: jobtest
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: test

--- a/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   template:
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: pi

--- a/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -9,6 +9,7 @@ kind: Pod
 metadata:
   name: handlers
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: handlers-container

--- a/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: nginx
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginx

--- a/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: besteffort-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-besteffort

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: pod-block-pv
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: my-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: burstable-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-burstable

--- a/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: config-env-test-pod
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: default-cpu-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: default-cpu-demo-ctr

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: constraints-cpu-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: first-cpu-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: default
   name: custom-dns-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: sharevol-kata
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: test

--- a/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: test-env
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: footubuntu
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   volumes:
   - name: runv

--- a/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: qos-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-guaranteed

--- a/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -10,6 +10,7 @@ metadata:
     test: liveness-test
   name: liveness-http
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: liveness

--- a/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
@@ -10,6 +10,7 @@ metadata:
     test: liveness
   name: liveness-exec
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: liveness

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: memory-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: memory-test-ctr

--- a/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: cpu-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: c1

--- a/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: test-projected-volume
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: test-projected-volume

--- a/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         purpose: quota-demo
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: pod-quota-demo

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: secret-envars-test-pod
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: envars-test-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: secret-test-pod
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: security-context-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   securityContext:
     runAsUser: 1000

--- a/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: test-shared-volume
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   volumes:

--- a/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: sysctl-test
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   securityContext:
     sysctls:

--- a/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     app: tcp-liveness
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: tcp-liveness

--- a/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 metadata:
   name: pv-pod
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   volumes:
     - name: pv-storage

--- a/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         role: master
         tier: backend
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: master

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: nginx
     spec:
+      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginxtest


### PR DESCRIPTION
Set terminationGracePeriodSeconds to zero will delete pod immediately without waiting for 30+s(default gracePeriodSeconds).

Fixes: #2708

Signed-off-by: bin liu <bin@hyper.sh>


This maybe safer than adding `--grace-period=0 --force` to `delete pods` command.