### PR TITLE
metrics: Add blogbench limits for clh+virtiofs

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
@@ -45,3 +45,29 @@ checktype = "mean"
 midval = 283939.43
 minpercent = 5.0
 maxpercent = 5.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench write"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .write.Result"
+checktype = "mean"
+midval = 3927.30
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench read"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .read.Result"
+checktype = "mean"
+midval = 11488.28
+minpercent = 20.0
+maxpercent = 20.0


### PR DESCRIPTION
This adds the limits for blogbench for read and write for the
clh+virtiofs.

Fixes #2720

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>