### PR TITLE
.ci/openshift-ci: Turn SELinux on

### DIFF
--- a/.ci/openshift-ci/buildall_install.sh
+++ b/.ci/openshift-ci/buildall_install.sh
@@ -52,8 +52,8 @@ export USE_VSOCK="yes"
 # Configure the QEMU machine type.
 export MACHINETYPE="q35"
 
-# Disable SELinux.
-export FEATURE_SELINUX="no"
+# Enable SELinux.
+export FEATURE_SELINUX="yes"
 
 # The default /usr prefix makes the deployment on Red Hat CoreOS (rhcos) more
 # complex because that directory is read-only by design. Another prefix than


### PR DESCRIPTION
Currently Kata Containers is built with feature selinux disabled
and the OpenShift workers are configured with SELinux on permissive
mode. This will change the build and installation so that SELinux
is on.

Fixes #3086

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>