### PR TITLE
ci: Fixes to build experimental QEMU with virtiofs

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -77,16 +77,12 @@ case "${KATA_HYPERVISOR}" in
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-virtiofs.toml"
 		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
-			if [ "$CI" == true ] && [ "$(uname -m)" == "x86_64" ]; then
-				qemu_version="$(get_version "assets.hypervisor.qemu.version")"
-				qemu_major="$(echo ${qemu_version} | cut -d. -f1)"
-				qemu_minor="$(echo ${qemu_version} | cut -d. -f2)"
-				if [[ ${qemu_major} -ge 5 || ( ${qemu_major} -eq 4 && ${qemu_minor} -ge 2 ) ]]; then
-					# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
-					# see https://github.com/kata-containers/runtime/pull/2355#issuecomment-625469252
-					sudo sed -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
-				fi
-			fi
+		fi
+		if [ "$CI" == true ] && [ "$(uname -m)" == "x86_64" ]; then
+			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
+			# All CI now uses qemu 5.0+, disabled in the time..
+			# see https://github.com/kata-containers/runtime/pull/2355#issuecomment-625469252
+			sudo sed -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
 		fi
 		;;
 	*)


### PR DESCRIPTION
- disable vmx-rdseed-exit:  Needed to use qemu 5.0+ in azure VMs.
- Install docker all the time, needed to build cached components in podman tests

Depends-on: github.com/kata-containers/packaging#1097
Depends-on: github.com/kata-containers/runtime#2840

Fixes: #2736

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>