### PR TITLE
docker: cpuset case test on arm64 should be skipped

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -19,6 +19,7 @@ test:
 docker:
   Describe:
     - CPUs and CPU set
+    - CPU constraints
     - Update number of CPUs
     - Hot plug CPUs
     - Update CPU constraints


### PR DESCRIPTION
tests skip info included in arch specific configuration
file doesn't pass to Makefile, which lead to ci failure.
this patch pass these info to Makefile.

Fixes: #2977
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@devimc @bergwolf @dgibson 