### PR TITLE
ci: add test cases for kubectl exec command

### DIFF
--- a/integration/kubernetes/k8s-exec.bats
+++ b/integration/kubernetes/k8s-exec.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2020 Ant Financial
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	get_pod_config_dir
+	pod_name="busybox"
+	first_container_name="first-test-container"
+	second_container_name="second-test-container"
+}
+
+@test "Kubectl exec" {
+	# Create the pod
+	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
+
+	# Get pod specification
+	kubectl wait --for=condition=Ready pod "$pod_name"
+
+	# Run commands in Pod
+	## Cases for -it options
+	# TODO: enable -i option after updated to new CRI-O
+	# see: https://github.com/kata-containers/tests/issues/2770
+	# kubectl exec -i "$pod_name" -- ls -tl /
+	# kubectl exec -it "$pod_name" -- ls -tl /
+	kubectl exec "$pod_name" -- date
+
+	## Case for stdin
+	kubectl exec -i "$pod_name" -- sh <<EOC
+echo abc > /tmp/abc.txt
+grep abc /tmp/abc.txt
+exit
+EOC
+
+	## Case for return value
+	### Command return non-zero code
+	run bash -c "kubectl exec -i $pod_name -- sh <<EOC
+exit 123
+EOC"
+	echo "run status: $status" 1>&2
+	echo "run output: $output" 1>&2
+	[ "$status" -eq 123 ]
+
+	## Cases for target container
+	### First container
+	container_name=$(kubectl exec $pod_name -c $first_container_name -- env | grep CONTAINER_NAME)
+	[ "$container_name" == "CONTAINER_NAME=$first_container_name" ]
+
+	### Second container
+	container_name=$(kubectl exec $pod_name -c $second_container_name -- env | grep CONTAINER_NAME)
+	[ "$container_name" == "CONTAINER_NAME=$second_container_name" ]
+
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -34,6 +34,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-custom-dns.bats" \
 	"k8s-empty-dirs.bats" \
 	"k8s-env.bats" \
+	"k8s-exec.bats" \
 	"k8s-expose-ip.bats" \
 	"k8s-job.bats" \
 	"k8s-limit-range.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -14,11 +14,17 @@ spec:
   containers:
   - name: first-test-container
     image: busybox
+    env:
+    - name: CONTAINER_NAME
+      value: "first-test-container"
     command:
         - sleep
         - "30"
   - name: second-test-container
     image: busybox
+    env:
+    - name: CONTAINER_NAME
+      value: "second-test-container"
     command:
         - sleep
         - "30"


### PR DESCRIPTION
Add cases for test `kubectl exec`'s options, input, and return values.

Fixes: #2765

Signed-off-by: bin liu <bin@hyper.sh>