### PR TITLE
ci: skip checking license header for patch files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -478,6 +478,8 @@ static_check_license_headers()
 			--exclude="*.lock" \
 			--exclude="grpc-rs/*" \
 			--exclude="target/*" \
+			--exclude="*.patch" \
+			--exclude="*.diff" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
Patch files from other projects are not created by Kata
containers, and should not check license header in CI.

Fixes: #2904

Signed-off-by: bin liu <bin@hyper.sh>