### PR TITLE
CI: Add initrd support to CI scripts

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -96,7 +96,7 @@ build_and_install_qemu() {
 
 	# Apply required patches
 	QEMU_PATCHES_TAG=$(echo "${CURRENT_QEMU_VERSION}" | cut -d '.' -f1-2)
-	QEMU_PATCHES_PATH="${GOPATH}/src/${PACKAGING_REPO}/qemu/patches/${QEMU_PATCHES_TAG}.x"
+	QEMU_PATCHES_PATH="${PACKAGING_DIR}/qemu/patches/${QEMU_PATCHES_TAG}.x"
 	for patch in ${QEMU_PATCHES_PATH}/*.patch; do
 		echo "Applying patch: $patch"
 		git apply "$patch"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -105,10 +105,9 @@ esac
 
 if [ x"${TEST_INITRD}" == x"yes" ]; then
 	echo "Set to test initrd image"
-	sudo sed -i -e '/^image =/d' "${runtime_config_path}"
-else
-	echo "Set to test rootfs image"
-	sudo sed -i -e '/^initrd =/d' "${runtime_config_path}"
+	image_path="${image_path:-$SHAREDIR/kata-containers}"
+	initrd_name=${initrd_name:-kata-containers-initrd.img}
+	sudo sed -i -e "s|^image =.*|initrd = \"$image_path/$initrd_name\"|" "${runtime_config_path}"
 fi
 
 if [ -z "${METRICS_CI}" ]; then


### PR DESCRIPTION
Add initrd support to enable a CI job that will run the tests with initrd.
