### PR TITLE
ci: compress kata-hypervisor logs

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -157,6 +157,7 @@ collect_logs()
 		prefixes+=" ${vc_throttler_log_prefix}"
 		prefixes+=" ${kernel_log_prefix}"
 		prefixes+=" ${virtiofs_log_prefix}"
+		prefixes+=" ${kata_hypervisor_log_prefix}"
 
 		[ "${have_collect_script}" = "yes" ] && prefixes+=" ${collect_data_log_prefix}"
 


### PR DESCRIPTION
To save space in CI.

Fixes: #2874

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>