### PR TITLE
ci: vfio: Enable vfio test with qemu-virtiofs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,8 @@ vcpus:
 	bash -f integration/vcpus/default_vcpus_test.sh
 
 vfio:
+	bash -f functional/vfio/run.sh -s false -p qemu-virtiofs -i image
+	bash -f functional/vfio/run.sh -s true -p qemu-virtiofs -i image
 	bash -f functional/vfio/run.sh -s false -p clh -i image
 	bash -f functional/vfio/run.sh -s true -p clh -i image
 #   bash -f functional/vfio/run.sh -s false -p clh -i initrd

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -109,6 +109,7 @@ EOF
 
 setup_configuration_file() {
 	local qemu_config_file="configuration-qemu.toml"
+	local qemu_virtiofs_config_file="configuration-qemu-virtiofs.toml"
 	local clh_config_file="configuration-clh.toml"
 	local image_file="/usr/share/kata-containers/kata-containers.img"
 	local initrd_file="/usr/share/kata-containers/kata-containers-initrd.img"
@@ -119,6 +120,8 @@ setup_configuration_file() {
 
 		if [ "$HYPERVISOR" = "qemu" ]; then
 			config_filename="${qemu_config_file}"
+		elif [ "$HYPERVISOR" = "qemu-virtiofs" ]; then
+			config_filename="${qemu_virtiofs_config_file}"
 		elif [ "$HYPERVISOR" = "clh" ]; then
 			config_filename="${clh_config_file}"
 		fi


### PR DESCRIPTION
This patch enables the VFIO test with qemu-virtiofs.

Fixes: #2677

Signed-off-by: Bo Chen <chen.bo@intel.com>