### PR TITLE
ci: use nanoseconds to compare container start time

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -13,14 +13,14 @@ spec:
   initContainers:
   - name: first
     image: busybox
-    command: [ "sh", "-c", "date +%s > /volume/initContainer" ]
+    command: [ "sh", "-c", "date +%s%N > /volume/initContainer" ]
     volumeMounts:
       - mountPath: /volume
         name: volume
   containers:
   - name: last
     image: busybox
-    command: [ "sh", "-c", "date +%s > /volume/container; tail -f /dev/null" ]
+    command: [ "sh", "-c", "date +%s%N > /volume/container; tail -f /dev/null" ]
     volumeMounts:
     - mountPath: /volume
       name: volume


### PR DESCRIPTION
Use nanoseconds instead of seconds to compare container
start time to ensure the container start order.

Fixes: #2783

Signed-off-by: bin liu <bin@hyper.sh>