### PR TITLE
tests: Update consul docker integration test

### DIFF
--- a/integration/popular_docker_hub_images/popular_docker_images.bats
+++ b/integration/popular_docker_hub_images/popular_docker_images.bats
@@ -119,7 +119,7 @@ setup() {
 
 @test "[run agent] run a consul container" {
 	image="consul"
-	docker run --rm --runtime=$RUNTIME -i $image sh -c "timeout -t 10 consul agent -dev -client 0.0.0.0 | grep 0.0.0.0"
+	docker run --rm --runtime=$RUNTIME -i $image sh -c "timeout 10 consul agent -dev -client 0.0.0.0 | grep 0.0.0.0"
 }
 
 @test "[display version] run a crate container" {


### PR DESCRIPTION
This PR updates the consul docker hub popular image test as the -t flag has
been removed it from the command timeout.

Fixes #2786

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>