### PR TITLE
ci: Enable vsock_test for firecracker

### DIFF
--- a/.ci/hypervisors/firecracker/configuration_firecracker.yaml
+++ b/.ci/hypervisors/firecracker/configuration_firecracker.yaml
@@ -39,7 +39,6 @@ docker:
     - memory constraints
     - Hotplug memory when create containers
     - run container and update its memory constraints
-    - vsock test
   Context:
     - remove bind-mount source before container exits
   It:


### PR DESCRIPTION
Along with the development of kata in general, The vsock test is now
passing w/ firecracker.

Fixes: #2398

Signed-off-by: Bo Chen <chen.bo@intel.com>