### PR TITLE
test: Enable package manager test for virtiofs

### DIFF
--- a/integration/docker/package_manager_test.go
+++ b/integration/docker/package_manager_test.go
@@ -85,10 +85,6 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check dnf update", func() {
 		It("should not fail", func() {
-			if KataConfig.Hypervisor[KataHypervisor].SharedFS == "virtio-fs" {
-				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
-			}
-
 			if distroID() == "rhel" && versionID() >= "8" {
 				Skip("Issue:https://github.com/kata-containers/runtime/issues/2580")
 			}
@@ -112,10 +108,6 @@ var _ = Describe("[Serial Test] package manager update test", func() {
 
 	Context("check yum update", func() {
 		It("should not fail", func() {
-			if KataConfig.Hypervisor[KataHypervisor].SharedFS == "virtio-fs" {
-				Skip("Skip issue: https://github.com/kata-containers/tests/issues/2008")
-			}
-
 			if distroID() == "rhel" && versionID() >= "8" {
 				Skip("Issue:https://github.com/kata-containers/runtime/issues/2580")
 			}


### PR DESCRIPTION
This PR enables the package manager test for virtiofs CI.

Fixes #2008

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>