### PR TITLE
crio: Add containerd-shim-kata-v2 runtime class

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -34,6 +34,10 @@ default_runtime = "kata"
 runtime_path = "/usr/local/bin/kata-runtime"
 runtime_root = "/run/vc"
 runtime_type = "oci"
+[crio.runtime.runtimes.containerd-shim-kata-v2]
+runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
+runtime_root = "/run/vc"
+runtime_type = "vm"
 EOF
 elif [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"


### PR DESCRIPTION
Let's also add a new runtime class to the runtimes map, so we can also
test expand the tests to use shimv2.

Fixes: #2841

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>