### PR TITLE
test: Unskip k8s tests for firecracker

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -19,10 +19,6 @@ cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_version=$(get_version "externals.kubernetes.version")
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	die "Kubernetes will not work with $KATA_HYPERVISOR"
-fi
-
 if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -273,6 +273,14 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"FIRECRACKER")
+	init_ci_flags
+	export KATA_HYPERVISOR="firecracker"
+	export KUBERNETES="yes"
+	export CRI_CONTAINERD="no"
+	export CRIO="yes"
+	export OPENSHIFT="no"
+	;;
 "VFIO")
 	init_ci_flags
 	export CRIO="no"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -49,6 +49,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running complete e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"FIRECRACKER")
+		echo "INFO: Running kubernetes tests"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -15,6 +15,7 @@ source /etc/os-release || source /usr/lib/os-release
 
 export JOBS="${JOBS:-$(nproc)}"
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.
@@ -80,7 +81,7 @@ done
 IFS=$OLD_IFS
 
 # run CRI-O tests using devicemapper on ubuntu
-if [ "$ID" == "ubuntu" ]; then
+if [ "$ID" == "ubuntu" ] || [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	if [ ! -b "${LVM_DEVICE}" ]; then
 		info "Creating a loop device to use it as LVM device"
 		# create a loop device and use it as lvm device

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -16,10 +16,6 @@ arch="$(uname -m)"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	die "Kubernetes tests will not run with $KATA_HYPERVISOR"
-fi
-
 # Using trap to ensure the cleanup occurs when the script exists.
 trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 


### PR DESCRIPTION
This PR removes the skip for the k8s when running firecracker in
kata 2.x

Fixes #3017

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>