### PR TITLE
ci: Enable minimal e2e k8s tests with clh and containerd

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -250,6 +250,16 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
+	init_ci_flags
+	export MINIMAL_CONTAINERD_K8S_E2E="true"
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export experimental_kernel="true"
+	;;
+
 esac
 "${ci_dir_name}/setup.sh"
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -41,6 +41,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests with containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
+		echo "INFO: Running e2e kubernetes tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"


### PR DESCRIPTION
This PR enables the possiblity to run e2e k8s tests for clh and
containerd.

Fixes #2878

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>