### PR TITLE
tests: Enable conformance tests on virtiofs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,19 @@ ifeq (${CI}, true)
         endif
 endif
 
+CONFORMANCE_DEPENDENCY = conformance
+ifeq (${CI}, true)
+	ifneq (${TEST_CONFORMANCE}, true)
+		CONFORMANCE_DEPENDENCY =
+	endif
+endif
+
+
 # union for 'make test'
 UNION := crio \
 	compatibility \
 	configuration \
+	$(CONFORMANCE_DEPENDENCY) \
 	debug-console \
 	$(DOCKER_DEPENDENCY) \
 	docker-compose \
@@ -224,6 +233,9 @@ configuration:
 	cd integration/change_configuration_toml && \
 	bats change_configuration_toml.bats
 
+conformance:
+	bash -f conformance/posixfs/fstests.sh
+
 docker-compose:
 	bash .ci/install_bats.sh
 	cd integration/docker-compose && \
@@ -359,6 +371,7 @@ help:
 	check \
 	checkcommits \
 	crio \
+	conformance \
 	debug-console \
 	docker \
 	docker-compose \


### PR DESCRIPTION
This PR enables conformance tests in order to run in the virtiofs CI.

Fixes #2713

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>