### PR TITLE
metrics: clh: Update midval for memory footprint

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 272586.75
+midval = 141664.95
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 272546.74
+midval = 141659.35
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
As a result of disabling the virtio-fs DAX when using cloud-hypervisor,
the expected memory footprint of kata+clh is reduced substantially. This
PR updates the reference value of memory footprint used by our metrics
CI.

Depends-on: github.com/kata-containers/runtime#3073

Fixes: #3057

Signed-off-by: Bo Chen <chen.bo@intel.com>