### PR TITLE
ci: fix VFIO CI

### DIFF
--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -174,20 +174,20 @@ main() {
 		sleep 5
 	done
 
-	# Skip clh + initrd:
+	# Skip clh/QEMU + initrd:
 	# https://github.com/kata-containers/kata-containers/issues/900
 	# run_test initrd "" cloud-hypervisor false
 	# run_test initrd "" cloud-hypervisor false
+	# run_test initrd "q35" qemu false
+	# run_test initrd "q35" qemu true
+	# run_test initrd "pc" qemu false
+	# run_test initrd "pc" qemu true
 	run_test image "" cloud-hypervisor false
 	run_test image "" cloud-hypervisor true
 	run_test image "q35" qemu false
 	run_test image "q35" qemu true
-	run_test initrd "q35" qemu false
-	run_test initrd "q35" qemu true
 	run_test image "pc" qemu false
 	run_test image "pc" qemu true
-	run_test initrd "pc" qemu false
-	run_test initrd "pc" qemu true
 }
 
 main $@

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -115,7 +115,7 @@ run_test() {
 
 	setup_configuration_file "$image_type" "$machine_type" "$hypervisor" "$sandbox_cgroup_only"
 
-	sudo -E kubectl apply -f "${SCRIPT_DIR}/runtimeclass_workloads/vfio.yaml"
+	sudo -E kubectl create -f "${SCRIPT_DIR}/runtimeclass_workloads/vfio.yaml"
 
 	pod_name=vfio
 	sudo -E kubectl wait --for=condition=Ready pod "${pod_name}"
@@ -127,6 +127,8 @@ run_test() {
 	else
 		info "Success: found 2 network interfaces"
 	fi
+
+	sudo -E kubectl delete -f "${SCRIPT_DIR}/runtimeclass_workloads/vfio.yaml"
 }
 
 main() {


### PR DESCRIPTION
Delete vfio POD after checking the net interfaces otherwise the following PODs
won't be created since there is already a POD with the same name and yaml.
Due to bug #3013 I was unable to detect that VFIO hotplug is not working with
QEMU+initrd. Let's skip these tests until we get a fix.

fixes #3013

Signed-off-by: Julio Montes <julio.montes@intel.com>