### PR TITLE
Fix VFIO CI

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -62,7 +62,7 @@ create_user_data() {
 	ssh_pub_key="$(cat "${ssh_pub_key_file}")"
 	dnf_proxy=""
 	service_proxy=""
-	docker_user_proxy=""
+	docker_user_proxy="{}"
 	environment=$(env | egrep "ghprb|WORKSPACE|KATA|GIT|JENKINS|_PROXY|_proxy" | \
 	                    sed -e "s/'/'\"'\"'/g" \
 	                        -e "s/\(^[[:alnum:]_]\+\)=/\1='/" \

--- a/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -8,6 +8,7 @@ kind: Pod
 metadata:
   name: vfio
 spec:
+  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: c1

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -19,7 +19,9 @@ SYSCONFIG_FILE="/etc/kata-containers/configuration.toml"
 trap cleanup EXIT
 cleanup() {
 	sudo rm -rf "${SYSCONFIG_FILE}"
-	${SCRIPT_DIR}/cleanup_env.sh
+	# Don't fail the test if cleanup fails
+	# VM will be destroyed anyway.
+	${SCRIPT_DIR}/cleanup_env.sh || true
 }
 
 setup_configuration_file() {

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -123,9 +123,9 @@ run_test() {
 	sudo -E kubectl wait --for=condition=Ready pod "${pod_name}"
 
 	# Expecting 2 network interaces -> 2 mac addresses
-	mac_addrs=$(sudo -E kubectl exec -ti "${pod_name}" ip a | grep "link/ether" | wc -l)
+	mac_addrs=$(sudo -E kubectl exec -t "${pod_name}" -- ip a | grep "link/ether" | wc -l)
 	if [ ${mac_addrs} -ne 2 ]; then
-		die "Error: expecting 2 network interfaces, Got: $(kubectl exec -ti "${pod_name}" ip a)"
+		die "Error: expecting 2 network interfaces, Got: $(kubectl exec -t "${pod_name}" -- ip a)"
 	else
 		info "Success: found 2 network interfaces"
 	fi


### PR DESCRIPTION
set terminationGracePeriodSeconds to 0 to reduce pod deletion time
Fix warning: Error loading config file: /root/.docker/config.json.Use an empty json object `{}`.
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.

fixes #3025 #3027 #3028

Signed-off-by: Julio Montes <julio.montes@intel.com>