### PR TITLE
k8s: skip oom and k8s-block-volume test for aarch64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -38,3 +38,4 @@ kubernetes:
   - k8s-number-cpus
   - k8s-expose-ip
   - k8s-oom
+  - k8s-block-volume

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -68,8 +68,10 @@ if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
 	info "pod oom: ${oom_issue}"
 else
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
-	K8S_TEST_UNION+=("k8s-oom.bats")
+	# filter_k8s_test.sh requires a space at the end of the last component
+	K8S_TEST_UNION+=("k8s-oom.bats ")
 fi
+
 # we may need to skip a few test cases when running on non-x86_64 arch
 if [ -f "${cidir}/${arch}/configuration_${arch}.yaml" ]; then
 	config_file="${cidir}/${arch}/configuration_${arch}.yaml"


### PR DESCRIPTION
It seems that filter_k8s_test.sh is failing to filter the last
component.

E.g., adding an extra component can make it work.

```
[witch-1@kubernetes]$../../.ci/filter/filter_k8s_test.sh
../../.ci/aarch64/configuration_aarch64.yaml "k8s-oom.bats"
k8s-oom.bats
[witch-1@kubernetes]$../../.ci/filter/filter_k8s_test.sh
../../.ci/aarch64/configuration_aarch64.yaml "k8s-oom.bats foo"
foo
```

Also mark k8s-block-volume as skipped since it is failing randomly.

Fixes: #2944