### PR TITLE
ci: scripts modifications to support cri-o and kubernetes 1.18

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -20,15 +20,20 @@ minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -
 
 if [ "$minor_crio_version" -ge "18" ]; then
 	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
-	echo "- Set kata as default runtime"
+	echo "- Add kata as alternative runtime"
 	sudo tee -a "$crio_config_dir/99-runtime.conf" > /dev/null <<EOF
 [crio.runtime]
-default_runtime = "kata"
+default_runtime = "runc"
+manage_ns_lifecycle = true
 [crio.runtime.runtimes.kata]
-runtime_path = "/usr/local/bin/kata-runtime"
+runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
 runtime_root = "/run/vc"
-runtime_type = "oci"
+runtime_type = "vm"
 privileged_without_host_devices = true
+[crio.runtime.runtimes.runc]
+runtime_path = "/usr/local/bin/crio-runc"
+runtime_type = "oci"
+runtime_root = "/run/runc"
 EOF
 elif [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -16,7 +16,7 @@ crio_config_dir="/etc/crio/crio.conf.d"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/containerd-shim-kata-v2"
 
-minor_crio_version=$(crio --version | head -1 | cut -d '.' -f2)
+minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1 | cut -d '.' -f2)
 
 if [ "$minor_crio_version" -ge "18" ]; then
 	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -140,10 +140,15 @@ make BUILDTAGS="$(IFS=" "; echo "${build_union[*]}")"
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
 popd
 
-echo "Set manage_network_ns_lifecycle to true"
-network_ns_flag="manage_network_ns_lifecycle"
+echo "Set manage_ns_lifecycle to true"
+network_ns_flag="manage_ns_lifecycle"
+# Set ns_network_flag for CRI-O versions less than 1.17
+crio_version_current=$(crio --version | head -1 | cut -d ' ' -f3)
+if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
+	network_ns_flag="manage_network_ns_lifecycle"
+fi
 sudo sed -i "/\[crio.runtime\]/a$network_ns_flag = true" "$crio_config_file"
-sudo sed -i 's/manage_network_ns_lifecycle = false/#manage_network_ns_lifecycle = false/' "$crio_config_file"
+sudo sed -i "s/$network_ns_flag = false/#$network_ns_flag = false/" "$crio_config_file"
 
 echo "Add docker.io registry to pull images"
 # Matches cri-o 1.10 file format

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -143,7 +143,7 @@ popd
 echo "Set manage_ns_lifecycle to true"
 network_ns_flag="manage_ns_lifecycle"
 # Set ns_network_flag for CRI-O versions less than 1.17
-crio_version_current=$(crio --version | head -1 | cut -d ' ' -f3)
+crio_version_current=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1)
 if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
 	network_ns_flag="manage_network_ns_lifecycle"
 fi

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -140,16 +140,6 @@ make BUILDTAGS="$(IFS=" "; echo "${build_union[*]}")"
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
 popd
 
-echo "Set manage_ns_lifecycle to true"
-network_ns_flag="manage_ns_lifecycle"
-# Set ns_network_flag for CRI-O versions less than 1.17
-crio_version_current=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1)
-if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
-	network_ns_flag="manage_network_ns_lifecycle"
-fi
-sudo sed -i "/\[crio.runtime\]/a$network_ns_flag = true" "$crio_config_file"
-sudo sed -i "s/$network_ns_flag = false/#$network_ns_flag = false/" "$crio_config_file"
-
 echo "Add docker.io registry to pull images"
 # Matches cri-o 1.10 file format
 sudo sed -i 's/^registries = \[/registries = \[ "docker.io"/' "$crio_config_file"

--- a/versions.yaml
+++ b/versions.yaml
@@ -70,4 +70,4 @@ externals:
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"
-    version: "0.17.2"
+    version: "0.18.5"


### PR DESCRIPTION
- We need to update Sonobuoy to 0.18.5 to test k8s to 1.18.9
Related: github.com/kata-containers/kata-containers#961
- Update network_ns_flag to reflect change in CRI-O v1.17. Configure flag
based on installed CRI-O version.
- We need to update how we get the value of the crio version
as the output of `crio --version` has changed since crio 1.18.0.
This change now works with new and old versions of crio.
- ci: do not use drop-in file
Found an issue when the default runtime (runc) is configured in
the main config file.

Fixes: #2957.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>