### PR TITLE
ci: compress virtiofsd logs

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -156,6 +156,7 @@ collect_logs()
 		prefixes+=" ${ksm_throttler_log_prefix}"
 		prefixes+=" ${vc_throttler_log_prefix}"
 		prefixes+=" ${kernel_log_prefix}"
+		prefixes+=" ${virtiofs_log_prefix}"
 
 		[ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
 


### PR DESCRIPTION
Compress virtiofsd  logs to save space in CI.

Fixes: #2874

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>