### PR TITLE
integration: update cpuset tests

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -466,8 +466,8 @@ var _ = Describe("Update CPU constraints", func() {
 		withCPUSetConstraint("0-1", 2, shouldNotFail),
 		withCPUSetConstraint("0-2", 3, shouldNotFail),
 		withCPUSetConstraint("0-3", 4, shouldNotFail),
-		withCPUSetConstraint("0,2", 3, shouldNotFail),
-		withCPUSetConstraint("0,3", 4, shouldNotFail),
+		withCPUSetConstraint("0,2", 2, shouldNotFail),
+		withCPUSetConstraint("0,3", 2, shouldNotFail),
 		withCPUSetConstraint("0,-2,3", 0, shouldFail),
 		withCPUSetConstraint("-1-3", 0, shouldFail),
 	)


### PR DESCRIPTION
Remove cpuset test

    This test will fail until we have appropriate CPUSet support inside the
    guest. Today CPUSets are only supported on the host, and are done by
    placing the entire guest into a CPUset that matches the sum of container
    cpusets. This isn't reflected via nproc in the guest.


