### PR TITLE
k8s: Re-enable "k8s-liveness-probes" tests for CRI-O

### DIFF
--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -7,10 +7,8 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	sleep_liveness=20
 
@@ -18,7 +16,6 @@ setup() {
 }
 
 @test "Liveness probe" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="liveness-exec"
 
 	# Create pod
@@ -36,7 +33,6 @@ setup() {
 }
 
 @test "Liveness http probe" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="liveness-http"
 
 	# Create pod
@@ -55,7 +51,6 @@ setup() {
 
 
 @test "Liveness tcp probe" {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	pod_name="tcptest"
 
 	# Create pod
@@ -73,6 +68,5 @@ setup() {
 }
 
 teardown() {
-	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working - see: ${issue}"
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
This has been fixed some time ago and was brought in as part of v1.18.4
release.  However, we forgot to re-enable the tests when we bumped the
CRI-O version.

Fixes: #2574

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>