### PR TITLE
CI: Don't license check kernel config files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -468,6 +468,8 @@ static_check_license_headers()
 			--exclude="*.txt" \
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
+			--exclude="kata_config_version" \
+			--exclude="tools/packaging/kernel/configs" \
 			--exclude="virtcontainers/pkg/firecracker/*" \
 			--exclude="${ignore_clh_generated_code}*" \
 			--exclude="*.xml" \

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -464,6 +464,7 @@ static_check_license_headers()
 			--exclude="*.pub" \
 			--exclude="*.service" \
 			--exclude="*.svg" \
+			--exclude="*.drawio" \
 			--exclude="*.toml" \
 			--exclude="*.txt" \
 			--exclude="vendor/*" \


### PR DESCRIPTION

Stop the license checker from looking for license headers in kernel config files.

Also ignore license header check for drawio files (effectively a cherry pick of 11ea324de4144c5dc67e9e6fe9cb5514231089c9 (which fixed #2637).

Fixes: #2960.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>