### PR TITLE
ci: Fix docker installation centos 8

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -135,6 +135,10 @@ install_docker(){
 			sudo -E yum install -y yum-utils
 			repo_url="https://download.docker.com/linux/centos/docker-ce.repo"
 			sudo yum-config-manager --add-repo "$repo_url"
+			# With this we will be able to install docker 18.06
+			if [ "$ID" == "centos" ] && [ "$VERSION_ID" -ge "8" ]; then
+				sudo sed -i 's/$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
+			fi
 			sudo yum makecache
 			docker_version_full=$(sudo yum --showduplicate list "$pkg_name" | \
 				grep "$docker_version" | awk '{print $2}' | tail -1 | cut -d':' -f2)


### PR DESCRIPTION
This PR enables docker repo for centos 7 in centos 8 mainly to the lack
of the current docker version supported by kata. In the centos 8 the
only docker version available is 19, however kata needs 18.06.

Fixes #2890

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>