### PR TITLE
metrics: enable blogbench to check IO performance

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -45,3 +45,29 @@ checktype = "mean"
 midval = 66170.0
 minpercent = 5.0
 maxpercent = 5.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench write"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .write.Result"
+checktype = "mean"
+midval = 321.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench read"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .read.Result"
+checktype = "mean"
+midval = 16894.0
+minpercent = 10.0
+maxpercent = 10.0

--- a/metrics/storage/blogbench.sh
+++ b/metrics/storage/blogbench.sh
@@ -26,8 +26,8 @@ ITERATIONS="${ITERATIONS:-30}"
 
 # Directory to run the test on
 # This is run inside of the container
-TESTDIR="${TESTDIR:-/tmp}"
-CMD="blogbench -i ${ITERATIONS} -d ${TESTDIR}"
+TESTDIR="${TESTDIR:-/testdir}"
+CMD="mkdir -p ${TESTDIR}; blogbench -i ${ITERATIONS} -d ${TESTDIR}"
 
 function main() {
 	# Check tools/commands dependencies
@@ -39,7 +39,9 @@ function main() {
 
 	metrics_json_init
 
-	local output=$(docker run --rm --runtime=$RUNTIME $IMAGE $CMD)
+	# Run with 4 vcpus, issue:
+	# https://github.com/kata-containers/tests/issues/2717
+	local output=$(docker run --cpus 4 --rm --runtime=$RUNTIME $IMAGE bash -c ''"$CMD"'')
 
 	# Save configuration
 	metrics_json_start_array


### PR DESCRIPTION
Enable blogbench as part of the metrics CI to measure read-write IO
performance on every pull request

fixes #2716

Signed-off-by: Julio Montes <julio.montes@intel.com>