### PR TITLE
k8s: increase podoverhead memory limit

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -15,6 +15,8 @@ readonly runc_path=$(command -v runc)
 sudo mkdir -p /etc/containerd/
 
 cat << EOT | sudo tee /etc/containerd/config.toml
+[debug]
+  level = "debug"
 [plugins]
   [plugins.cri]
     [plugins.cri.containerd]

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -102,6 +102,7 @@ case "${KATA_HYPERVISOR}" in
 			# See https://github.com/kata-containers/kata-containers/issues/990
 			sudo sed -i 's|^shared_fs = "virtio-fs"|shared_fs = "virtio-9p"|g' "${runtime_config_path}"
 		fi
+		sudo sed -i 's|^#enable_debug|enable_debug|g' "${runtime_config_path}"
 		;;
 	*)
 		die "failed to enable config for '${KATA_HYPERVISOR}', not supported"

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -39,6 +39,8 @@ if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 fi
 
+dmesg
+
 # Check no kata processes are left behind after reseting kubernetes
 check_processes
 

--- a/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
@@ -5,5 +5,5 @@ metadata:
 handler: kata
 overhead:
   podFixed:
-    memory: "160Mi"
+    memory: "300Mi"
     cpu: "250m"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -189,6 +189,7 @@ check_pods_in_dir() {
 		# Verify that pods were not left
 		pods_number=$(ls ${DIR} | wc -l)
 		if [ ${pods_number} -ne 0 ]; then
+			sudo journalctl -t containerd
             ls ${DIR}
 			die "${pods_number} pods left and found at ${DIR}"
 		fi


### PR DESCRIPTION
Now that we enable sandbox cgroups only option, we need more pod overhead
to put in all kata components.
