### PR TITLE
static-check: do not check ignore list license header

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -483,6 +483,7 @@ static_check_license_headers()
 			--exclude="target/*" \
 			--exclude="*.patch" \
 			--exclude="*.diff" \
+			--exclude="tools/packaging/static-build/qemu.blacklist" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
It is just a plain list.

Fixes: #2972