### PR TITLE
ci: change qemu patch path for qemu build on arm64

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -61,7 +61,7 @@ build_and_install_qemu() {
         [ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git --depth 1 ui/keycodemapdb
 
         # Apply required patches
-        QEMU_PATCHES_PATH="${PACKAGING_DIR}/obs-packaging/qemu-aarch64/patches"
+        QEMU_PATCHES_PATH="${PACKAGING_DIR}/qemu/patches/5.1.x"
         for patch in ${QEMU_PATCHES_PATH}/*.patch; do
                 echo "Applying patch: $patch"
                 patch -p1 <"$patch"


### PR DESCRIPTION
As obs-packaging has been removed, new patch path should be set.

Fixes: #2906
Signed-off-by: Edmond AK Dantes <edmond.dantes.ak47@outlook.com>

@jodh-intel  @jongwu  @devimc 