### PR TITLE
ci: deep clean stale files and cleanup iptables before save

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -299,8 +299,11 @@ delete_containerd_cri_stale_resource() {
 	done
 	# remove cluster directory
 	sudo rm -rf /opt/containerd/
-	# remove containerd home directory
+	# remove containerd home/run directory
 	sudo rm -r /var/lib/containerd
+	sudo rm -r /var/lib/containerd-test
+	sudo rm -r /run/containerd
+	sudo rm -r /run/containerd-test
 	# remove configuration files
 	sudo rm -f /etc/containerd/config.toml
 	sudo rm -f /etc/crictl.yaml
@@ -333,9 +336,9 @@ gen_clean_arch() {
 		sudo apt-get purge kubeadm kubelet kubectl -y
 	fi
 	# Remove existing CNI configurations and binaries.
-	sudo sh -c 'rm -rf /var/lib/cni/networks/*'
 	sudo sh -c 'rm -rf /opt/cni/bin/*'
-	sudo sh -c 'rm /etc/cni/net.d/*'
+	sudo sh -c 'rm -rf /etc/cni'
+	sudo sh -c 'rm -rf /var/lib/cni'
 
 	info "Remove Kata package repo registrations"
 	delete_kata_repo_registrations

--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -23,8 +23,11 @@ sudo iptables-restore < "$iptables_cache"
 sudo -E rm -rf "$HOME/.kube"
 
 # Remove existing CNI configurations and binaries.
-sudo sh -c 'rm -rf /var/lib/cni/networks/*'
+sudo sh -c 'rm -rf /var/lib/cni'
 sudo sh -c 'rm -rf /opt/cni/bin/*'
+
+#cleanup stale file under /run
+sudo sh -c 'rm -rf /run/flannel'
 
 # delete containers resource created by runc
 cri_runtime="${CRI_RUNTIME:-crio}"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -47,6 +47,8 @@ BAREMETAL="${BAREMETAL:-false}"
 iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 if [ "${BAREMETAL}" == true ]; then
 	[ -d "${KATA_TESTS_DATADIR}" ] || sudo mkdir -p "${KATA_TESTS_DATADIR}"
+	# cleanup iptables before save
+	iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X
 	iptables-save > "$iptables_cache"
 fi
 


### PR DESCRIPTION
Clean stale files and directories under /run, /var/lib/ at the end
of ci build.
Cleanup iptables before "iptables-save" as stale iptables may
accumulated across ci build round after round as for the cases
where the ci run in bare metal.

Fixes: #542
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @devimc 