### PR TITLE
ci: skip k8s-oom test on ARM.

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -37,3 +37,4 @@ kubernetes:
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-expose-ip
+  - k8s-oom


### PR DESCRIPTION
skip k8s-oom test on ARM as it can't pass on ARM for now,
even the root cause is unknown.

Fixes: #2887
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@devimc @jodh-intel 