### PR TITLE
ci: Remove duplication of kubernetes installation

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -52,8 +52,6 @@ if [ "${BAREMETAL}" == true ]; then
 	iptables-save > "$iptables_cache"
 fi
 
-[ "$ID" == "fedora" ] && bash "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
-
 case "${cri_runtime}" in
 containerd)
 	cri_runtime_socket="/run/containerd/containerd.sock"


### PR DESCRIPTION
Kubernetes is being installed at the setup.sh script, we do not need
to installed it twice in init.sh. This PR removes the duplication
of the kubernetes installation.

Fixes #2886

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>