### PR TITLE
ppc64le: fixing rust install

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -28,6 +28,10 @@ export PATH="${PATH}:${HOME}/.cargo/bin"
 echo "Install rust"
 rustup toolchain install ${version}
 rustup default ${version}
-rustup target add ${rustarch}-unknown-linux-musl
+if [ "${rustarch}" == "powerpc64le" ]; then
+	rustup target add ${rustarch}-unknown-linux-gnu
+else
+	rustup target add ${rustarch}-unknown-linux-musl
+	sudo ln -sf /usr/bin/g++ /bin/musl-g++
+fi
 rustup component add rustfmt
-sudo ln -sf /usr/bin/g++ /bin/musl-g++


### PR DESCRIPTION
ppc64le uses glibc implemtation of the
toolchain to install rust agent

Fixes: #2829

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>