### PR TITLE
lib/common.bash: Fix overwrite of KATA_TESTS_BASEDIR

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -14,7 +14,7 @@ VC_POD_DIR="${VC_POD_DIR:-/run/vc/sbs}"
 RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"
 
 # Kata tests directory used for storing various test-related artifacts.
-KATA_TESTS_BASEDIR="${KATA_TESTS_LOGDIR:-/var/log/kata-tests}"
+KATA_TESTS_BASEDIR="${KATA_TESTS_BASEDIR:-/var/log/kata-tests}"
 
 # Directory that can be used for storing test logs.
 KATA_TESTS_LOGDIR="${KATA_TESTS_LOGDIR:-${KATA_TESTS_BASEDIR}/logs}"


### PR DESCRIPTION
To overwrite the KATA_TESTS_BASEDIR variable it should be defined
another of same name, not KATA_TESTS_LOGDIR.

Fixes #2999

Backport of https://github.com/kata-containers/tests/pull/3000

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>