### PR TITLE
ci: gzip virtiofs log

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -132,6 +132,7 @@ collect_logs()
 		prefixes+=" ${ksm_throttler_log_prefix}"
 		prefixes+=" ${vc_throttler_log_prefix}"
 		prefixes+=" ${kernel_log_prefix}"
+		prefixes+=" ${virtiofs_log_prefix}"
 
 		[ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
 


### PR DESCRIPTION
Gzip virtiofs log at teardown stage.

Fixes: #2763

Signed-off-by: bin liu <bin@hyper.sh>