### PR TITLE
Cleanup Repositories for SLES

### DIFF
--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -12,35 +12,17 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
 arch=$("${cidir}"/kata-arch.sh -d)
 
-echo "Add repo for perl-IPC-Run"
-perl_repo="https://download.opensuse.org/repositories/devel:languages:perl/SLE_${VERSION//-/_}/devel:languages:perl.repo"
-sudo -E zypper addrepo --no-gpgcheck ${perl_repo}
-sudo -E zypper refresh
-
-echo "Add repo for myspell"
-leap_repo="http://download.opensuse.org/update/leap/15.0/oss/"
-leap_repo_name="leap-oss"
-sudo -E zypper addrepo --no-gpgcheck ${leap_repo} ${leap_repo_name}
-sudo -E zypper refresh  ${leap_repo_name}
-
-echo "Install perl-IPC-Run"
-sudo -E zypper -n install perl-IPC-Run
-
-echo "Add repo for filesystems"
-filesystems_repo="https://download.opensuse.org/repositories/filesystems/SLE_${VERSION//-/_}/filesystems.repo"
-sudo -E zypper refresh
-sudo -E zypper -n install xfsprogs
-
-echo "Add repo for hunspell and pandoc packages"
+echo "Add PackageHub repositories for additional dependencies which are not part of the main distro"
 sudo -E SUSEConnect -p PackageHub/${VERSION_ID}/${arch}
+sudo -E zypper refresh
 
 echo "Install chronic"
 sudo -E zypper -n install moreutils
 
 declare -A minimal_packages=( \
-	[spell-check]="hunspell myspell-en_GB myspell-en_US pandoc" \
+	[spell-check]="hunspell myspell-en myspell-en_US pandoc" \
 	[xml_validator]="libxml2-tools" \
-	[yaml_validator_dependencies]="python-setuptools" \
+	[yaml_validator]="python3-yamllint" \
 )
 
 declare -A packages=( \
@@ -48,7 +30,8 @@ declare -A packages=( \
 	[build_tools]="gcc python zlib-devel" \
 	[cri-containerd_dependencies]="libapparmor-devel libseccomp-devel make pkg-config" \
 	[crio_dependencies]="glibc-devel glibc-devel-static glib2-devel libapparmor-devel libgpg-error-devel libglib-2_0-0 libgpgme-devel libseccomp-devel libassuan-devel util-linux" \
-	[general_dependencies]="curl git patch" \
+	[crudini]="crudini" \
+	[general_dependencies]="curl git patch xfsprogs perl-IPC-Run" \
 	[gnu_parallel]="gnu_parallel" \
 	[haveged]="haveged" \
 	[kata_containers_dependencies]="autoconf automake bc coreutils libpixman-1-0-devel libtool" \
@@ -57,6 +40,7 @@ declare -A packages=( \
 	[libudev-dev]="libudev-devel" \
 	[metrics_dependencies]="jq" \
 	[qemu_dependencies]="libattr1 libcap-devel libcap-ng-devel libpmem-devel librbd-devel libselinux-devel libffi-devel libmount-devel libblkid-devel" \
+	[redis]="redis" \
 )
 
 main()
@@ -80,25 +64,6 @@ main()
 	fi
 
 	chronic sudo -E zypper -n install $pkgs_to_install
-
-	echo "Install YAML validator"
-	chronic sudo -E easy_install pip
-	chronic sudo -E pip install yamllint
-
-	echo "Add redis repo and install redis"
-	redis_repo="https://download.opensuse.org/repositories/server:database/SLE_${VERSION//-/_}/server:database.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${redis_repo}
-	chronic sudo -E zypper refresh
-	chronic sudo -E zypper -n install redis
-
-	[ "$setup_type" = "minimal" ] && exit 0
-
-	echo "Add crudini repo"
-	VERSIONID="12_SP1"
-	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
-	chronic sudo -E zypper refresh
-	chronic sudo -E zypper -n install crudini
 }
 
 main "$@"

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -150,8 +150,17 @@ install_docker(){
 			docker_version_full=$(apt-cache madison $pkg_name | grep "$docker_version" | awk '{print $3}' | head -1)
 			sudo -E apt-get -y install "${pkg_name}=${docker_version_full}"
 		elif [[ "$ID" =~ ^opensuse.*$ ]] || [ "$ID" == "sles" ]; then
+			# We need docker 18.06 for now, which is only provided by an older Leap 15 release
+			# Instead of adding the repo to the system (via zypper addrepo) we just install
+			# the package and its dependencies directly here. Mainly to avoid other packages
+			# from that repo creeping in.
+			leap15_repo="https://download.opensuse.org/repositories/openSUSE:/Leap:/15.0:/Update/standard/rpms/x86_64"
 			sudo zypper removelock docker
-			sudo zypper -n  install 'docker<19.03'
+			sudo zypper -n --no-gpg-checks install \
+                            $leap15_repo/docker-18.06.1_ce-lp150.5.6.1.x86_64.rpm \
+                            $leap15_repo/containerd-1.1.2-lp150.4.3.1.x86_64.rpm \
+                            $leap15_repo/docker-runc-1.0.0rc5+gitr3562_69663f0bd4b6-lp150.5.3.1.x86_64.rpm \
+                            $leap15_repo/docker-libnetwork-0.7.0.1+gitr2664_3ac297bc7fd0-lp150.3.3.1.x86_64.rpm
 			sudo zypper addlock docker
 		fi
 	elif [ "$tag" == "swarm" ]; then


### PR DESCRIPTION
Most of the repositories that are added to the SLES nodes can be removed
as many of the additionally required packages are meanwhile part of the
"PackageHub" repositories that are offered for SLES.
This should also speed up things a bit as only a single "zypper refresh"
call is needed now.

Fixes #2986
Signed-off-by: Ralf Haferkamp <rhafer@suse.com>