### PR TITLE
metrics: clh: Update the 'midval' for boot time

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 1.60
+midval = 1.10
 minpercent = 25.0
 maxpercent = 5.0
 


### PR DESCRIPTION
We observed reduced boot-time for cloud-hypervisor w/ kata from one
recent PR kata-containers/runtime#2996. It is expected as we removed
some unnecessary VMMping in the clh driver. Expecting to land the
changes in kata-runtime, we need to adjust the mival of boot time for
clh metrics.

Depends-on: github.com/kata-containers/runtime#2996

Fixes: #2911

Signed-off-by: Bo Chen <chen.bo@intel.com>