### PR TITLE
crio: use drop-in file to configure kata runtime

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -18,12 +18,24 @@ if [ "$ID" == "centos" ]; then
 fi
 
 crio_config_file="/etc/crio/crio.conf"
+crio_config_dir="/etc/crio/crio.conf.d"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/kata-runtime"
 
 minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1 | cut -d '.' -f2)
 
-if [ "$minor_crio_version" -ge "12" ]; then
+if [ "$minor_crio_version" -ge "18" ]; then
+	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
+	echo "- Set kata as default runtime"
+	cat <<EOF >> "$crio_config_dir/99-runtime.conf"
+[crio.runtime]
+default_runtime = "kata"
+[crio.runtime.runtimes.kata]
+runtime_path = "/usr/local/bin/kata-runtime"
+runtime_root = "/run/vc"
+runtime_type = "oci"
+EOF
+elif [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"
 	echo "- Set runc as default runtime"
 	runc_configured=$(grep -q $runc_flag $crio_config_file; echo "$?")


### PR DESCRIPTION
This is partially motivated by failures in https://github.com/cri-o/cri-o/pull/4165 where we expect to be able to see if we're running kata if the runtime chosen has "kata" in the runtime name.

This is also more idiomatic for how cri-o works now
Signed-off-by: Peter Hunt <pehunt@redhat.com>