### PR TITLE
ci : Enable CLH+CRIO kata 2.x testing

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -255,6 +255,14 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CRIO")
+	export KUBERNETES=yes
+	export CRIO=yes
+	export OPENSHIFT=no
+	export CRI_CONTAINERD=no
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export experimental_kernel="true"
+	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
 	init_ci_flags
 	export MINIMAL_CONTAINERD_K8S_E2E="true"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -41,6 +41,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests with containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CRIO")
+		echo "INFO: Running kubernetes tests"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
 	"CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -8,8 +8,10 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 issue="https://github.com/kata-containers/tests/issues/2574"
+clh_issue="https://github.com/kata-containers/tests/issues/2995"
 
 setup() {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
 	get_pod_config_dir
@@ -18,6 +20,7 @@ setup() {
 }
 
 @test "Copy file in a pod" {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -35,6 +38,7 @@ setup() {
 }
 
 @test "Copy from pod to host" {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -52,6 +56,7 @@ setup() {
 }
 
 teardown() {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -8,8 +8,10 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 issue="https://github.com/kata-containers/tests/issues/2574"
+clh_issue="https://github.com/kata-containers/tests/issues/2995"
 
 setup() {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	sleep_liveness=20
@@ -18,6 +20,7 @@ setup() {
 }
 
 @test "Liveness probe" {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="liveness-exec"
 
@@ -36,6 +39,7 @@ setup() {
 }
 
 @test "Liveness http probe" {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="liveness-http"
 
@@ -55,6 +59,7 @@ setup() {
 
 
 @test "Liveness tcp probe" {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="tcptest"
 
@@ -73,6 +78,7 @@ setup() {
 }
 
 teardown() {
+	[ "$CI_JOB" == "CLOUD-HYPERVISOR-K8S-CRIO" ] && skip "test not working see: ${clh_issue}"
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
This PR enables the CLH+CRIO kata 2.x k8s testing.

Fixes #2996

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>