### PR TITLE
CI: Add ability to skip CI run in fast-return script

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -78,7 +78,11 @@ read_yaml() {
 
 # Install jq package
 install_jq() {
-	package="jq"
+	local cmd="jq"
+	local package="$cmd"
+
+	command -v "$cmd" &>/dev/null && return 0 || true
+
 	case "$ID" in
 		centos|rhel)
 			sudo yum -y install "${package}" 1>&5 2>&1


### PR DESCRIPTION
Allow the CI to be skipped if the magic `force-skip-ci` label is set for a PR.

Added test for new function.

Fixes: #2914.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>