### PR TITLE
static-checks: ignore gogo and google proto files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -484,6 +484,8 @@ static_check_license_headers()
 			--exclude="*.patch" \
 			--exclude="*.diff" \
 			--exclude="tools/packaging/static-build/qemu.blacklist" \
+			--exclude="src/agent/protocols/protos/gogo/*" \
+			--exclude="src/agent/protocols/protos/google/*" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
These are pulled from other repositories.

Fixes: #3005