### PR TITLE
2.0 dev actually enable fast return

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -201,8 +201,7 @@ fi
 } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."
-	#TODO: testing - remove next comment
-	#exit 0
+	exit 0
 fi
 
 # Setup Kata Containers Environment

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -196,8 +196,14 @@ fi
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
 {
-	"${tests_repo_dir}/.ci/ci-fast-return.sh"
-	ret=$?
+	if [ "${pr_number:-}"  != "" ]; then
+		echo "Testing a PR check if can fastpath return/skip"
+		"${tests_repo_dir}/.ci/ci-fast-return.sh"
+		ret=$?
+	else
+		echo "not a PR will run all the CI"
+		ret=1
+	fi
 } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."


### PR DESCRIPTION
Uncomment the crucial line to allow fast return to work on the `2.0-dev` branch as it currently does for `master`.

Also includes cherry pick of 77a968e89b535ae1b8acca19d622d36d97df942a (PR https://github.com/kata-containers/tests/pull/2653) to ensure fast return only works on PR branches. 

Fixes: #2948.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>