### PR TITLE
ci/openshift-ci: Run the OpenShift e2e tests

### DIFF
--- a/.ci/openshift-ci/run_e2e_test.sh
+++ b/.ci/openshift-ci/run_e2e_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the OpenShift e2e conformance tests.
+#
+set -e
+
+script_dir="$(dirname $0)"
+tests_dir="$script_dir/../../"
+
+# The test cluster will be configured to run the tests.
+export CI="true"
+
+pushd "$tests_dir"
+make openshift-e2e
+popd

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -8,11 +8,6 @@
 script_dir=$(dirname $0)
 source ${script_dir}/../lib.sh
 
-suite=$1
-if [ -z "$1" ]; then
-	suite='smoke'
-fi
-
 # Make oc and kubectl visible
 export PATH=/tmp/shared:$PATH
 
@@ -21,7 +16,11 @@ oc version || die "Test cluster is unreachable"
 info "Install and configure kata into the test cluster"
 ${script_dir}/cluster/install_kata.sh || die "Failed to install kata-containers"
 
-info "Run test suite: $suite"
-test_status='PASS'
-${script_dir}/run_${suite}_test.sh || test_status='FAIL'
-info "Test suite: $suite: $test_status"
+# Note: let the smoke tests run first and, if failed, do not run the others.
+for suite in "smoke" "e2e"; do
+	info "Run test suite: $suite"
+	test_status='PASS'
+	${script_dir}/run_${suite}_test.sh || test_status='FAIL'
+	info "Test suite: $suite: $test_status"
+	[ "$test_status" == "FAIL" ] && exit 1
+done


### PR DESCRIPTION
Enable the execution of Openshift e2e tests in the OpenShift CI
Kata Containers job.

The smoke tests continue to execute. Run them first, and proceed to
the e2e tests only if passed.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>