### PR TITLE
ci: add VFIO CI for kata 2.0

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -66,4 +66,8 @@ if [ "${repo_to_test}" == "${tests_repo}" ]; then
 	git rebase "origin/${ghprbTargetBranch}"
 fi
 
-.ci/jenkins_job_build.sh "${repo_to_test}"
+if [ "${CI_JOB}" == "VFIO" ]; then
+	.ci/vfio_jenkins_job_build.sh "${repo_to_test}"
+else
+	.ci/jenkins_job_build.sh "${repo_to_test}"
+fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -45,6 +45,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"VFIO")
+		echo "INFO: Running VFIO functional tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Run the .ci/jenkins_job_build.sh script in a VM
+# that supports VFIO, then run VFIO functional tests
+
+set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+
+source /etc/os-release || source /usr/lib/os-release
+source "${cidir}/lib.sh"
+
+http_proxy=${http_proxy:-}
+https_proxy=${https_proxy:-}
+vm_ip="127.0.15.1"
+vm_port="10022"
+# Don't save data in /tmp, we need it after rebooting the system
+data_dir="${HOME}/k8s-vfio-test"
+ssh_key_file="${data_dir}/key"
+arch=$(uname -m)
+artifacts_dir="${WORKSPACE}/artifacts"
+
+kill_vms() {
+	sudo killall -9 qemu-system-${arch}
+}
+
+cleanup() {
+	mkdir -p ${artifacts_dir}
+	sudo chown -R ${USER} ${artifacts_dir}
+	scp_vm ${artifacts_dir}/* ${artifacts_dir} || true
+	kill_vms
+}
+
+create_ssh_key() {
+	rm -f "${ssh_key_file}"
+	ssh-keygen -f "${ssh_key_file}" -t rsa -N ""
+}
+
+create_meta_data() {
+	file="$1"
+	cat <<EOF > "${file}"
+{
+  "uuid": "d1b4aafa-5d75-4f9c-87eb-2ceabe110c39",
+  "hostname": "test"
+}
+EOF
+}
+
+create_user_data() {
+	file="$1"
+	ssh_pub_key_file="$2"
+
+	ssh_pub_key="$(cat "${ssh_pub_key_file}")"
+	dnf_proxy=""
+	service_proxy=""
+	docker_user_proxy=""
+	environment=$(env | egrep "ghprb|WORKSPACE|KATA|GIT|JENKINS|_PROXY|_proxy" | \
+	                    sed -e "s/'/'\"'\"'/g" \
+	                        -e "s/\(^[[:alnum:]_]\+\)=/\1='/" \
+	                        -e "s/$/'/" \
+	                        -e 's/^/    export /')
+
+	if [ -n "${http_proxy}" ] && [ -n "${https_proxy}" ]; then
+		dnf_proxy="proxy=${http_proxy}"
+		service_proxy='[Service]
+    Environment="HTTP_PROXY='${http_proxy}'" "HTTPS_PROXY='${https_proxy}'" "NO_PROXY='${no_proxy}'"'
+		docker_user_proxy='{"proxies": { "default": {
+    "httpProxy": "'${http_proxy}'",
+    "httpsProxy": "'${https_proxy}'",
+    "noProxy": "'${no_proxy}'"
+    } } }'
+	fi
+
+	cat <<EOF > "${file}"
+#cloud-config
+package_upgrade: false
+runcmd:
+- chown -R ${USER}:${USER} /home/${USER}
+- touch /.done
+users:
+- gecos: User
+  gid: "1000"
+  lock-passwd: true
+  name: ${USER}
+  shell: /bin/bash
+  ssh-authorized-keys:
+  - ${ssh_pub_key}
+  sudo: ALL=(ALL) NOPASSWD:ALL
+  uid: "1000"
+write_files:
+- content: |
+${environment}
+  path: /etc/environment
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/docker.service.d/http-proxy.conf
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/kubelet.service.d/http-proxy.conf
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+- content: |
+    ${docker_user_proxy}
+  path: ${HOME}/.docker/config.json
+- content: |
+    ${docker_user_proxy}
+  path: /root/.docker/config.json
+- content: |
+    set -x
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+    set -o errtrace
+    . /etc/environment
+    . /etc/os-release
+
+    [ "$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
+
+    echo "${dnf_proxy}" | sudo tee -a /etc/dnf/dnf.conf
+
+    for i in \$(seq 1 50); do
+        [ -f /.done ] && break
+        echo "waiting for cloud-init to finish"
+        sleep 5;
+    done
+
+    export CI_JOB="VFIO"
+    export GOPATH=\${WORKSPACE}/go
+    export PATH=\${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:\${PATH}
+    export GOROOT="/usr/local/go"
+
+    # Make sure the packages were installed
+    # Sometimes cloud-init is unable to install them
+    sudo dnf makecache
+    sudo dnf install -y git make pciutils
+
+    tests_repo_dir="\${GOPATH}/src/github.com/kata-containers/tests"
+    mkdir -p "\${tests_repo_dir}"
+
+    trap "cd \${tests_repo_dir} && sudo -E PATH=\$PATH .ci/teardown.sh ${artifacts_dir} || true; sudo chown -R \${USER} ${artifacts_dir}" EXIT
+
+    curl -sLO https://raw.githubusercontent.com/kata-containers/tests/master/.ci/ci_entry_point.sh
+    bash -f ci_entry_point.sh "\${GIT_URL}"
+
+  path: /home/${USER}/run.sh
+  permissions: '0755'
+EOF
+}
+
+create_config_iso() {
+	iso_file="$1"
+	ssh_pub_key_file="${ssh_key_file}.pub"
+	iso_data_dir="${data_dir}/d"
+	meta_data_file="${iso_data_dir}/openstack/latest/meta_data.json"
+	user_data_file="${iso_data_dir}/openstack/latest/user_data"
+
+	mkdir -p $(dirname "${user_data_file}")
+
+	create_meta_data "${meta_data_file}"
+	create_user_data "${user_data_file}" "${ssh_pub_key_file}"
+
+	[ -f "${iso_file}" ] && rm -f "${iso_file}"
+
+	xorriso -as mkisofs -R -V config-2 -o "${iso_file}" "${iso_data_dir}"
+}
+
+pull_fedora_cloud_image() {
+	fedora_img="$1"
+	fedora_img_cache="${fedora_img}.cache"
+	fedora_version=32
+
+	if [ ! -f "${fedora_img_cache}" ]; then
+		curl -sL "https://download.fedoraproject.org/pub/fedora/linux/releases/${fedora_version}/Cloud/${arch}/images/Fedora-Cloud-Base-${fedora_version}-1.6.${arch}.raw.xz" -o "${fedora_img_cache}.xz"
+		xz -f -d "${fedora_img_cache}.xz"
+		sync
+	fi
+
+	cp -a "${fedora_img_cache}" "${fedora_img}"
+	sync
+
+	# setup cloud image
+	sudo losetup -D
+	loop=$(sudo losetup --show -Pf "${fedora_img}")
+	sudo mount "${loop}p1" /mnt
+
+	# disable selinux
+	sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /mnt/etc/selinux/config
+
+	# add intel_iommu=on to the guest kernel command line
+	kernelopts="intel_iommu=on systemd.unified_cgroup_hierarchy=0 selinux=0 "
+	sudo sed -i 's|kernelopts="|kernelopts="'"${kernelopts}"'|g' /mnt/boot/grub2/grub.cfg
+	sudo sed -i 's|kernelopts=|kernelopts='"${kernelopts}"'|g' /mnt/boot/grub2/grubenv
+
+	# cleanup
+	sudo umount -R /mnt/
+	sudo losetup -d "${loop}"
+
+	qemu-img resize -f raw "${fedora_img}" +20G
+}
+
+run_vm() {
+	image="$1"
+	config_iso="$2"
+	disable_modern="off"
+	hostname="$(hostname)"
+	memory="16384M"
+	cpus=4
+	machine_type="q35"
+
+	/usr/bin/qemu-system-${arch} -m "${memory}" -smp cpus="${cpus}" \
+	   -cpu host,host-phys-bits \
+	   -machine ${machine_type},accel=kvm,kernel_irqchip=split \
+	   -device intel-iommu,intremap=on,caching-mode=on,device-iotlb=on \
+	   -drive file=${image},if=virtio,aio=threads,format=raw \
+	   -drive file=${config_iso_file},if=virtio,media=cdrom \
+	   -daemonize -enable-kvm -device virtio-rng-pci -display none -vga none \
+	   -netdev user,hostfwd=tcp:${vm_ip}:${vm_port}-:22,hostname="${hostname}",id=net0 \
+	   -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern="${disable_modern}",iommu_platform=on,ats=on \
+	   -netdev user,id=net1 \
+	   -device virtio-net-pci,netdev=net1,disable-legacy=on,disable-modern="${disable_modern}",iommu_platform=on,ats=on
+}
+
+install_dependencies() {
+	case "${ID}" in
+		ubuntu|debian)
+			# cloud image dependencies
+			deps=(xorriso curl qemu-utils openssh-client)
+
+			# QEMU dependencies
+			deps+=(libcap-dev libattr1-dev libcap-ng-dev librbd-dev gcc pkg-config libglib2.0-dev libpixman-1-dev psmisc)
+
+			sudo apt-get update
+			sudo apt-get install -y ${deps[@]}
+			;;
+		fedora|centos|rhel)
+			# cloud image dependencies
+			deps=(xorriso curl qemu-img openssh)
+
+			# QEMU dependencies
+			deps+=(libcap-devel libattr-devel libcap-ng-devel librbd-devel gcc glib2-devel pixman-devel psmisc)
+
+			sudo dnf install -y ${deps[@]}
+			;;
+
+		"*")
+			die "Unsupported distro: ${ID}"
+			;;
+	esac
+
+	# Build and Install QEMU
+	qemu_version=$(get_version "assets.hypervisor.qemu.version")
+	qemu_dir="${data_dir}/qemu-${qemu_version}"
+	qemu_tar_file="${data_dir}/qemu-${qemu_version}.tar.xz"
+
+	rm -rf "${qemu_dir}"
+	mkdir -p "${qemu_dir}"
+
+	pushd "${qemu_dir}"
+	[ ! -f "${qemu_tar_file}" ] && curl -sL https://download.qemu.org/qemu-${qemu_version}.tar.xz -o "${qemu_tar_file}"
+	tar --strip-components=1 -xf "${qemu_tar_file}"
+	curl -sLO https://raw.githubusercontent.com/kata-containers/packaging/master/scripts/configure-hypervisor.sh
+	bash configure-hypervisor.sh qemu | sed -e 's|--disable-slirp||' -e 's|--enable-libpmem||' | xargs ./configure
+	make -j$(($(nproc)-1))
+	sudo make install
+	popd
+}
+
+ssh_vm() {
+	cmd=$@
+	ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${ssh_key_file}" -p "${vm_port}" "${USER}@${vm_ip}" "${cmd}"
+}
+
+scp_vm() {
+	guest_src=$1
+	host_dest=$2
+	scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${ssh_key_file}" -P "${vm_port}" ${USER}@${vm_ip}:${guest_src} ${host_dest}
+}
+
+wait_for_vm() {
+	for i in $(seq 1 30); do
+		if ssh_vm true; then
+			return 0
+		fi
+		info "waiting for VM to start"
+		sleep 5
+	done
+	return 1
+}
+
+main() {
+	trap cleanup EXIT
+
+	config_iso_file="${data_dir}/config.iso"
+	fedora_img="${data_dir}/image.img"
+
+	mkdir -p "${data_dir}"
+
+	install_dependencies
+
+	create_ssh_key
+
+	create_config_iso "${config_iso_file}"
+
+	for i in $(seq 1 5); do
+		pull_fedora_cloud_image "${fedora_img}"
+		run_vm "${fedora_img}" "${config_iso_file}"
+		if wait_for_vm; then
+			break
+		fi
+		info "Couldn't connect to the VM. Stopping VM and starting a new one."
+		kill_vms
+	done
+
+	ssh_vm "/home/${USER}/run.sh"
+}
+
+main $@

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,9 @@ $(INSTALL_TARGETS): install-%: .ci/install_%.sh
 list-install-targets:
 	@echo $(INSTALL_TARGETS) | tr " " "\n"
 
+vfio:
+	bash -f integration/kubernetes/vfio.sh
+
 help:
 	@echo Subsets of the tests can be run using the following specific make targets:
 	@echo " $(UNION)" | sed 's/ /\n\t/g'
@@ -269,4 +272,5 @@ help:
 	test \
 	tracing \
 	vcpus \
+	vfio \
 	vm-factory

--- a/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vfio
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: c1
+    image: busybox
+    command:
+      - sh
+    tty: true
+    stdin: true
+    resources:
+      limits:
+        intel.com/virtio_net: "1"
+      requests:
+        intel.com/virtio_net: "1"

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/../../.ci/lib.sh"
+
+SYSCONFIG_FILE="/etc/kata-containers/configuration.toml"
+
+trap cleanup EXIT
+cleanup() {
+	sudo rm -rf "${SYSCONFIG_FILE}"
+	${SCRIPT_DIR}/cleanup_env.sh
+}
+
+setup_configuration_file() {
+	local image_type="$1"
+	local machine_type="$2"
+	local hypervisor="$3"
+	local sandbox_cgroup_only="$4"
+
+	local default_config_file="/usr/share/defaults/kata-containers/configuration.toml"
+	local qemu_config_file="/usr/share/defaults/kata-containers/configuration-qemu.toml"
+	local clh_config_file="/usr/share/defaults/kata-containers/configuration-clh.toml"
+	local image_file="/usr/share/kata-containers/kata-containers.img"
+	local initrd_file="/usr/share/kata-containers/kata-containers-initrd.img"
+
+	sudo mkdir -p $(dirname "${SYSCONFIG_FILE}")
+
+	if [ "${hypervisor}" = "qemu" ]; then
+		config_file="${qemu_config_file}"
+	elif [ "${hypervisor}" = "cloud-hypervisor" ]; then
+		config_file="${clh_config_file}"
+	fi
+
+	if [ -f "${config_file}" ]; then
+		cp -a "${config_file}" "${SYSCONFIG_FILE}"
+	elif [ -f "${default_config_file}" ]; then
+		# Check if path contains the hypervisor name
+		if ! grep "^path" "${default_config_file}" | grep -q "${hypervisor}"; then
+			die "Configuration file for ${hypervisor} hypervisor not found"
+		fi
+		sudo cp -a "${default_config_file}" "${SYSCONFIG_FILE}"
+	else
+		die "Error: configuration file for ${hypervisor} doesn't exist"
+	fi
+
+	# machine type applies to configuration.toml and configuration-qemu.toml
+	if [ -n "${machine_type}" ]; then
+		if [ "${hypervisor}" = "qemu" ]; then
+			sudo sed -i 's|^machine_type.*|machine_type = "'${machine_type}'"|g' "${SYSCONFIG_FILE}"
+		else
+			info "Variable machine_type only applies to qemu. It will be ignored"
+		fi
+	fi
+
+	if [ -n "${sandbox_cgroup_only}" ]; then
+		sudo sed -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${sandbox_cgroup_only}'|g' "${SYSCONFIG_FILE}"
+	fi
+
+	# Change to initrd or image depending on user input.
+	# Non-default configs must be changed to specify either initrd or image, image is default.
+	if [ "${image_type}" = "initrd" ]; then
+		if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
+			if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
+				sudo sed -i '/^image.*/d' "${SYSCONFIG_FILE}"
+			else
+				sudo sed -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${SYSCONFIG_FILE}"
+			fi
+		fi
+	else
+		if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
+			if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
+				sudo sed -i '/^initrd.*/d' "${SYSCONFIG_FILE}"
+			else
+				sudo sed -i 's|^initrd.*|image = "'${image_file}'"|g' "${SYSCONFIG_FILE}"
+			fi
+		fi
+	fi
+
+	# enable debug
+	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+		-e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
+		"${SYSCONFIG_FILE}"
+}
+
+run_test() {
+	local image_type="${1:-}"
+	[ -n "$image_type" ] || die "need image type"
+
+	local machine_type="${2:-}"
+
+	local hypervisor="${3:-}"
+	[ -n "$hypervisor" ] || die "need hypervisor"
+
+	local sandbox_cgroup_only="${4:-}"
+	[ -n "$sandbox_cgroup_only" ] || die "need sandbox cgroup only"
+
+	setup_configuration_file "$image_type" "$machine_type" "$hypervisor" "$sandbox_cgroup_only"
+
+	sudo -E kubectl apply -f "${SCRIPT_DIR}/runtimeclass_workloads/vfio.yaml"
+
+	pod_name=vfio
+	sudo -E kubectl wait --for=condition=Ready pod "${pod_name}"
+
+	# Expecting 2 network interaces -> 2 mac addresses
+	mac_addrs=$(sudo -E kubectl exec -ti "${pod_name}" ip a | grep "link/ether" | wc -l)
+	if [ ${mac_addrs} -ne 2 ]; then
+		die "Error: expecting 2 network interfaces, Got: $(kubectl exec -ti "${pod_name}" ip a)"
+	else
+		info "Success: found 2 network interfaces"
+	fi
+}
+
+main() {
+	# Init k8s cluster
+	${SCRIPT_DIR}/init.sh
+
+	sudo modprobe vfio
+	sudo modprobe vfio-pci
+
+	# unbind device from driver
+	# PCI address
+	local addr="00:03.0"
+	echo 0000:${addr} | sudo tee /sys/bus/pci/devices/0000:${addr}/driver/unbind
+
+	# Create a new VFIO device
+	# Ethernet controller: Red Hat, Inc. Virtio network device
+	# vendor ID: 1af4
+	# device ID: 1041
+	local vendor_id="1af4"
+	local device_id="1041"
+	echo "${vendor_id} ${device_id}" | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
+
+	# Install network (device) plugin
+	sriov_plugin_url=$(get_version "plugins.sriov-network-device.url")
+	sriov_plugin_version=$(get_version "plugins.sriov-network-device.version")
+	git clone --depth=1 "${sriov_plugin_url}"
+	pushd sriov-network-device-plugin
+	git checkout "${sriov_plugin_version}"
+	sed -i 's|resourceList.*|resourceList": [{"resourceName":"virtio_net","selectors":{"vendors":["'"${vendor_id}"'"],"devices":["'"${device_id}"'"],"drivers":["vfio-pci"],"pfNames":["eth1"]}},{|g' deployments/configMap.yaml
+	sudo -E kubectl create -f deployments/configMap.yaml
+	sudo -E kubectl create -f deployments/k8s-v1.16/sriovdp-daemonset.yaml
+	sleep 5
+	popd
+	rm -rf sriov-network-device-plugin
+
+	sriov_pod="$(sudo -E kubectl --namespace=kube-system get pods --output=name | grep sriov-device-plugin | cut -d/ -f2)"
+	sudo -E kubectl --namespace=kube-system wait --for=condition=Ready pod "${sriov_pod}"
+
+	# wait for the virtio_net resource
+	for _ in $(seq 1 30); do
+		v="$(sudo -E kubectl get node $(hostname) -o json | jq '.status.allocatable["intel.com/virtio_net"]')"
+		[ "${v}" == \"1\" ] && break
+		sleep 5
+	done
+
+	# Skip clh + initrd:
+	# https://github.com/kata-containers/kata-containers/issues/900
+	# run_test initrd "" cloud-hypervisor false
+	# run_test initrd "" cloud-hypervisor false
+	run_test image "" cloud-hypervisor false
+	run_test image "" cloud-hypervisor true
+	run_test image "q35" qemu false
+	run_test image "q35" qemu true
+	run_test initrd "q35" qemu false
+	run_test initrd "q35" qemu true
+	run_test image "pc" qemu false
+	run_test image "pc" qemu true
+	run_test initrd "pc" qemu false
+	run_test initrd "pc" qemu true
+}
+
+main $@


### PR DESCRIPTION
Use kubernetes + containerd + intel/sriov-network-device-plugin to
run a kata container, hot attach a VFIO network device to check
whether it was added correctly or not.

fixes #2917

Signed-off-by: Julio Montes <julio.montes@intel.com>