### PR TITLE
metrics: Enable blogbench limits for virtiofs+qemu

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
@@ -45,3 +45,29 @@ checktype = "mean"
 midval = 144151.64
 minpercent = 5.0
 maxpercent = 5.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench write"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .write.Result"
+checktype = "mean"
+midval = 1471.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "blogbench"
+type = "json"
+description = "measure container average of blogbench read"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"blogbench\".Results | .[] | .read.Result"
+checktype = "mean"
+midval = 60731.43
+minpercent = 10.0
+maxpercent = 10.0


### PR DESCRIPTION
This PR enables the limits for blogbench operations like read and write for
virtiofs+qemu.

Fixes #2726

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>