### PR TITLE
[2.0] crio: use drop-in file to configure kata runtime

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -12,12 +12,24 @@ set -o pipefail
 source /etc/os-release || source /usr/lib/os-release
 
 crio_config_file="/etc/crio/crio.conf"
+crio_config_dir="/etc/crio/crio.conf.d"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/containerd-shim-kata-v2"
 
 minor_crio_version=$(crio --version | head -1 | cut -d '.' -f2)
 
-if [ "$minor_crio_version" -ge "12" ]; then
+if [ "$minor_crio_version" -ge "18" ]; then
+	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
+	echo "- Set kata as default runtime"
+	cat <<EOF >> "$crio_config_dir/99-runtime.conf"
+[crio.runtime]
+default_runtime = "kata"
+[crio.runtime.runtimes.kata]
+runtime_path = "/usr/local/bin/kata-runtime"
+runtime_root = "/run/vc"
+runtime_type = "oci"
+EOF
+elif [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"
 	echo "- Set runc as default runtime"
 	runc_configured=$(grep -q $runc_flag $crio_config_file; echo "$?")

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -21,7 +21,7 @@ minor_crio_version=$(crio --version | head -1 | cut -d '.' -f2)
 if [ "$minor_crio_version" -ge "18" ]; then
 	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
 	echo "- Set kata as default runtime"
-	cat <<EOF >> "$crio_config_dir/99-runtime.conf"
+	sudo tee -a "$crio_config_dir/99-runtime.conf" > /dev/null <<EOF
 [crio.runtime]
 default_runtime = "kata"
 [crio.runtime.runtimes.kata]


### PR DESCRIPTION
when setting up crio >= 1.18.0, use drop-in configs (more idiomatic and simpler), rather
than replacing in line

Fixes #2835

Signed-off-by: Peter Hunt <pehunt@redhat.com>