### PR TITLE
k8s: use ubuntu instead of alpine

### DIFF
--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -48,8 +48,6 @@ setup() {
 	# Verify persistent volume claim is bound
 	kubectl get pvc | grep "Bound"
 
-	# Add the e2fsprogs package to get mkfs.ext4 installed
-	kubectl exec "$pod_name" -- sh -c "apk add --no-cache e2fsprogs"
 	# make fs, mount device and write on it
 	kubectl exec "$pod_name" -- sh -c "mkfs.ext4 $ctr_dev_path"
 	ctr_mount_path="/mnt"

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -7,7 +7,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: my-container
-      image: alpine
+      image: ubuntu:18.04
       command: ["tail", "-f", "/dev/null"]
       volumeDevices:
         - devicePath: DEVICE_PATH


### PR DESCRIPTION
It is much more stable and includes e2fsprogs by default, thus
we do not have to install e2fsprogs on the fly which is not the purpose
of the test and might hit network issues.

Fixes: #2865