### PR TITLE
ci: Fix docker installation centos 8 kata 2.0

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -128,6 +128,9 @@ install_docker(){
 			sudo -E yum install -y yum-utils
 			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"
 			sudo yum-config-manager --add-repo "$repo_url"
+			if [ "$ID" == "centos" ] && [ "$VERSION_ID" -ge "8" ]; then
+				sudo sed -i 's/$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+			fi
 			sudo yum makecache
 			docker_version_full=$(yum --showduplicate list "$pkg_name" | \
 				grep "$docker_version" | awk '{print $2}' | tail -1 | cut -d':' -f2)


### PR DESCRIPTION
This PR enables the docker repo for centos 7 in centos 8 mainly to the lack
of the current docker version supported by kata. In the centos 8 docker
repository the only docker version that is supported is 19. With this we will have
the possibility to install docker 18.06.

Fixes #2880

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>