### PR TITLE
tests: Unskip k8s tests for kata 2.0

### DIFF
--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -13,10 +13,8 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	deployment="hello-world"
 	service="my-service"
@@ -24,7 +22,6 @@ setup() {
 }
 
 @test "Expose IP Address" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	wait_time=20
 	sleep_time=2
 
@@ -61,7 +58,6 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete services ${service}
 	kubectl delete deployment ${deployment}
 }

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -7,10 +7,8 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="busybox"
 	first_container_name="first-test-container"
@@ -20,7 +18,6 @@ setup() {
 }
 
 @test "Check PID namespaces" {
-	skip "test not working - see: ${issue}"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
@@ -43,6 +40,5 @@ setup() {
 }
 
 teardown() {
-	skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -6,16 +6,13 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Pod quota" {
-	skip "test not working - see: ${issue}"
 	resource_name="pod-quota"
 	deployment_name="deploymenttest"
 
@@ -33,7 +30,6 @@ setup() {
 }
 
 teardown() {
-	skip "test not working - see: ${issue}"
 	kubectl delete resourcequota "$resource_name"
 	kubectl delete deployment "$deployment_name"
 }

--- a/integration/kubernetes/k8s-shared-volume.bats
+++ b/integration/kubernetes/k8s-shared-volume.bats
@@ -7,16 +7,13 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Containers with shared volume" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="test-shared-volume"
 	first_container_name="busybox-first-container"
 	second_container_name="busybox-second-container"
@@ -34,7 +31,6 @@ setup() {
 }
 
 @test "initContainer with shared volume" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="initcontainer-shared-volume"
 	last_container="last"
 
@@ -49,6 +45,5 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
This PR removes the skipping of the kubernetes tests for kata 2.0

Fixes #2753

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>