### PR TITLE
ci: Enable and fix clh CI for kata 2.0 for k8s+containerd tests

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -90,16 +90,12 @@ case "${KATA_HYPERVISOR}" in
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-virtiofs.toml"
 		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
-			if [ "$(uname -m)" == "x86_64" ]; then
-				qemu_version="$(get_version "assets.hypervisor.qemu.version")"
-				qemu_major="$(echo ${qemu_version} | cut -d. -f1)"
-				qemu_minor="$(echo ${qemu_version} | cut -d. -f2)"
-				if [[ ${qemu_major} -ge 5 || ( ${qemu_major} -eq 4 && ${qemu_minor} -ge 2 ) ]]; then
-					# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
-					# see https://github.com/kata-containers/runtime/pull/2355#issuecomment-625469252
-					sudo sed -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
-				fi
-			fi
+		fi
+		if [ "$(uname -m)" == "x86_64" ]; then
+			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
+			# All CI now uses qemu 5.0+, disabled in the time..
+			# see https://github.com/kata-containers/runtime/pull/2355#issuecomment-625469252
+			sudo sed -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
 		fi
 		;;
 	*)

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -41,6 +41,8 @@ init_ci_flags() {
 	export KATA_HYPERVISOR=""
 	# Install k8s
 	export KUBERNETES="no"
+        # install openshift
+	export OPENSHIFT="no"
 	# Run a subset of k8s e2e test
 	# Will run quick to ensure e2e setup is OK
 	# - Use false for PRs
@@ -60,8 +62,8 @@ init_ci_flags() {
 
 	# METRICS_CI flags
 	# Request to run METRICS_CI
-	# Values: ""|some value : If empty metrics CI is not enabled
-	export METRICS_CI=""
+	# Values: "true|false"
+	export METRICS_CI="false"
 	# Metrics check values depend in the env it run
 	# Define a profile to check on PRs
 	# Values: empty|string : String will be used to find a profile with defined values to check
@@ -223,14 +225,11 @@ case "${CI_JOB}" in
 	fi
 	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD")
-	export CRIO="no"
+	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
-	export OPENSHIFT="no"
-	export TEST_CRIO="false"
-	export TEST_DOCKER="true"
 	export experimental_kernel="true"
 	;;
 esac

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -26,6 +26,13 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+		echo "INFO: Containerd checks"
+		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+
+		echo "INFO: Running kubernetes tests with containerd"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -28,6 +28,7 @@ trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 systemctl is-active --quiet docker || sudo systemctl start docker
 
 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
+	"k8s-block-volume.bats" \
 	"k8s-configmap.bats" \
 	"k8s-copy-file.bats" \
 	"k8s-cpu-ns.bats" \
@@ -57,13 +58,10 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-hugepages.bats")
 
 if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
-	blk_issue="https://github.com/kata-containers/tests/issues/2318"
 	sysctl_issue="https://github.com/kata-containers/tests/issues/2324"
-	info "blk ${blk_issue}"
 	info "$KATA_HYPERVISOR sysctl is failing:"
 	info "sysctls: ${sysctl_issue}"
 else
-	K8S_TEST_UNION+=("k8s-block-volume.bats")
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
 fi
 # we may need to skip a few test cases when running on non-x86_64 arch

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -30,6 +30,7 @@ systemctl is-active --quiet docker || sudo systemctl start docker
 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-configmap.bats" \
 	"k8s-copy-file.bats" \
+	"k8s-cpu-ns.bats" \
 	"k8s-credentials-secrets.bats" \
 	"k8s-custom-dns.bats" \
 	"k8s-empty-dirs.bats" \
@@ -39,6 +40,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-limit-range.bats" \
 	"k8s-liveness-probes.bats" \
 	"k8s-memory.bats" \
+	"k8s-number-cpus.bats" \
 	"k8s-parallel.bats" \
 	"k8s-pid-ns.bats" \
 	"k8s-pod-quota.bats" \
@@ -56,17 +58,12 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 
 if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
 	blk_issue="https://github.com/kata-containers/tests/issues/2318"
-	cpu_issue="https://github.com/kata-containers/tests/issues/2325"
 	sysctl_issue="https://github.com/kata-containers/tests/issues/2324"
-	info "$KATA_HYPERVISOR hotplug is not implemented:"
 	info "blk ${blk_issue}"
-	info "cpu ${cpu_issue}"
 	info "$KATA_HYPERVISOR sysctl is failing:"
 	info "sysctls: ${sysctl_issue}"
 else
 	K8S_TEST_UNION+=("k8s-block-volume.bats")
-	K8S_TEST_UNION+=("k8s-cpu-ns.bats")
-	K8S_TEST_UNION+=("k8s-number-cpus.bats")
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
 fi
 # we may need to skip a few test cases when running on non-x86_64 arch


### PR DESCRIPTION
We now have a running CI for clh w/ kata 2.0, but it is failing at a very early 
stage (before starts to run tests). 

First, we are falling into the default code path in run.sh for the CLH CI,
where we are running all tests w/ 'make test'. This patch added the code
path for clh in run.sh to run k8s tests w/ containerd only.

Second, to have a functioning CI, this PR also back-ported patches from 
tests/master branch to tests/dev-2.0 branches.

Third, this PR works along with PR https://github.com/kata-containers/kata-containers/pull/543,
which back-ported related patches from kata-runtime to kata 2.0. 

Depends-on: github.com/kata-containers/kata-containers#543

Fixes: #2788

Signed-off-by: Bo Chen <chen.bo@intel.com>