### PR TITLE
Fix fast return

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -68,7 +68,7 @@ local_info() {
 #  to the empty string)
 #
 read_yaml() {
-	${cidir}/install_yq.sh >&2
+	${cidir}/install_yq.sh 1>&5 2>&1
 
 	res=$(yq read "$1" "$2")
 	[ "$res" == "null" ] && res=""

--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -81,16 +81,16 @@ install_jq() {
 	package="jq"
 	case "$ID" in
 		centos|rhel)
-			sudo yum -y install "${package}"
+			sudo yum -y install "${package}" 1>&5 2>&1
 			;;
 		debian|ubuntu)
-			sudo apt-get -y install "${package}"
+			sudo apt-get -y install "${package}" 1>&5 2>&1
 			;;
 		opensuse-*|sles)
-			sudo -E zypper install -y "${package}"
+			sudo zypper install -y "${package}" 1>&5 2>&1
 			;;
 		fedora)
-			sudo dnf -y install "${package}"
+			sudo dnf -y install "${package}" 1>&5 2>&1
 			;;
 	esac
 }


### PR DESCRIPTION
Use the special file descriptor created for messages when installing `jq(1)` and `yq(1)` to avoid polluting the standard streams and causing the fast return script to fail.

Also drops the `-E` from the `sudo(8)` call for SUSE for consistency with the other distro logic.

Fixes: #2365.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>