### PR TITLE
k8s: Fix e2e conformance skip list for containerd

### DIFF
--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -7,7 +7,8 @@
 # are not running correctly using kata-runtime.
 
 containerd:
-  - \[sig-api-machinery\] Aggregator should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
+  - \[sig-api-machinery\] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
+  - Daemon set \[Serial\] should rollback without unnecessary restarts
 
 crio:
   - Daemon set \[Serial\] should rollback without unnecessary restarts


### PR DESCRIPTION
Added to the list a test that requires a two node cluster.
Additionally, fixed a letter in another entry which requires
to be Uppercase.

Fixes: #3034.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>