### PR TITLE
test: Add k8s test to verify init containers work

### DIFF
--- a/integration/kubernetes/k8s-init.bats
+++ b/integration/kubernetes/k8s-init.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+
+setup() {
+	export KUBECONFIG="$HOME/.kube/config"
+	pod_name="test-init"
+	get_pod_config_dir
+}
+
+@test "Test init containers" {
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-init.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready pod "$pod_name"
+	cmd="printenv"
+	kubectl exec $pod_name -- sh -c $cmd | grep "HOSTNAME=$pod_name"
+}
+
+teardown() {
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/runtimeclass_workloads/pod-init.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-init.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-init
+spec:
+  runtimeClassName: kata
+  initContainers:
+  - name: init-myservice
+    image: busybox
+    command: ['sh', '-c', 'date']
+  containers:
+  - name: test
+    image: busybox
+    command: [ 'sh', '-c', 'tail -f /dev/null']
+restartPolicy: Never


### PR DESCRIPTION
This adds a k8s test to verify that init containers are not broken with k8s.

Fixes #2825

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>