### PR TITLE
k8s: Enable "k8s-oom" tests for CRI-O

### DIFF
--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -7,7 +7,6 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2859"
 
 setup() {
 	export KUBECONFIG="$HOME/.kube/config"
@@ -16,10 +15,6 @@ setup() {
 }
 
 @test "Test OOM events for pods" {
-	if [ "$CI_JOB" == "CRIO_K8S" ]; then
-		skip "test not working on CRI-O, see: ${issue}"
-	fi
-
 	wait_time=20
 	sleep_time=2
 
@@ -36,8 +31,5 @@ setup() {
 }
 
 teardown() {
-	if [ "$CI_JOB" == "CRIO_K8S" ]; then
-		skip "test not working on CRI-O, see: ${issue}"
-	fi
 	kubectl delete pod "$pod_name"
 }


### PR DESCRIPTION
k8s-oom.bats has been introduced and enabled only for containerd as the
patch for CRI-O had to be backported to the correct branch.  As the
backport was done and we are bumping CRI-O dependency version for
kata-containers, we can finally enable this test also for CRI-O.

Depends-on: github.com/kata-containers/kata-containers#1117

Fixes: #2859

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>