### PR TITLE
ci: metrics: always run teardown in run_metrics_PR_ci.sh

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -134,7 +134,8 @@ teardown() {
 	fi
 }
 
+trap teardown EXIT QUIT KILL
+
 init
 run
 check
-teardown


### PR DESCRIPTION
Use `trap` to make sure the `teardown` function runs even
if something in the script fails earlier.

Fixes: #3036.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>