### PR TITLE
CI: Don't license check kernel config files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -464,6 +464,8 @@ static_check_license_headers()
 			--exclude="*.txt" \
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
+			--exclude="kata_config_version" \
+			--exclude="tools/packaging/kernel/configs/*" \
 			--exclude="virtcontainers/pkg/firecracker/*" \
 			--exclude="${ignore_clh_generated_code}*" \
 			--exclude="*.xml" \


### PR DESCRIPTION
Stop the license checker from looking for license headers in kernel config files.

Fixes: #2960.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>