### PR TITLE
k8s: enable memroy tests

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -39,3 +39,4 @@ kubernetes:
   - k8s-expose-ip
   - k8s-oom
   - k8s-block-volume
+  - k8s-memory

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -7,21 +7,14 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-TEST_INITRD="${TEST_INITRD:-no}"
-issue="https://github.com/kata-containers/runtime/issues/1127"
-memory_issue="https://github.com/kata-containers/runtime/issues/1249"
 
 setup() {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="memory-test"
 	get_pod_config_dir
 }
 
 @test "Exceeding memory constraints" {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
 	memory_limit_size="50Mi"
 	allocated_size="250M"
 	# Create test .yaml
@@ -38,9 +31,7 @@ setup() {
 }
 
 @test "Running within memory constraints" {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
-	memory_limit_size="200Mi"
+	memory_limit_size="600Mi"
 	allocated_size="150M"
 	# Create test .yaml
         sed \

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -17,6 +17,6 @@ spec:
       limits:
         memory: "${memory_size}"
       requests:
-        memory: "100Mi"
+        memory: "500Mi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "${memory_allocated}", "--vm-hang", "1"]


### PR DESCRIPTION
Increase the memory size to allow testing.

Depends-on: github.com/kata-containers/kata-containers#910
Fixes: #2942