### PR TITLE
ci: Enable clh+containerd k8s e2e testing

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -264,6 +264,15 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
+	init_ci_flags
+	export MINIMAL_CONTAINERD_K8S_E2E="false"
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export experimental_kernel="true"
+	;;
 "VFIO")
 	init_ci_flags
 	export CRIO="no"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -45,6 +45,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
+		echo "INFO: Running complete e2e kubernetes tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
+		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"

--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -8,7 +8,9 @@ jobs:
   CRI_CONTAINERD_K8S_MINIMAL:
     passed: 12
   CRI_CONTAINERD_K8S_COMPLETE:
-    passed: 273
+    passed: 269
+  CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
+    passed: 274
   minimal:
     focus:
       - ConfigMap should be consumable from pods in volume

--- a/integration/kubernetes/e2e_conformance/setup.sh
+++ b/integration/kubernetes/e2e_conformance/setup.sh
@@ -29,4 +29,6 @@ if ! bash ./init.sh; then
 	bash ./init.sh
 fi
 crictl --version
+kubectl get runtimeclass
+kubectl apply -f "runtimeclass_workloads/kata-runtimeclass.yaml"
 kubectl get pods --all-namespaces

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -7,8 +7,13 @@
 # are not running correctly using kata-runtime.
 
 containerd:
-  - SchedulerPredicates
-  - Daemon set \[Serial\] should rollback without unnecessary restarts
+  - \[sig-api-machinery\] Aggregator should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
 
 crio:
   - Daemon set \[Serial\] should rollback without unnecessary restarts
+
+hypervisor:
+  cloud-hypervisor:
+    - \[sig-apps]\ Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]
+    - \[sig-api-machinery\] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
+    - \[k8s.io\] Security Context When creating a pod with privileged should run the container as unprivileged when false \[LinuxOnly\] \[NodeConformance\]


### PR DESCRIPTION
This PR enables the clh+containerd full k8s e2e testing.

Fixes #2989

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>