### PR TITLE
spellcheck: add netlink term to spellchecker

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -98,3 +98,4 @@ webhook/AB
 whitespace
 workflow/A
 Xeon/A
+netlink


### PR DESCRIPTION
Fixes: #2772

reason: for https://github.com/kata-containers/agent/pull/814

Signed-off-by: jiangpengfei <jiangpengfei9@huawei.com>