### PR TITLE
docs: Update breaking compatibility sectionf in README for kata 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ For example:
 
 	Fixes: #nnn
 
-	Depends-on:github.com/kata-containers/runtime#999
+	Depends-on:github.com/kata-containers/kata-containers#999
 
 	Signed-off-by: <contributor@foo.com>
 
 ```
 
-In this example, we tell the CI to fetch the pull request 999 from the `runtime`
+In this example, we tell the CI to fetch the pull request 999 from the `kata-containers`
 repository and use that rather than the `master` branch when testing the changes
 contained in this pull request.
 


### PR DESCRIPTION
This PR updates the breaking compatibility section to replace the
kata-containers/runtime repository for the kata-containers/kata-containers
repository.

Fixes #2751

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>