### PR TITLE
ci: vfio: fix VFIO CI

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -284,15 +284,17 @@ if [ "${CI_JOB}" == "VFIO" ]; then
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
-	echo "Installing QEMU experimental to get virtiofsd"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
+	# Skip cloud-hypervisor
+	# Issue: https://github.com/kata-containers/tests/issues/2963
+	# echo "Installing QEMU experimental to get virtiofsd"
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
 
-	echo "Installing experimental kernel"
-	export experimental_kernel=true
-	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
+	# echo "Installing experimental kernel"
+	# export experimental_kernel=true
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
 
-	echo "Installing Cloud Hypervisor"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
+	# echo "Installing Cloud Hypervisor"
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
 
 	echo "Running VFIO tests"
 	"${ci_dir_name}/run.sh"

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -124,7 +124,7 @@ ${environment}
     . /etc/environment
     . /etc/os-release
 
-    [ "$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
+    [ "\$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
 
     echo "${dnf_proxy}" | sudo tee -a /etc/dnf/dnf.conf
 

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -168,8 +168,10 @@ main() {
 	# https://github.com/kata-containers/kata-containers/issues/900
 	# run_test initrd "" cloud-hypervisor false
 	# run_test initrd "" cloud-hypervisor false
-	run_test image "" cloud-hypervisor false
-	run_test image "" cloud-hypervisor true
+	# Skip clh
+	# https://github.com/kata-containers/tests/issues/2963
+	# run_test image "" cloud-hypervisor false
+	# run_test image "" cloud-hypervisor true
 	run_test image "q35" qemu false
 	run_test image "q35" qemu true
 	run_test initrd "q35" qemu false


### PR DESCRIPTION
escape ID variable since it shouldn't be expanded in the host

fixes #2940

Signed-off-by: Julio Montes <julio.montes@intel.com>