### PR TITLE
[DNM] dummy: clh: test PR #1099 from kata-containers/packaging

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -66,14 +66,8 @@ main() {
 	cached_cloud_hypervisor_version=$(curl -sfL "${latest_build_url}/latest") || cached_cloud_hypervisor_version="none"
 	info "current cloud hypervisor : ${current_cloud_hypervisor_version}"
 	info "cached cloud hypervisor  : ${cached_cloud_hypervisor_version}"
-	if [ "$cached_cloud_hypervisor_version" == "$current_cloud_hypervisor_version" ] && [ "$arch" == "x86_64" ]; then
-		if ! install_prebuilt_clh; then
-			info "failed to install cached cloud hypervisor, trying to build from source"
-			install_clh
-		fi
-	else
-		install_clh
-	fi
+        # enforce to install clh from source to validate whether clh is built statically
+	install_clh
 }
 
 main "$@"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -52,6 +52,14 @@ echo "Install runtime"
 case "${KATA_HYPERVISOR}" in
 	"cloud-hypervisor")
 		"${cidir}/install_cloud_hypervisor.sh"
+
+		printf "ldd $(which cloud-hypervisor)\n"
+                if ldd $(which cloud-hypervisor); then
+                    echo "cloud-hypervisor is not static"
+                else
+                    echo "cloud-hypervisor is static"
+                fi
+
 		echo "Installing experimental_qemu to install virtiofsd"
 		export experimental_qemu=true
 		install_qemu


### PR DESCRIPTION
Again this is a dummy PR to the test repo, and is used to validate the
changes to another PR from the packaging PR related to
cloud-hypervisor. The following linked issue is just a place holder.


Depends-on: github.com/kata-containers/packaging#1099
Depends-on: github.com/kata-containers/runtime#2900

Fixes: #2546

Signed-off-by: Bo Chen <chen.bo@intel.com>