### PR TITLE
crio: Use systemd as cgroup driver.

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -154,7 +154,7 @@ sudo mkdir -p "${kubelet_service_dir}"
 
 cat <<EOF| sudo tee "${kubelet_service_dir}/0-crio.conf"
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"
+Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"
 EOF
 
 echo "Reload systemd services"


### PR DESCRIPTION
When debugging https://github.com/kata-containers/kata-containers/issues/1080
locally, I've noticed that the pod wouldn't start as CRI-O expects systemd to be
used as the cgroup driver, but kubelet doesn't have it explicitly set.

Locally, just adding "--cgroup-driver=systemd" to the KUBELET_EXTRA_ARGS
was enough to get ConfigMap failing pretty much with the same rate with
1.18.4 and with 1.18.3.

Fixes: https://github.com/kata-containers/kata-containers/issues/1080

Note: I know, I need to open an issue for the tests repo, but let me test it first.