### PR TITLE
ci: Add flag "privileged_without_host_devices"

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -26,6 +26,7 @@ cat << EOT | sudo tee /etc/containerd/config.toml
              Root = ""
         [plugins.cri.containerd.runtimes.kata]
            runtime_type = "io.containerd.runc.v1"
+           privileged_without_host_devices = true
            pod_annotations = ["io.kata-containers.*"]
            [plugins.cri.containerd.runtimes.kata.options]
              BinaryName = "${kata_runtime_path}"

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -32,6 +32,7 @@ if [ "$minor_crio_version" -ge "18" ]; then
 default_runtime = "kata"
 [crio.runtime.runtimes.kata]
 runtime_path = "/usr/local/bin/kata-runtime"
+privileged_without_host_devices = true
 runtime_root = "/run/vc"
 runtime_type = "oci"
 EOF


### PR DESCRIPTION
This flag should be used while running privileged containers
with Kata. Lets add this flag as certain tests are run in privileged
containers.

Fixes #2929

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>