### PR TITLE
s390x: Switch to newer qemu version

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -142,7 +142,7 @@ main() {
 				build_and_install_static_qemu
 			fi
 			;;
-		"ppc64le"|"s390x")
+		"ppc64le")
 			packaged_qemu_version=$(get_packaged_qemu_version)
 			short_current_qemu_version=${CURRENT_QEMU_VERSION#*-}
 			if [ "$packaged_qemu_version" == "$short_current_qemu_version" ] && [ -z "${CURRENT_QEMU_TAG}" ] || [ "${QEMU_ARCH}" == "s390x" ]; then
@@ -151,7 +151,7 @@ main() {
 				build_and_install_qemu
 			fi
 			;;
-		"aarch64")
+		"aarch64"|"s390x")
 			# For now, we don't follow stable version on aarch64, but one specific tag version, so we need to build from scratch.
 			build_and_install_qemu
 			;;

--- a/.ci/s390x/lib_install_qemu_s390x.sh
+++ b/.ci/s390x/lib_install_qemu_s390x.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.version")
+CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.tag")
 PACKAGED_QEMU="qemu"
 
 [ "$ID" == "ubuntu" ] || die "Unsupported distro: $ID"
@@ -49,7 +49,7 @@ build_and_install_qemu() {
 
 	pushd "${GOPATH}/src/${QEMU_REPO_PATH}"
 	git fetch
-	git checkout "$CURRENT_QEMU_VERSION"
+	git checkout "$CURRENT_QEMU_TAG"
 	[ -d "capstone" ] || git clone https://github.com/qemu/capstone.git capstone
 	[ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 


### PR DESCRIPTION
Since kata now needs support for multidevs, this PR switches from packaged qemu to custom build qemu.

Fixes #2756

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>