### PR TITLE
ci/vfio: don't fail if teardown fails

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -154,7 +154,7 @@ ${environment}
     git clone https://github.com/kata-containers/tests.git "\${tests_repo_dir}"
     cd "\${tests_repo_dir}"
 
-    trap "cd \${tests_repo_dir}; sudo -E PATH=\$PATH .ci/teardown.sh ${artifacts_dir}; sudo chown -R \${USER} ${artifacts_dir}" EXIT
+    trap "cd \${tests_repo_dir}; sudo -E PATH=\$PATH .ci/teardown.sh ${artifacts_dir} || true; sudo chown -R \${USER} ${artifacts_dir}" EXIT
 
     if echo \${GIT_URL} | grep -q tests; then
         pr_number="\${ghprbPullId}"


### PR DESCRIPTION
Due to a known bug in kata-log-parser[1], the teardown process is
failing in the VFIO CI.
Add `|| true` after running teardown, this way the VFIO CI won't fail
if kata-log-parse fails.

fixes #2827

[1] - https://github.com/kata-containers/tests/issues/2570

Signed-off-by: Julio Montes <julio.montes@intel.com>