### PR TITLE
WIP: Run basic CRI-O tests using also shimv2

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -219,6 +219,13 @@ case "${CI_JOB}" in
 	export CRIO="no"
 	export OPENSHIFT="no"
 	;;
+"CRIO")
+	init_ci_flags
+	# FIXME: skip run kata check only for debugging purposes
+	export RUN_KATA_CHECK="false"
+	export TEST_CRIO="true"
+	export CRIO="yes"
+	;;
 "PODMAN")
 	export TEST_CGROUPSV2="true"
 	;;

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -90,6 +90,10 @@ END
 	"CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL")
 		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"
 		;;
+	"CRIO")
+		echo "INFO: Running crio tests with kata-runtime ($PWD)"
+		sudo -E PATH="$PATH" RUNTIME="kata-runtime" bash -c "make crio"
+		;;
 	"PODMAN")
 		export TRUSTED_GROUP="kvm"
 		newgrp "${TRUSTED_GROUP}" << END

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -93,6 +93,8 @@ END
 	"CRIO")
 		echo "INFO: Running crio tests with kata-runtime ($PWD)"
 		sudo -E PATH="$PATH" RUNTIME="kata-runtime" bash -c "make crio"
+		echo "INFO: Running crio tests with containerd-shim-kata-v2 ($PWD)"
+		sudo -E PATH="$PATH" RUNTIME="containerd-shim-kata-v2" bash -c "make crio"
 		;;
 	"PODMAN")
 		export TRUSTED_GROUP="kvm"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -58,7 +58,7 @@ trap 'handle_error $LINENO' ERR
 # and recommended Kata docker runtime install names.
 is_a_kata_runtime(){
 	case "$1" in
-	"kata"*)
+	*"kata"*)
 		echo "1"
 		return
 		;;


### PR DESCRIPTION
In order to do so, a new "CRIO" CI_JOB target has been introduced, which will be used to run both the basic tests with kata-runtime and with containerd-shim-kata-v2.