### PR TITLE
versions: Update golangci-lint version to 1.19.0.

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -56,7 +56,7 @@ externals:
   golangci-lint:
     description: "utility to run various golang linters"
     url: "github.com/golangci/golangci-lint"
-    version: "v1.16.0"
+    version: "v1.19.0"
 
   parallel:
     description: "GNU parallel tool"


### PR DESCRIPTION
Bump the version of `golangci-lint` to `v1.18.0` for parity with the
vesrion in `master`. The newer version is more strict.

Fixes: #2870.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>