### PR TITLE
k8s: Re-enable "k8s-copy-file" tests for CRI-O

### DIFF
--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -7,10 +7,8 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/cri-o/cri-o/issues/4353"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
 	get_pod_config_dir
@@ -19,7 +17,6 @@ setup() {
 }
 
 @test "Copy file in a pod" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -37,7 +34,6 @@ setup() {
 }
 
 @test "Copy from pod to host" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -55,7 +51,6 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
This basically reverts commit ef5cda7463416997bc051b83fc87ac3100be93ae,
as the fix for this already reached CRI-O, and CRI-I version will be
bumped on the kata-containers side.

Fixes: #3041