### PR TITLE
metrics: clh: Loose the check on the minVal of memory footprint

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
@@ -30,7 +30,7 @@ description = "measure container average footprint"
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
 midval = 283923.70
-minpercent = 5.0
+minpercent = 25.0
 maxpercent = 5.0
 
 [[metric]]
@@ -43,7 +43,7 @@ description = "measure container average footprint with KSM"
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
 midval = 283939.43
-minpercent = 5.0
+minpercent = 25.0
 maxpercent = 5.0
 
 [[metric]]


### PR DESCRIPTION
We observed the CLH metrics CI can fail with decreased memory
footprint (compared with the reference value). As we are more concerned
about the increased memory footprint, this patch loosed the checks on
the minVal by increasing the `minpercent` from `5.0` to `25.0`.

Fixes: #2808

Signed-off-by: Bo Chen <chen.bo@intel.com>