### PR TITLE
docker: set rw on block device before hotplug test.

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -573,6 +573,13 @@ func createLoopDevice() (string, string, error) {
 	if len(loopPath) == 0 {
 		return "", "", fmt.Errorf("Unable to get loop device path, stdout: %s, stderr: %s", stdout, stderr)
 	}
+
+	// set loop device to rw using blockdev --setrw
+	setrwLoopDevice := tests.NewCommand("blockdev", "--setrw", loopPath[0])
+	stdout, stderr, exitCode = setrwLoopDevice.Run()
+	if exitCode != 0 {
+		return "", "", fmt.Errorf("exitCode: %d, stdout: %s, stderr: %s ", exitCode, stdout, stderr)
+	}
 	return f.Name(), loopPath[0], nil
 }
 


### PR DESCRIPTION
rw check on block device is enhanced in qemu 5.1. So block device should be
set to rw using blockdev before hotplug test in docker.
If not, block device hotplug test will fail.

test case:
docker run --rm --runtime kata-runtime --device /dev/loop0 ubuntu ls

more info see https://patchew.org/QEMU/20200717105426.51134-1-kwolf@redhat.com/20200717105426.51134-3-kwolf@redhat.com/

Fixes: #3002
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @fidencio @devimc 