### PR TITLE
ci: Enable clh+virtiofs CI

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Usage:
+# curl -OL https://raw.githubusercontent.com/kata-containers/tests/master/.ci/ci_entry_point.sh.sh
+# export export CI_JOB="JOB_ID"
+# bash ci_entry_point.sh.sh "<repo-to-test>"
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+script_name=${0##*/}
+script_dir=$(dirname "$(readlink -f "$0")")
+
+handle_error() {
+	local exit_code="${?}"
+	local line_number="${1:-}"
+	echo "Failed at ${script_dir}/${script_name} +$line_number: ${BASH_COMMAND}"
+	exit "${exit_code}"
+}
+
+trap 'handle_error $LINENO' ERR
+
+# Repository to be tested
+repo_to_test="${1}"
+[ -z "${repo_to_test}" ] && echo "kata repo no provided" && exit 1
+
+repo_to_test=${repo_to_test#"https://"}
+repo_to_test=${repo_to_test%".git"}
+
+# PR info provided by the caller
+export ghprbPullId
+export ghprbTargetBranch
+
+# Use workspace as gopath
+export WORKSPACE=${WORKSPACE:-$HOME}
+export GOPATH="${WORKSPACE}/go"
+
+# Repository where we store all tests
+tests_repo="github.com/kata-containers/tests"
+
+# Clone as golang would do it with GOPATH
+tests_repo_dir="${GOPATH}/src/${tests_repo}"
+mkdir -p "${tests_repo_dir}"
+git clone "https://${tests_repo}.git" "${tests_repo_dir}"
+cd "${tests_repo_dir}"
+
+# Checkout to target branch: master, stable-X.Y, 2.0-dev etc
+git checkout "origin/${ghprbTargetBranch}"
+
+# If the changes are in the repository to test:
+# Update the repository first so we can catch most of changes
+# Only changes in this file will have effect
+# So lets try to keep this file small, simple and generic to avoid need
+# update it in the future
+if [ "${repo_to_test}" == "${tests_repo}" ]; then
+	pr_number="${ghprbPullId}"
+	pr_branch="PR_${pr_number}"
+	git fetch origin "pull/${pr_number}/head:${pr_branch}"
+	git checkout "${pr_branch}"
+	git rebase "origin/${ghprbTargetBranch}"
+fi
+
+.ci/jenkins_job_build.sh "${repo_to_test}"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -38,7 +38,7 @@ install_clh() {
 	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
 	# packaging build script expects run in the hypervisor repo parent directory
 	# It will find the hypervisor repo and checkout to the version exported above
-	"${kata_repo_dir}/static-build/cloud-hypervisor/build-static-clh.sh"
+	"${kata_repo_dir}/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh"
 	sudo install -D "cloud-hypervisor/${clh_bin_name}"  "${clh_install_path}"
 	popd
 }

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -22,6 +22,58 @@ WORKSPACE=${WORKSPACE:-}
 BAREMETAL=${BAREMETAL:-false}
 TMPDIR=${TMPDIR:-}
 
+# List of all setup flags used by scripts
+init_ci_flags() {
+	# Make jobs work like in CI
+	# CI disables non-working tests
+	export CI="true"
+	export KATA_DEV_MODE="false"
+	# Install crio
+	export CRIO="no"
+	# Install cri-containerd
+	export CRI_CONTAINERD="no"
+	# Default cri runtime - used to setup k8s
+	export CRI_RUNTIME=""
+	# Ask runtime to only use cgroup at pod level
+	# Useful for pod overhead
+	export DEFSANDBOXCGROUPONLY="false"
+	# Hypervisor to use
+	export KATA_HYPERVISOR=""
+	# Install k8s
+	export KUBERNETES="no"
+	# Run a subset of k8s e2e test
+	# Will run quick to ensure e2e setup is OK
+	# - Use false for PRs
+	# - Use true for nightly testing
+	export MINIMAL_K8S_E2E="false"
+	# Test cgroup v2
+	export TEST_CGROUPSV2="false"
+	# Run crio functional test
+	export TEST_CRIO="false"
+	# Run docker functional test
+	export TEST_DOCKER="no"
+	# Use experimental kernel
+	# Values: true|false
+	export experimental_kernel="false"
+	# Run the kata-check checks
+	export RUN_KATA_CHECK="true"
+
+	# METRICS_CI flags
+	# Request to run METRICS_CI
+	# Values: ""|some value : If empty metrics CI is not enabled
+	export METRICS_CI=""
+	# Metrics check values depend in the env it run
+	# Define a profile to check on PRs
+	# Values: empty|string : String will be used to find a profile with defined values to check
+	export METRICS_CI_PROFILE=""
+	# Check values for a profile defined as CLOUD
+	# Deprecated use METRICS_CI_PROFILE will be replaced by METRICS_CI_PROFILE=cloud-metrics
+	export METRICS_CI_CLOUD=""
+	# Generate a report using a jenkins job data
+	# Name of the job to get data from
+	export METRICS_JOB_BASELINE=""
+}
+
 # Run noninteractive on debian and ubuntu
 if [ "$ID" == "debian" ] || [ "$ID" == "ubuntu" ]; then
 	export DEBIAN_FRONTEND=noninteractive
@@ -169,6 +221,17 @@ case "${CI_JOB}" in
 	if [ "$arch" == "x86_64" ]; then
 		export TEST_CRIO="true"
 	fi
+	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+	export CRIO="no"
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export OPENSHIFT="no"
+	export TEST_CRIO="false"
+	export TEST_DOCKER="true"
+	export experimental_kernel="true"
 	;;
 esac
 "${ci_dir_name}/setup.sh"


### PR DESCRIPTION
This PR will allow us to enable a jenkins job for the clh+virtiofs CI.

Depends-on: github.com/kata-containers/kata-containers#533

Fixes #2788

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>