### PR TITLE
test: check against 2.0-dev branch instead of master

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -229,7 +229,10 @@ static_check_commits()
 {
 	# Since this script is called from another repositories directory,
 	# ensure the utility is built before running it.
-	(cd "${tests_repo_dir}" && make checkcommits)
+	# for master branch
+	# (cd "${tests_repo_dir}" && make checkcommits)
+	# for 2.0-dev branch
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin '2.0-dev' && git fetch -v)
 
 	# Check the commits in the branch
 	{
@@ -237,7 +240,9 @@ static_check_commits()
 			--need-fixes \
 			--need-sign-offs \
 			--ignore-fixes-for-subsystem "release" \
-			--verbose; \
+			--verbose \
+			HEAD \
+			2.0-dev; \
 			rc="$?";
 	} || true
 
@@ -1173,7 +1178,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "master" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "2.0-dev" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"


### PR DESCRIPTION
For kata 2.0, checkcommits should check against 2.0-dev branch.

Fixes: #2732

Signed-off-by: bin liu <bin@hyper.sh>