### PR TITLE
backport patches to stable-2.0.0

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -37,3 +37,4 @@ kubernetes:
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-expose-ip
+  - k8s-oom

--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -38,3 +38,4 @@ kubernetes:
   - k8s-number-cpus
   - k8s-expose-ip
   - k8s-oom
+  - k8s-block-volume

--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -39,3 +39,4 @@ kubernetes:
   - k8s-expose-ip
   - k8s-oom
   - k8s-block-volume
+  - k8s-memory

--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -61,7 +61,7 @@ build_and_install_qemu() {
         [ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git --depth 1 ui/keycodemapdb
 
         # Apply required patches
-        QEMU_PATCHES_PATH="${PACKAGING_DIR}/obs-packaging/qemu-aarch64/patches"
+        QEMU_PATCHES_PATH="${PACKAGING_DIR}/qemu/patches/5.1.x"
         for patch in ${QEMU_PATCHES_PATH}/*.patch; do
                 echo "Applying patch: $patch"
                 patch -p1 <"$patch"

--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -66,4 +66,8 @@ if [ "${repo_to_test}" == "${tests_repo}" ]; then
 	git rebase "origin/${ghprbTargetBranch}"
 fi
 
-.ci/jenkins_job_build.sh "${repo_to_test}"
+if [ "${CI_JOB}" == "VFIO" ]; then
+	.ci/vfio_jenkins_job_build.sh "${repo_to_test}"
+else
+	.ci/jenkins_job_build.sh "${repo_to_test}"
+fi

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -20,15 +20,20 @@ minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -
 
 if [ "$minor_crio_version" -ge "18" ]; then
 	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
-	echo "- Set kata as default runtime"
+	echo "- Add kata as alternative runtime"
 	sudo tee -a "$crio_config_dir/99-runtime.conf" > /dev/null <<EOF
 [crio.runtime]
-default_runtime = "kata"
+default_runtime = "runc"
+manage_ns_lifecycle = true
 [crio.runtime.runtimes.kata]
-runtime_path = "/usr/local/bin/kata-runtime"
+runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
 runtime_root = "/run/vc"
-runtime_type = "oci"
+runtime_type = "vm"
 privileged_without_host_devices = true
+[crio.runtime.runtimes.runc]
+runtime_path = "/usr/local/bin/crio-runc"
+runtime_type = "oci"
+runtime_root = "/run/runc"
 EOF
 elif [ "$minor_crio_version" -ge "12" ]; then
 	echo "Configure runtimes map for RuntimeClass feature"

--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -16,7 +16,7 @@ crio_config_dir="/etc/crio/crio.conf.d"
 runc_flag="\/usr\/local\/bin\/crio-runc"
 kata_flag="\/usr\/local\/bin\/containerd-shim-kata-v2"
 
-minor_crio_version=$(crio --version | head -1 | cut -d '.' -f2)
+minor_crio_version=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1 | cut -d '.' -f2)
 
 if [ "$minor_crio_version" -ge "18" ]; then
 	echo "Configure runtimes map for RuntimeClass feature with drop-in configs"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -140,10 +140,15 @@ make BUILDTAGS="$(IFS=" "; echo "${build_union[*]}")"
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
 popd
 
-echo "Set manage_network_ns_lifecycle to true"
-network_ns_flag="manage_network_ns_lifecycle"
+echo "Set manage_ns_lifecycle to true"
+network_ns_flag="manage_ns_lifecycle"
+# Set ns_network_flag for CRI-O versions less than 1.17
+crio_version_current=$(crio --version | head -1 | cut -d ' ' -f3)
+if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
+	network_ns_flag="manage_network_ns_lifecycle"
+fi
 sudo sed -i "/\[crio.runtime\]/a$network_ns_flag = true" "$crio_config_file"
-sudo sed -i 's/manage_network_ns_lifecycle = false/#manage_network_ns_lifecycle = false/' "$crio_config_file"
+sudo sed -i "s/$network_ns_flag = false/#$network_ns_flag = false/" "$crio_config_file"
 
 echo "Add docker.io registry to pull images"
 # Matches cri-o 1.10 file format

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -143,7 +143,7 @@ popd
 echo "Set manage_ns_lifecycle to true"
 network_ns_flag="manage_ns_lifecycle"
 # Set ns_network_flag for CRI-O versions less than 1.17
-crio_version_current=$(crio --version | head -1 | cut -d ' ' -f3)
+crio_version_current=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1)
 if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
 	network_ns_flag="manage_network_ns_lifecycle"
 fi

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -140,16 +140,6 @@ make BUILDTAGS="$(IFS=" "; echo "${build_union[*]}")"
 sudo -E install -D -m0755 runc "/usr/local/bin/crio-runc"
 popd
 
-echo "Set manage_ns_lifecycle to true"
-network_ns_flag="manage_ns_lifecycle"
-# Set ns_network_flag for CRI-O versions less than 1.17
-crio_version_current=$(crio --version | egrep -o "[0-9]+\.[0-9]+\.[0-9]+" | head -1)
-if [ "$(compare_versions "$crio_version_current" "1.17.0")" -eq "1" ]; then
-	network_ns_flag="manage_network_ns_lifecycle"
-fi
-sudo sed -i "/\[crio.runtime\]/a$network_ns_flag = true" "$crio_config_file"
-sudo sed -i "s/$network_ns_flag = false/#$network_ns_flag = false/" "$crio_config_file"
-
 echo "Add docker.io registry to pull images"
 # Matches cri-o 1.10 file format
 sudo sed -i 's/^registries = \[/registries = \[ "docker.io"/' "$crio_config_file"

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -109,13 +109,6 @@ curl -Ls "$crictl_url" | sudo tar xfz - -C /usr/local/bin
 # Change CRI-O configuration options
 crio_config_file="/etc/crio/crio.conf"
 
-# This commit contains changes regarding CRI-O’s default configuration files,
-# so we have to use a new default config path from here.
-# https://github.com/cri-o/cri-o/commit/0f1226b99685f95e83c94dc6668b6452df5056db
-if git merge-base --is-ancestor 0f1226b99685f95e83c94dc6668b6452df5056db HEAD; then
-    crio_config_file="/etc/crio/crio.conf.d/00-default.conf"
-fi
-
 # Change socket format and pause image used for infra containers
 # Needed for cri-o 1.10
 if crio --version | grep '1.10'; then

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -201,8 +201,7 @@ fi
 } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."
-	#TODO: testing - remove next comment
-	#exit 0
+	exit 0
 fi
 
 # Setup Kata Containers Environment

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -284,15 +284,17 @@ if [ "${CI_JOB}" == "VFIO" ]; then
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
-	echo "Installing QEMU experimental to get virtiofsd"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
+	# Skip cloud-hypervisor
+	# Issue: https://github.com/kata-containers/tests/issues/2963
+	# echo "Installing QEMU experimental to get virtiofsd"
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
 
-	echo "Installing experimental kernel"
-	export experimental_kernel=true
-	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
+	# echo "Installing experimental kernel"
+	# export experimental_kernel=true
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
 
-	echo "Installing Cloud Hypervisor"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
+	# echo "Installing Cloud Hypervisor"
+	# sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
 
 	echo "Running VFIO tests"
 	"${ci_dir_name}/run.sh"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -196,8 +196,14 @@ fi
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
 {
-	"${tests_repo_dir}/.ci/ci-fast-return.sh"
-	ret=$?
+	if [ "${pr_number:-}"  != "" ]; then
+		echo "Testing a PR check if can fastpath return/skip"
+		"${tests_repo_dir}/.ci/ci-fast-return.sh"
+		ret=$?
+	else
+		echo "not a PR will run all the CI"
+		ret=1
+	fi
 } || true
 if [ "$ret" -eq 0 ]; then
 	echo "Short circuit fast path skipping the rest of the CI."

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -284,17 +284,15 @@ if [ "${CI_JOB}" == "VFIO" ]; then
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
-	# Skip cloud-hypervisor
-	# Issue: https://github.com/kata-containers/tests/issues/2963
-	# echo "Installing QEMU experimental to get virtiofsd"
-	# sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
+	echo "Installing QEMU experimental to get virtiofsd"
+	sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
 
-	# echo "Installing experimental kernel"
-	# export experimental_kernel=true
-	# sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
+	echo "Installing experimental kernel"
+	export experimental_kernel=true
+	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
 
-	# echo "Installing Cloud Hypervisor"
-	# sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
+	echo "Installing Cloud Hypervisor"
+	sudo -E PATH=$PATH "${ci_dir_name}/install_cloud_hypervisor.sh"
 
 	echo "Running VFIO tests"
 	"${ci_dir_name}/run.sh"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -45,6 +45,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"VFIO")
+		echo "INFO: Running VFIO functional tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -470,7 +470,7 @@ static_check_license_headers()
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
 			--exclude="kata_config_version" \
-			--exclude="tools/packaging/kernel/configs" \
+			--exclude="tools/packaging/kernel/configs/*" \
 			--exclude="virtcontainers/pkg/firecracker/*" \
 			--exclude="${ignore_clh_generated_code}*" \
 			--exclude="*.xml" \

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -468,6 +468,8 @@ static_check_license_headers()
 			--exclude="*.txt" \
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
+			--exclude="kata_config_version" \
+			--exclude="tools/packaging/kernel/configs" \
 			--exclude="virtcontainers/pkg/firecracker/*" \
 			--exclude="${ignore_clh_generated_code}*" \
 			--exclude="*.xml" \

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -464,6 +464,7 @@ static_check_license_headers()
 			--exclude="*.pub" \
 			--exclude="*.service" \
 			--exclude="*.svg" \
+			--exclude="*.drawio" \
 			--exclude="*.toml" \
 			--exclude="*.txt" \
 			--exclude="vendor/*" \

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Run the .ci/jenkins_job_build.sh script in a VM
+# that supports VFIO, then run VFIO functional tests
+
+set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+
+source /etc/os-release || source /usr/lib/os-release
+source "${cidir}/lib.sh"
+
+http_proxy=${http_proxy:-}
+https_proxy=${https_proxy:-}
+vm_ip="127.0.15.1"
+vm_port="10022"
+# Don't save data in /tmp, we need it after rebooting the system
+data_dir="${HOME}/k8s-vfio-test"
+ssh_key_file="${data_dir}/key"
+arch=$(uname -m)
+artifacts_dir="${WORKSPACE}/artifacts"
+
+kill_vms() {
+	sudo killall -9 qemu-system-${arch}
+}
+
+cleanup() {
+	mkdir -p ${artifacts_dir}
+	sudo chown -R ${USER} ${artifacts_dir}
+	scp_vm ${artifacts_dir}/* ${artifacts_dir} || true
+	kill_vms
+}
+
+create_ssh_key() {
+	rm -f "${ssh_key_file}"
+	ssh-keygen -f "${ssh_key_file}" -t rsa -N ""
+}
+
+create_meta_data() {
+	file="$1"
+	cat <<EOF > "${file}"
+{
+  "uuid": "d1b4aafa-5d75-4f9c-87eb-2ceabe110c39",
+  "hostname": "test"
+}
+EOF
+}
+
+create_user_data() {
+	file="$1"
+	ssh_pub_key_file="$2"
+
+	ssh_pub_key="$(cat "${ssh_pub_key_file}")"
+	dnf_proxy=""
+	service_proxy=""
+	docker_user_proxy=""
+	environment=$(env | egrep "ghprb|WORKSPACE|KATA|GIT|JENKINS|_PROXY|_proxy" | \
+	                    sed -e "s/'/'\"'\"'/g" \
+	                        -e "s/\(^[[:alnum:]_]\+\)=/\1='/" \
+	                        -e "s/$/'/" \
+	                        -e 's/^/    export /')
+
+	if [ -n "${http_proxy}" ] && [ -n "${https_proxy}" ]; then
+		dnf_proxy="proxy=${http_proxy}"
+		service_proxy='[Service]
+    Environment="HTTP_PROXY='${http_proxy}'" "HTTPS_PROXY='${https_proxy}'" "NO_PROXY='${no_proxy}'"'
+		docker_user_proxy='{"proxies": { "default": {
+    "httpProxy": "'${http_proxy}'",
+    "httpsProxy": "'${https_proxy}'",
+    "noProxy": "'${no_proxy}'"
+    } } }'
+	fi
+
+	cat <<EOF > "${file}"
+#cloud-config
+package_upgrade: false
+runcmd:
+- chown -R ${USER}:${USER} /home/${USER}
+- touch /.done
+users:
+- gecos: User
+  gid: "1000"
+  lock-passwd: true
+  name: ${USER}
+  shell: /bin/bash
+  ssh-authorized-keys:
+  - ${ssh_pub_key}
+  sudo: ALL=(ALL) NOPASSWD:ALL
+  uid: "1000"
+write_files:
+- content: |
+${environment}
+  path: /etc/environment
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/docker.service.d/http-proxy.conf
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/kubelet.service.d/http-proxy.conf
+- content: |
+    ${service_proxy}
+  path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+- content: |
+    ${docker_user_proxy}
+  path: ${HOME}/.docker/config.json
+- content: |
+    ${docker_user_proxy}
+  path: /root/.docker/config.json
+- content: |
+    set -x
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+    set -o errtrace
+    . /etc/environment
+    . /etc/os-release
+
+    [ "$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
+
+    echo "${dnf_proxy}" | sudo tee -a /etc/dnf/dnf.conf
+
+    for i in \$(seq 1 50); do
+        [ -f /.done ] && break
+        echo "waiting for cloud-init to finish"
+        sleep 5;
+    done
+
+    export CI_JOB="VFIO"
+    export GOPATH=\${WORKSPACE}/go
+    export PATH=\${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:\${PATH}
+    export GOROOT="/usr/local/go"
+
+    # Make sure the packages were installed
+    # Sometimes cloud-init is unable to install them
+    sudo dnf makecache
+    sudo dnf install -y git make pciutils
+
+    tests_repo_dir="\${GOPATH}/src/github.com/kata-containers/tests"
+    mkdir -p "\${tests_repo_dir}"
+
+    trap "cd \${tests_repo_dir} && sudo -E PATH=\$PATH .ci/teardown.sh ${artifacts_dir} || true; sudo chown -R \${USER} ${artifacts_dir}" EXIT
+
+    curl -sLO https://raw.githubusercontent.com/kata-containers/tests/master/.ci/ci_entry_point.sh
+    bash -f ci_entry_point.sh "\${GIT_URL}"
+
+  path: /home/${USER}/run.sh
+  permissions: '0755'
+EOF
+}
+
+create_config_iso() {
+	iso_file="$1"
+	ssh_pub_key_file="${ssh_key_file}.pub"
+	iso_data_dir="${data_dir}/d"
+	meta_data_file="${iso_data_dir}/openstack/latest/meta_data.json"
+	user_data_file="${iso_data_dir}/openstack/latest/user_data"
+
+	mkdir -p $(dirname "${user_data_file}")
+
+	create_meta_data "${meta_data_file}"
+	create_user_data "${user_data_file}" "${ssh_pub_key_file}"
+
+	[ -f "${iso_file}" ] && rm -f "${iso_file}"
+
+	xorriso -as mkisofs -R -V config-2 -o "${iso_file}" "${iso_data_dir}"
+}
+
+pull_fedora_cloud_image() {
+	fedora_img="$1"
+	fedora_img_cache="${fedora_img}.cache"
+	fedora_version=32
+
+	if [ ! -f "${fedora_img_cache}" ]; then
+		curl -sL "https://download.fedoraproject.org/pub/fedora/linux/releases/${fedora_version}/Cloud/${arch}/images/Fedora-Cloud-Base-${fedora_version}-1.6.${arch}.raw.xz" -o "${fedora_img_cache}.xz"
+		xz -f -d "${fedora_img_cache}.xz"
+		sync
+	fi
+
+	cp -a "${fedora_img_cache}" "${fedora_img}"
+	sync
+
+	# setup cloud image
+	sudo losetup -D
+	loop=$(sudo losetup --show -Pf "${fedora_img}")
+	sudo mount "${loop}p1" /mnt
+
+	# disable selinux
+	sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /mnt/etc/selinux/config
+
+	# add intel_iommu=on to the guest kernel command line
+	kernelopts="intel_iommu=on systemd.unified_cgroup_hierarchy=0 selinux=0 "
+	sudo sed -i 's|kernelopts="|kernelopts="'"${kernelopts}"'|g' /mnt/boot/grub2/grub.cfg
+	sudo sed -i 's|kernelopts=|kernelopts='"${kernelopts}"'|g' /mnt/boot/grub2/grubenv
+
+	# cleanup
+	sudo umount -R /mnt/
+	sudo losetup -d "${loop}"
+
+	qemu-img resize -f raw "${fedora_img}" +20G
+}
+
+run_vm() {
+	image="$1"
+	config_iso="$2"
+	disable_modern="off"
+	hostname="$(hostname)"
+	memory="16384M"
+	cpus=4
+	machine_type="q35"
+
+	/usr/bin/qemu-system-${arch} -m "${memory}" -smp cpus="${cpus}" \
+	   -cpu host,host-phys-bits \
+	   -machine ${machine_type},accel=kvm,kernel_irqchip=split \
+	   -device intel-iommu,intremap=on,caching-mode=on,device-iotlb=on \
+	   -drive file=${image},if=virtio,aio=threads,format=raw \
+	   -drive file=${config_iso_file},if=virtio,media=cdrom \
+	   -daemonize -enable-kvm -device virtio-rng-pci -display none -vga none \
+	   -netdev user,hostfwd=tcp:${vm_ip}:${vm_port}-:22,hostname="${hostname}",id=net0 \
+	   -device virtio-net-pci,netdev=net0,disable-legacy=on,disable-modern="${disable_modern}",iommu_platform=on,ats=on \
+	   -netdev user,id=net1 \
+	   -device virtio-net-pci,netdev=net1,disable-legacy=on,disable-modern="${disable_modern}",iommu_platform=on,ats=on
+}
+
+install_dependencies() {
+	case "${ID}" in
+		ubuntu|debian)
+			# cloud image dependencies
+			deps=(xorriso curl qemu-utils openssh-client)
+
+			# QEMU dependencies
+			deps+=(libcap-dev libattr1-dev libcap-ng-dev librbd-dev gcc pkg-config libglib2.0-dev libpixman-1-dev psmisc)
+
+			sudo apt-get update
+			sudo apt-get install -y ${deps[@]}
+			;;
+		fedora|centos|rhel)
+			# cloud image dependencies
+			deps=(xorriso curl qemu-img openssh)
+
+			# QEMU dependencies
+			deps+=(libcap-devel libattr-devel libcap-ng-devel librbd-devel gcc glib2-devel pixman-devel psmisc)
+
+			sudo dnf install -y ${deps[@]}
+			;;
+
+		"*")
+			die "Unsupported distro: ${ID}"
+			;;
+	esac
+
+	# Build and Install QEMU
+	qemu_version=$(get_version "assets.hypervisor.qemu.version")
+	qemu_dir="${data_dir}/qemu-${qemu_version}"
+	qemu_tar_file="${data_dir}/qemu-${qemu_version}.tar.xz"
+
+	rm -rf "${qemu_dir}"
+	mkdir -p "${qemu_dir}"
+
+	pushd "${qemu_dir}"
+	[ ! -f "${qemu_tar_file}" ] && curl -sL https://download.qemu.org/qemu-${qemu_version}.tar.xz -o "${qemu_tar_file}"
+	tar --strip-components=1 -xf "${qemu_tar_file}"
+	curl -sLO https://raw.githubusercontent.com/kata-containers/packaging/master/scripts/configure-hypervisor.sh
+	bash configure-hypervisor.sh qemu | sed -e 's|--disable-slirp||' -e 's|--enable-libpmem||' | xargs ./configure
+	make -j$(($(nproc)-1))
+	sudo make install
+	popd
+}
+
+ssh_vm() {
+	cmd=$@
+	ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${ssh_key_file}" -p "${vm_port}" "${USER}@${vm_ip}" "${cmd}"
+}
+
+scp_vm() {
+	guest_src=$1
+	host_dest=$2
+	scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${ssh_key_file}" -P "${vm_port}" ${USER}@${vm_ip}:${guest_src} ${host_dest}
+}
+
+wait_for_vm() {
+	for i in $(seq 1 30); do
+		if ssh_vm true; then
+			return 0
+		fi
+		info "waiting for VM to start"
+		sleep 5
+	done
+	return 1
+}
+
+main() {
+	trap cleanup EXIT
+
+	config_iso_file="${data_dir}/config.iso"
+	fedora_img="${data_dir}/image.img"
+
+	mkdir -p "${data_dir}"
+
+	install_dependencies
+
+	create_ssh_key
+
+	create_config_iso "${config_iso_file}"
+
+	for i in $(seq 1 5); do
+		pull_fedora_cloud_image "${fedora_img}"
+		run_vm "${fedora_img}" "${config_iso_file}"
+		if wait_for_vm; then
+			break
+		fi
+		info "Couldn't connect to the VM. Stopping VM and starting a new one."
+		kill_vms
+	done
+
+	ssh_vm "/home/${USER}/run.sh"
+}
+
+main $@

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -124,7 +124,7 @@ ${environment}
     . /etc/environment
     . /etc/os-release
 
-    [ "$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
+    [ "\$ID" = "fedora" ] || (echo >&2 "$0 only supports Fedora"; exit 1)
 
     echo "${dnf_proxy}" | sudo tee -a /etc/dnf/dnf.conf
 

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,9 @@ $(INSTALL_TARGETS): install-%: .ci/install_%.sh
 list-install-targets:
 	@echo $(INSTALL_TARGETS) | tr " " "\n"
 
+vfio:
+	bash -f integration/kubernetes/vfio.sh
+
 help:
 	@echo Subsets of the tests can be run using the following specific make targets:
 	@echo " $(UNION)" | sed 's/ /\n\t/g'
@@ -269,4 +272,5 @@ help:
 	test \
 	tracing \
 	vcpus \
+	vfio \
 	vm-factory

--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -47,6 +47,7 @@ Logstash/B
 Mellanox/B
 Minikube/B
 MITRE/B
+musl/B
 Netlify/B
 Nginx/B
 OpenCensus/B

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -52,8 +52,6 @@ if [ "${BAREMETAL}" == true ]; then
 	iptables-save > "$iptables_cache"
 fi
 
-[ "$ID" == "fedora" ] && bash "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
-
 case "${cri_runtime}" in
 containerd)
 	cri_runtime_socket="/run/containerd/containerd.sock"

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -7,21 +7,14 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-TEST_INITRD="${TEST_INITRD:-no}"
-issue="https://github.com/kata-containers/runtime/issues/1127"
-memory_issue="https://github.com/kata-containers/runtime/issues/1249"
 
 setup() {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="memory-test"
 	get_pod_config_dir
 }
 
 @test "Exceeding memory constraints" {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
 	memory_limit_size="50Mi"
 	allocated_size="250M"
 	# Create test .yaml
@@ -38,9 +31,7 @@ setup() {
 }
 
 @test "Running within memory constraints" {
-	skip "test not working see: ${issue}, ${memory_issue}"
-
-	memory_limit_size="200Mi"
+	memory_limit_size="600Mi"
 	allocated_size="150M"
 	# Create test .yaml
         sed \

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -68,8 +68,10 @@ if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
 	info "pod oom: ${oom_issue}"
 else
 	K8S_TEST_UNION+=("k8s-sysctls.bats")
-	K8S_TEST_UNION+=("k8s-oom.bats")
+	# filter_k8s_test.sh requires a space at the end of the last component
+	K8S_TEST_UNION+=("k8s-oom.bats ")
 fi
+
 # we may need to skip a few test cases when running on non-x86_64 arch
 if [ -f "${cidir}/${arch}/configuration_${arch}.yaml" ]; then
 	config_file="${cidir}/${arch}/configuration_${arch}.yaml"

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -17,6 +17,6 @@ spec:
       limits:
         memory: "${memory_size}"
       requests:
-        memory: "100Mi"
+        memory: "500Mi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "${memory_allocated}", "--vm-hang", "1"]

--- a/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vfio
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: c1
+    image: busybox
+    command:
+      - sh
+    tty: true
+    stdin: true
+    resources:
+      limits:
+        intel.com/virtio_net: "1"
+      requests:
+        intel.com/virtio_net: "1"

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -91,6 +91,14 @@ setup_configuration_file() {
 	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
 		-e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
 		"${SYSCONFIG_FILE}"
+
+	# Cloud-hypervisor workaround
+	# Issue: https://github.com/kata-containers/tests/issues/2963
+	if [ "${hypervisor}" = "cloud-hypervisor" ]; then
+		sudo sed -i -e 's|^default_memory.*|default_memory = 1024|g' \
+		            -e 's|^virtio_fs_cache =.*|virtio_fs_cache = "none"|g' \
+		            "${SYSCONFIG_FILE}"
+	fi
 }
 
 run_test() {

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/../../.ci/lib.sh"
+
+SYSCONFIG_FILE="/etc/kata-containers/configuration.toml"
+
+trap cleanup EXIT
+cleanup() {
+	sudo rm -rf "${SYSCONFIG_FILE}"
+	${SCRIPT_DIR}/cleanup_env.sh
+}
+
+setup_configuration_file() {
+	local image_type="$1"
+	local machine_type="$2"
+	local hypervisor="$3"
+	local sandbox_cgroup_only="$4"
+
+	local default_config_file="/usr/share/defaults/kata-containers/configuration.toml"
+	local qemu_config_file="/usr/share/defaults/kata-containers/configuration-qemu.toml"
+	local clh_config_file="/usr/share/defaults/kata-containers/configuration-clh.toml"
+	local image_file="/usr/share/kata-containers/kata-containers.img"
+	local initrd_file="/usr/share/kata-containers/kata-containers-initrd.img"
+
+	sudo mkdir -p $(dirname "${SYSCONFIG_FILE}")
+
+	if [ "${hypervisor}" = "qemu" ]; then
+		config_file="${qemu_config_file}"
+	elif [ "${hypervisor}" = "cloud-hypervisor" ]; then
+		config_file="${clh_config_file}"
+	fi
+
+	if [ -f "${config_file}" ]; then
+		cp -a "${config_file}" "${SYSCONFIG_FILE}"
+	elif [ -f "${default_config_file}" ]; then
+		# Check if path contains the hypervisor name
+		if ! grep "^path" "${default_config_file}" | grep -q "${hypervisor}"; then
+			die "Configuration file for ${hypervisor} hypervisor not found"
+		fi
+		sudo cp -a "${default_config_file}" "${SYSCONFIG_FILE}"
+	else
+		die "Error: configuration file for ${hypervisor} doesn't exist"
+	fi
+
+	# machine type applies to configuration.toml and configuration-qemu.toml
+	if [ -n "${machine_type}" ]; then
+		if [ "${hypervisor}" = "qemu" ]; then
+			sudo sed -i 's|^machine_type.*|machine_type = "'${machine_type}'"|g' "${SYSCONFIG_FILE}"
+		else
+			info "Variable machine_type only applies to qemu. It will be ignored"
+		fi
+	fi
+
+	if [ -n "${sandbox_cgroup_only}" ]; then
+		sudo sed -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${sandbox_cgroup_only}'|g' "${SYSCONFIG_FILE}"
+	fi
+
+	# Change to initrd or image depending on user input.
+	# Non-default configs must be changed to specify either initrd or image, image is default.
+	if [ "${image_type}" = "initrd" ]; then
+		if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
+			if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
+				sudo sed -i '/^image.*/d' "${SYSCONFIG_FILE}"
+			else
+				sudo sed -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${SYSCONFIG_FILE}"
+			fi
+		fi
+	else
+		if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
+			if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
+				sudo sed -i '/^initrd.*/d' "${SYSCONFIG_FILE}"
+			else
+				sudo sed -i 's|^initrd.*|image = "'${image_file}'"|g' "${SYSCONFIG_FILE}"
+			fi
+		fi
+	fi
+
+	# enable debug
+	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+		-e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
+		"${SYSCONFIG_FILE}"
+}
+
+run_test() {
+	local image_type="${1:-}"
+	[ -n "$image_type" ] || die "need image type"
+
+	local machine_type="${2:-}"
+
+	local hypervisor="${3:-}"
+	[ -n "$hypervisor" ] || die "need hypervisor"
+
+	local sandbox_cgroup_only="${4:-}"
+	[ -n "$sandbox_cgroup_only" ] || die "need sandbox cgroup only"
+
+	setup_configuration_file "$image_type" "$machine_type" "$hypervisor" "$sandbox_cgroup_only"
+
+	sudo -E kubectl apply -f "${SCRIPT_DIR}/runtimeclass_workloads/vfio.yaml"
+
+	pod_name=vfio
+	sudo -E kubectl wait --for=condition=Ready pod "${pod_name}"
+
+	# Expecting 2 network interaces -> 2 mac addresses
+	mac_addrs=$(sudo -E kubectl exec -ti "${pod_name}" ip a | grep "link/ether" | wc -l)
+	if [ ${mac_addrs} -ne 2 ]; then
+		die "Error: expecting 2 network interfaces, Got: $(kubectl exec -ti "${pod_name}" ip a)"
+	else
+		info "Success: found 2 network interfaces"
+	fi
+}
+
+main() {
+	# Init k8s cluster
+	${SCRIPT_DIR}/init.sh
+
+	sudo modprobe vfio
+	sudo modprobe vfio-pci
+
+	# unbind device from driver
+	# PCI address
+	local addr="00:03.0"
+	echo 0000:${addr} | sudo tee /sys/bus/pci/devices/0000:${addr}/driver/unbind
+
+	# Create a new VFIO device
+	# Ethernet controller: Red Hat, Inc. Virtio network device
+	# vendor ID: 1af4
+	# device ID: 1041
+	local vendor_id="1af4"
+	local device_id="1041"
+	echo "${vendor_id} ${device_id}" | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
+
+	# Install network (device) plugin
+	sriov_plugin_url=$(get_version "plugins.sriov-network-device.url")
+	sriov_plugin_version=$(get_version "plugins.sriov-network-device.version")
+	git clone --depth=1 "${sriov_plugin_url}"
+	pushd sriov-network-device-plugin
+	git checkout "${sriov_plugin_version}"
+	sed -i 's|resourceList.*|resourceList": [{"resourceName":"virtio_net","selectors":{"vendors":["'"${vendor_id}"'"],"devices":["'"${device_id}"'"],"drivers":["vfio-pci"],"pfNames":["eth1"]}},{|g' deployments/configMap.yaml
+	sudo -E kubectl create -f deployments/configMap.yaml
+	sudo -E kubectl create -f deployments/k8s-v1.16/sriovdp-daemonset.yaml
+	sleep 5
+	popd
+	rm -rf sriov-network-device-plugin
+
+	sriov_pod="$(sudo -E kubectl --namespace=kube-system get pods --output=name | grep sriov-device-plugin | cut -d/ -f2)"
+	sudo -E kubectl --namespace=kube-system wait --for=condition=Ready pod "${sriov_pod}"
+
+	# wait for the virtio_net resource
+	for _ in $(seq 1 30); do
+		v="$(sudo -E kubectl get node $(hostname) -o json | jq '.status.allocatable["intel.com/virtio_net"]')"
+		[ "${v}" == \"1\" ] && break
+		sleep 5
+	done
+
+	# Skip clh + initrd:
+	# https://github.com/kata-containers/kata-containers/issues/900
+	# run_test initrd "" cloud-hypervisor false
+	# run_test initrd "" cloud-hypervisor false
+	run_test image "" cloud-hypervisor false
+	run_test image "" cloud-hypervisor true
+	run_test image "q35" qemu false
+	run_test image "q35" qemu true
+	run_test initrd "q35" qemu false
+	run_test initrd "q35" qemu true
+	run_test image "pc" qemu false
+	run_test image "pc" qemu true
+	run_test initrd "pc" qemu false
+	run_test initrd "pc" qemu true
+}
+
+main $@

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -168,8 +168,10 @@ main() {
 	# https://github.com/kata-containers/kata-containers/issues/900
 	# run_test initrd "" cloud-hypervisor false
 	# run_test initrd "" cloud-hypervisor false
-	run_test image "" cloud-hypervisor false
-	run_test image "" cloud-hypervisor true
+	# Skip clh
+	# https://github.com/kata-containers/tests/issues/2963
+	# run_test image "" cloud-hypervisor false
+	# run_test image "" cloud-hypervisor true
 	run_test image "q35" qemu false
 	run_test image "q35" qemu true
 	run_test initrd "q35" qemu false

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -176,10 +176,8 @@ main() {
 	# https://github.com/kata-containers/kata-containers/issues/900
 	# run_test initrd "" cloud-hypervisor false
 	# run_test initrd "" cloud-hypervisor false
-	# Skip clh
-	# https://github.com/kata-containers/tests/issues/2963
-	# run_test image "" cloud-hypervisor false
-	# run_test image "" cloud-hypervisor true
+	run_test image "" cloud-hypervisor false
+	run_test image "" cloud-hypervisor true
 	run_test image "q35" qemu false
 	run_test image "q35" qemu true
 	run_test initrd "q35" qemu false

--- a/versions.yaml
+++ b/versions.yaml
@@ -70,4 +70,4 @@ externals:
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"
-    version: "0.17.2"
+    version: "0.18.5"

--- a/versions.yaml
+++ b/versions.yaml
@@ -40,7 +40,7 @@ externals:
 
   flannel:
     url: "https://github.com/coreos/flannel"
-    version: "862c448ef28fd890e2ac4e5fddc49e7fe9693b31"
+    version: "v0.13.0-rc2"
 
   xurls:
     description: |


### PR DESCRIPTION
34d2451  ci: Fix git error in crio installation
b6f661c ci: vfio: unskip cloud-hypervisor tests
ac081af ci: vfio: workaround virtiofs bug
d36f238 ci: Fix cri-o drop-in configuration file
f9e5884 ci: Remove duplication of kubernetes installation
6d5349b ci: ignore files within kernel/configs directory
b98f027 vfio: skip cloud-hypervisor
7326a45 ci: vfio: fix VFIO CI
066c6cd CI: ignore license header check for drawio files
e697148 CI: Don't license check kernel config files
5438de0 ci: update the way we get crio version
62a4242 ci: Update network namespace flag for CRIO install
3af1284 versions: update Sonobuoy version to match k8s version
805fcf6 ci: Try to skip CI only on PR jobs
4e97850 CI: Really enable fast return for 2.0-dev
8e57555 k8s: enable memroy tests
f9b1601 k8s: skip k8s-block-volume on aarch64
5b53060 k8s: skip oom test for aarch64
6c5a296 ci: add VFIO CI for kata 2.0
00437e0 spellcheck: Add "musl" to dictionary
22f7c88 versions: Update flannel version to v0.13.0-rc2
1af123c ci: change qemu patch path for qemu build on arm64
e095ccd ci: skip k8s-oom test on arm64.