### PR TITLE
versions: Update flannel version to v0.13.0-rc2

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -40,7 +40,7 @@ externals:
 
   flannel:
     url: "https://github.com/coreos/flannel"
-    version: "862c448ef28fd890e2ac4e5fddc49e7fe9693b31"
+    version: "v0.13.0-rc2"
 
   xurls:
     description: |


### PR DESCRIPTION
Recently we've seen CI issues on both Debian and CentOS because of
iptables > 1.8 has been causing a different set of connectivity issues.

The one CI is facing is due to a known issue with flannel*, which was
pointed out by Archana Shinde and updating flannel does solve the issue
without causing any other regression.

A huge thanks to Archana for nailing down the issue.

*: https://github.com/coreos/flannel/issues/1306

Fixes: #2910
