### PR TITLE
tests: Skip k8s tests in kata 2.0

### DIFF
--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -7,8 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2711"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="custom-dns-test"
 	file_name="/etc/resolv.conf"
@@ -16,6 +18,7 @@ setup() {
 }
 
 @test "Check custom dns" {
+	skip "test not working - see: ${issue}"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
 
@@ -28,5 +31,6 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -7,8 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/2711"
 
 setup() {
+	skip "test not working - see: ${issue}"
 	versions_file="${BATS_TEST_DIRNAME}/../../versions.yaml"
 	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
 	nginx_image="nginx:$nginx_version"
@@ -20,6 +22,7 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
+	skip "test not working - see: ${issue}"
 	wait_time=30
 	sleep_time=3
 
@@ -35,6 +38,7 @@ setup() {
 }
 
 teardown() {
+	skip "test not working - see: ${issue}"
 	rm -f "${pod_config_dir}/test-${deployment}.yaml"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"


### PR DESCRIPTION
We have random failures in some k8s tests on kata 2.0. We should skip
these tests to have a more stable CI and debug the reason of the failure
as it is randomly.

Fixes #2711

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>