### PR TITLE
ci: add sleep in init container

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -13,14 +13,14 @@ spec:
   initContainers:
   - name: first
     image: busybox
-    command: [ "sh", "-c", "date +%s > /volume/initContainer" ]
+    command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/initContainer" ]
     volumeMounts:
       - mountPath: /volume
         name: volume
   containers:
   - name: last
     image: busybox
-    command: [ "sh", "-c", "date +%s > /volume/container; tail -f /dev/null" ]
+    command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/container; tail -f /dev/null" ]
     volumeMounts:
     - mountPath: /volume
       name: volume


### PR DESCRIPTION
In some case the `date +%s` may get the same value
in initContainer and normal container, use $EPOCHREALTIME
can ensure that the values are different.

Fixes: #2783

Signed-off-by: bin liu <bin@hyper.sh>