### PR TITLE
ci: Fix the CLH CI regression in the test repo for kata 2.0

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -27,7 +27,12 @@ init_ci_flags() {
 	# Make jobs work like in CI
 	# CI disables non-working tests
 	export CI="true"
-	export KATA_DEV_MODE="false"
+
+	# Many checks assume this environment variable to be not set
+	# (e.g. [ -n $KATA_DEV_MODE ]). As a result, even its value is
+	# set to 'false', the check would think we are in "kata_dev_mode".
+	# export KATA_DEV_MODE="false"
+
 	# Install crio
 	export CRIO="no"
 	# Install cri-containerd

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -43,7 +43,6 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-liveness-probes.bats" \
 	"k8s-memory.bats" \
 	"k8s-number-cpus.bats" \
-	"k8s-oom.bats" \
 	"k8s-parallel.bats" \
 	"k8s-pid-ns.bats" \
 	"k8s-pod-quota.bats" \
@@ -63,8 +62,13 @@ if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
 	sysctl_issue="https://github.com/kata-containers/tests/issues/2324"
 	info "$KATA_HYPERVISOR sysctl is failing:"
 	info "sysctls: ${sysctl_issue}"
+
+	oom_issue="https://github.com/kata-containers/tests/issues/2864"
+	info "$KATA_HYPERVISOR is failing on:"
+	info "pod oom: ${oom_issue}"
 else
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
+	K8S_TEST_UNION+=("k8s-oom.bats")
 fi
 # we may need to skip a few test cases when running on non-x86_64 arch
 if [ -f "${cidir}/${arch}/configuration_${arch}.yaml" ]; then


### PR DESCRIPTION
This PR fixes the regression on the CLH CI in the test repo for kata 2.0 ( http://jenkins.katacontainers.io/job/kata-containers-2.0-tests-ubuntu-clh-virtiofs-PR/). There are three issues being fixed: 

1. In many of our CI scripts, we assume the 'KATA_DEV_MODE' environment variable to be not set at all when we are not in the 'kata dev mode'. Setting its value explicitly to 'false' would fail the check '[-n $KATA_DEV_MODE]' and make the script believe we ARE in the 'kata dev mode', which would skip some installation. For example, 'install_rust.sh'  is totally skipped in CLH's CI, which caused rust-agent compiling failure and the CI failure. (commit https://github.com/kata-containers/tests/pull/2862/commits/26e49adb7847620224702dc730a0829c45ae0e52).

2. Failure on the new k8s test `pod OOM`. As this is a new k8s tests, it is advisable to debug on this in a separate PR, after bring CLH CI back online. (commit https://github.com/kata-containers/tests/pull/2862/commits/d42d7ae78db9817fcf698d31d240553087b843e8)

3. Build failure for cloud-hypervisor. (commit https://github.com/kata-containers/kata-containers/pull/762/commits/7c1c1ff5191b31f3a8f00d00944f82bc4ae578e9)

Depends-on: github.com/kata-containers/kata-containers#762

Fixes: #2863

Signed-off-by: Bo Chen <chen.bo@intel.com>