### PR TITLE
k8s: Skip "k8s-copy-file" tests with CRI-O

### DIFF
--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -7,9 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
+issue="https://github.com/cri-o/cri-o/issues/4353"
 
 setup() {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
 	get_pod_config_dir
@@ -18,6 +19,7 @@ setup() {
 }
 
 @test "Copy file in a pod" {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -35,6 +37,7 @@ setup() {
 }
 
 @test "Copy from pod to host" {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -52,6 +55,7 @@ setup() {
 }
 
 teardown() {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
k8s-copy-file.bats tests regressed after bumping CRI-O version to
v1.18.4.

This has been tracked on CRI-O side`[0]`, we already have a patch waiting
for reviews, and we should enouble this test back as soon as a new
release contains the fix.

`[0]:` https://github.com/cri-o/cri-o/issues/4353

Fixes: #3033 

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>