### PR TITLE
ci: specify default toolchain version during rustup init

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -20,13 +20,11 @@ if [ -z "${version}" ]; then
 fi
 
 if ! command -v rustup > /dev/null; then
-	curl https://sh.rustup.rs -sSf | sh -s -- -y
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${version}
 fi
 
 export PATH="${PATH}:${HOME}/.cargo/bin"
 
-rustup toolchain install ${version}
-rustup default ${version}
 rustup target install ${rustarch}-unknown-linux-musl
 rustup component add rustfmt
 sudo ln -sf /usr/bin/g++ /bin/musl-g++


### PR DESCRIPTION
Specify default toolchain version during rustup init,
so avoid to download toolchain twice.

Fixes: #2883

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>