### PR TITLE
test: Improve k8s pid test

### DIFF
--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -29,9 +29,15 @@ setup() {
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name ps | grep "/pause")
+	# Verify that is not empty
+	check_first_pid=$(echo $first_pid_container | wc -l)
+	[ "$check_first_pid" == "1" ]
 
 	# Check PID from second container
 	second_pid_container=$(kubectl exec $pod_name -c $second_container_name ps | grep "/pause")
+	# Verify that is not empty
+	check_second_pid=$(echo $second_pid_container | wc -l)
+	[ "$check_second_pid" == "1" ]
 
 	[ "$first_pid_container" == "$second_pid_container" ]
 }


### PR DESCRIPTION
This PR imporves the k8s pid test by also verifying that the first pid
container and the second pid container are not empty. This is related with
the comment that was made in https://github.com/kata-containers/runtime/issues/2788#issuecomment-657895989.

Fixes #2722

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>