### PR TITLE
metrics: Increase maxpercent for memory footprint limits

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -31,7 +31,7 @@ checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
 midval = 135767.0
 minpercent = 5.0
-maxpercent = 5.0
+maxpercent = 7.0
 
 [[metric]]
 name = "memory-footprint-ksm"


### PR DESCRIPTION
We have an increment in the memory footprint maximum value as it seems that
a PR was merged where this changed was introduced. This PR fixes the metrics
CI as right now it is broken, we are incrementing the tolerance to 7%.

Fixes #2839

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>