### PR TITLE
metrics: Update midvalue for blogbench read

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -68,6 +68,6 @@ description = "measure container average of blogbench read"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .read.Result"
 checktype = "mean"
-midval = 16894.0
-minpercent = 10.0
+midval = 19524.0
+minpercent = 20.0
 maxpercent = 10.0


### PR DESCRIPTION
This PR updates the midvalue for blogbench read as this is needed in
order to update qemu 5.1.0

Depends-on:github.com/kata-containers/runtime#2993

Fixes #2925

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>