### PR TITLE
fix base64 option to work in MacOS

### DIFF
--- a/kata-webhook/create-certs.sh
+++ b/kata-webhook/create-certs.sh
@@ -10,7 +10,7 @@ WEBHOOK_SVC="${WEBHOOK_NAME}-webhook"
 
 # Create certs for our webhook
 openssl genrsa -out webhookCA.key 2048
-openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.svc" -out ./webhookCA.csr 
+openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.svc" -out ./webhookCA.csr
 openssl x509 -req -days 365 -in webhookCA.csr -signkey webhookCA.key -out webhook.crt
 
 # Create certs secrets for k8s
@@ -20,8 +20,12 @@ kubectl create secret generic \
     --from-file=cert.pem=./webhook.crt \
     --dry-run -o yaml > ./deploy/webhook-certs.yaml
 
+BASE64_OPT="-w0"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    BASE64_OPT=""
+fi
 # Set the CABundle on the webhook registration
-CA_BUNDLE=$(cat ./webhook.crt | base64 -w0)
+CA_BUNDLE=$(cat ./webhook.crt | base64 $BASE64_OPT)
 sed "s/CA_BUNDLE/${CA_BUNDLE}/" ./deploy/webhook-registration.yaml.tpl > ./deploy/webhook-registration.yaml
 
 # Clean


### PR DESCRIPTION
Description of problem
the default macOS base64 implementation doesn't have the -w flag

Expected result
successful cert creation

Actual result
$ ./create-certs.sh
Generating RSA private key, 2048 bit long modulus
........................................................................+++
...................................................................................................................+++
e is 65537 (0x10001)
Signature ok
subject=/CN=pod-annotate-webhook.default.svc
Getting Private key
base64: invalid option -- w
Usage: base64 [-hvDd] [-b num] [-i in_file] [-o out_file]
-h, --help display this message
-Dd, --decode decodes input
-b, --break break encoded string into num character lines
-i, --input input file (default: "-" for stdin)
-o, --output output file (default: "-" for stdout)

Further information
So, the flag is called -b in macOS, and it already defaults to 0, which means base64 in macOS has the same behaviour as base64 -w0 on Linux.

Fixes: #3078 
Signed-off-by: Peter Ruan (pruan@redhat.com)

