### PR TITLE
ci: delete -i option of kubectl exec

### DIFF
--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -23,8 +23,8 @@ setup() {
 	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check dns config at /etc/resolv.conf
-	kubectl exec -it "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"
-	kubectl exec -it "$pod_name" -- cat "$file_name" | grep -q "search dns.test.search"
+	kubectl exec "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"
+	kubectl exec "$pod_name" -- cat "$file_name" | grep -q "search dns.test.search"
 }
 
 teardown() {

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -28,7 +28,7 @@ setup() {
 
 	for _ in $(seq 1 "$retries"); do
 		# Get number of cpus
-		number_cpus=$(kubectl exec -ti pod/"$pod_name" -c "$container_name" nproc | sed 's/[[:space:]]//g')
+		number_cpus=$(kubectl exec pod/"$pod_name" -c "$container_name" nproc | sed 's/[[:space:]]//g')
 		# Verify number of cpus
 		[ "$number_cpus" -le "$max_number_cpus" ]
 		sleep 1


### PR DESCRIPTION
There is no need to use the -i option if there is no stdio.

Depends-on:github.com/kata-containers/kata-containers#440

Fixes: #2770

Signed-off-by: bin liu <bin@hyper.sh>