### PR TITLE
ci: Split virtiofs CI_JOB

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -46,6 +46,9 @@ init_ci_flags() {
 	# Use experimental kernel
 	# Values: true|false
 	export experimental_kernel="false"
+	# Use experimental qemu
+	# Values: true|false
+	export experimental_qemu="true"
 	# Run the kata-check checks
 	export RUN_KATA_CHECK="true"
 
@@ -227,6 +230,17 @@ case "${CI_JOB}" in
 	export experimental_kernel="true"
 	export METRICS_CI="true"
 	export METRICS_CI_PROFILE="virtiofs-baremetal"
+	;;
+"VIRTIOFS_STABLE")
+	init_ci_flags
+	export experimental_qemu="false"
+	export experimental_kernel="false"
+	export DOCKERFILE
+	;;
+"VIRTIOFS_EXPERIMENTAL")
+	init_ci_flags
+	export experimental_qemu="true"
+	export experimental_kernel="true"
 	;;
 "SANDBOX_CGROUP_ONLY")
 	# Used by runtime makefile to enable option on intall

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -125,8 +125,26 @@ END
 		echo "INFO: Running kubernetes tests ($PWD)"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 
-		echo "INFO: Running shimv2 tests ($PWD)"
-		sudo -E PATH="$PATH" bash -c "make shimv2"
+		;;
+	"VIRTIOFS_STABLE")
+		echo "INFO: Running docker tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make docker"
+
+		echo "INFO: Running crio tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make crio"
+
+		echo "INFO: Running kubernetes tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
+	"VIRTIOFS_EXPERIMENTAL")
+		echo "INFO: Running docker tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make docker"
+
+		echo "INFO: Running crio tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make crio"
+
+		echo "INFO: Running kubernetes tests ($PWD)"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
 	*)
 		echo "INFO: Running checks"


### PR DESCRIPTION
Add JOB cases for virtiofs experimental and stable.

This will allow to provide a more stable and easier to mantain virtiofs,
users can bennefit of quick qemu and kernel updates.

For stable users will have the well-known virtiofs configuration that
are stable.

Fixes: #3067

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>