### PR TITLE
ci: deep clean stale files and cleanup iptables before save

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -280,6 +280,32 @@ delete_crio_stale_resource() {
 	sudo rm -rf /etc/systemd/system/crio.service
 }
 
+delete_containerd_cri_stale_resource() {
+	# stop containerd service
+	sudo systemctl stop containerd
+	# remove stale binaries
+	containerd_cri_dir="github.com/containerd/cri"
+	release_dir="${GOPATH}/src/${containerd_cri_dir}/_output/release-stage"
+	binary_dir_union=( "/usr/local/bin" "/usr/local/sbin" )
+	for binary_dir in ${binary_dir_union[@]}
+	do
+		for stale_binary in ${release_dir}/${binary_dir}/*
+		do
+			sudo rm -rf ${binary_dir}/$(basename ${stale_binary})
+		done
+	done
+	# remove cluster directory
+	sudo rm -rf /opt/containerd/
+	# remove containerd home/run directory
+	sudo rm -r /var/lib/containerd
+	sudo rm -r /var/lib/containerd-test
+	sudo rm -r /run/containerd
+	sudo rm -r /run/containerd-test
+	# remove configuration files
+	sudo rm -f /etc/containerd/config.toml
+	sudo rm -f /etc/crictl.yaml
+}
+
 gen_clean_arch() {
 	# Set up some vars
 	stale_process_union=( "docker-containerd-shim" )
@@ -297,6 +323,8 @@ gen_clean_arch() {
 	delete_stale_kata_resource
 	info "Remove installed kata packages"
 	${GOPATH}/src/${tests_repo}/cmd/kata-manager/kata-manager.sh remove-packages
+	info "Remove installed containerd related files and directories"
+	delete_containerd_cri_stale_resource
 	info "Remove installed cri-o related binaries and configuration"
 	delete_crio_stale_resource
 	info "Remove installed kubernetes packages and configuration"
@@ -304,6 +332,12 @@ gen_clean_arch() {
 		sudo rm -rf /etc/systemd/system/kubelet.service.d
 		sudo apt-get purge kubeadm kubelet kubectl -y
 	fi
+
+	# Remove existing CNI configurations and binaries.
+	sudo sh -c 'rm -rf /opt/cni/bin/*'
+	sudo sh -c 'rm -rf /etc/cni'
+	sudo sh -c 'rm -rf /var/lib/cni'
+
 	info "Remove Kata package repo registrations"
 	delete_kata_repo_registrations
 

--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -23,8 +23,17 @@ sudo iptables-restore < "$iptables_cache"
 sudo -E rm -rf "$HOME/.kube"
 
 # Remove existing CNI configurations and binaries.
-sudo sh -c 'rm -rf /var/lib/cni/networks/*'
+sudo sh -c 'rm -rf /var/lib/cni'
 sudo sh -c 'rm -rf /opt/cni/bin/*'
+sudo sh -c 'rm -rf /etc/cni'
+
+#cleanup stale files in line with k8s
+sudo sh -c 'rm -rf /var/lib/kubelet'
+sudo sh -c 'rm -rf /etc/kubernetes'
+sudo sh -c 'rm -rf /var/lib/etcd'
+
+#cleanup stale files under /run
+sudo sh -c 'rm -rf /run/flannel'
 
 # delete containers resource created by runc
 cri_runtime="${CRI_RUNTIME:-crio}"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -47,6 +47,8 @@ BAREMETAL="${BAREMETAL:-false}"
 iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 if [ "${BAREMETAL}" == true ]; then
 	[ -d "${KATA_TESTS_DATADIR}" ] || sudo mkdir -p "${KATA_TESTS_DATADIR}"
+	# cleanup iptables before save
+	iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X
 	iptables-save > "$iptables_cache"
 fi
 


### PR DESCRIPTION
Clean stale files and dirctories under /run, /var/lib/ at the end
of ci build.
Cleanup iptables before "iptables-save" as stale iptables may
accumulated across ci build round after round as for the cases
where the ci run in bare metal.

Fixes: #542
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@egernst @devimc 