### PR TITLE
checkcommits: fix singleWordLine

### DIFF
--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -56,7 +56,7 @@ const (
 	defaultFixesString = "Fixes"
 
 	defaultMaxSubjectLineLength = 75
-	defaultMaxBodyLineLength    = 72
+	defaultMaxBodyLineLength    = 150
 
 	defaultCommit = "HEAD"
 	defaultBranch = "master"
@@ -161,10 +161,10 @@ func checkCommitBodyLine(config *CommitConfig, commit *Commit, line string,
 	}
 
 	// Remove all whitespace
-	trimmedLine := strings.TrimSpace(line)
+	trimmedLine := strings.Fields(line)
 
 	if *nonWhitespaceOnlyLine == -1 {
-		if trimmedLine != "" {
+		if len(trimmedLine) > 0 {
 			*nonWhitespaceOnlyLine = lineNum
 		}
 	}
@@ -202,13 +202,8 @@ func checkCommitBodyLine(config *CommitConfig, commit *Commit, line string,
 	// something like a URL (it's certainly very unlikely to be a
 	// normal word if the default lengths are being used), so length
 	// checks won't be applied to it.
-	singleWordLine := false
-	if trimmedLine == line {
-		singleWordLine = true
-	}
-
 	length := len(line)
-	if length > config.MaxBodyLineLength && !singleWordLine {
+	if length > config.MaxBodyLineLength && len(trimmedLine) > 1 {
 		return fmt.Errorf("commit %v: body line %d too long (max %v, got %v): %q",
 			commit.hash, 1+lineNum, config.MaxBodyLineLength, length, line)
 	}

--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -506,7 +506,7 @@ func TestCheckCommitBody(t *testing.T) {
 				strings.Repeat("l", (defaultMaxBodyLineLength/2)+1),
 				strings.Repeat("l", (defaultMaxBodyLineLength/2)+1),
 			),
-			"Signed-off-by: me@foo.com"}, config, false, false},
+			"Signed-off-by: me@foo.com"}, config, true, false},
 
 		{[]string{"foo", "Signed-off-by: me@foo.com"}, config, false, false},
 		{[]string{"你好", "Signed-off-by: me@foo.com"}, config, false, false},
@@ -527,7 +527,7 @@ func TestCheckCommitBody(t *testing.T) {
 		{[]string{"你好", "fixes: #999", "Signed-off-by: me@foo.com"}, config, false, true},
 		{[]string{"你好", "fixes #19123", "Signed-off-by: me@foo.com"}, config, false, true},
 		{[]string{"你好", "fixes #123, #234. Fixes: #3456.", "Signed-off-by: me@foo.com"}, config, false, true},
-		{[]string{"moo", lotsOfFixes, "Signed-off-by: me@foo.com"}, config, false, true},
+		{[]string{"moo", lotsOfFixes, "Signed-off-by: me@foo.com"}, config, true, true},
 		{[]string{"moo", fmt.Sprintf("  %s", lotsOfFixes), "Signed-off-by: me@foo.com"}, config, false, true},
 
 		// SOB can be any length


### PR DESCRIPTION
strings.TrimSpace only trims leading and trailing spaces. As a result,
singleWordLine is almost always true. Change to use strings.Fields to
determine singleWordLine.

In the meantime, change defaultMaxBodyLineLength to 150. 72 is way too
small and no one is using such small terminals. Linux kernel already
extends its 80-character limit to 100 and it is just a warning not
a real limit. Since we use it as a hard limit to filter out overly large
lines, let's use a really overly large number.

Fixes: #2847