### PR TITLE
ci: clean up stale files for containerd and cni

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -299,6 +299,8 @@ delete_containerd_cri_stale_resource() {
 	done
 	# remove cluster directory
 	sudo rm -rf /opt/containerd/
+	# remove containerd home directory
+	sudo rm -r /var/lib/containerd
 	# remove configuration files
 	sudo rm -f /etc/containerd/config.toml
 	sudo rm -f /etc/crictl.yaml
@@ -330,6 +332,11 @@ gen_clean_arch() {
 		sudo rm -rf /etc/systemd/system/kubelet.service.d
 		sudo apt-get purge kubeadm kubelet kubectl -y
 	fi
+	# Remove existing CNI configurations and binaries.
+	sudo sh -c 'rm -rf /var/lib/cni/networks/*'
+	sudo sh -c 'rm -rf /opt/cni/bin/*'
+	sudo sh -c 'rm /etc/cni/net.d/*'
+
 	info "Remove Kata package repo registrations"
 	delete_kata_repo_registrations
 


### PR DESCRIPTION
Some stale files and directorys of containerd and cni have not cleaned
up after last ci which lead to ci crash for next time on arm
as all ARM ci runs on baremental.

Fixes: #2758
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @devimc @GabyCT @Pennyzct 