### PR TITLE
spellcheck: Add "musl" to dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -47,6 +47,7 @@ Logstash/B
 Mellanox/B
 Minikube/B
 MITRE/B
+musl/B
 Netlify/B
 Nginx/B
 OpenCensus/B


### PR DESCRIPTION
The [`musl`](https://musl.libc.org/) library is used for building the
rust agent for 2.0 but we don't have "musl" in the spell check dictionary.

Fixes: #2936.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>