### PR TITLE
ci: Remove docker file after running baremetal tests

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -126,6 +126,15 @@ check() {
 	fi
 }
 
+teardown() {
+	docker_configuration_path="/etc/docker"
+	docker_configuration_file="${docker_configuration_path}/daemon.json"
+	if [ -f "${docker_configuration_file}" ]; then
+		sudo rm -f "${docker_configuration_file}"
+	fi
+}
+
 init
 run
 check
+teardown


### PR DESCRIPTION
After running the metrics tests we need to remove docker configuration file
so we have a clean environment.

Fixes #3010

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>