### PR TITLE
change v1beta1 to v1 to get rid of warning message with oc 4.6.x

### DIFF
--- a/kata-webhook/create-certs.sh
+++ b/kata-webhook/create-certs.sh
@@ -10,7 +10,7 @@ WEBHOOK_SVC="${WEBHOOK_NAME}-webhook"
 
 # Create certs for our webhook
 openssl genrsa -out webhookCA.key 2048
-openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.svc" -out ./webhookCA.csr 
+openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.svc" -out ./webhookCA.csr
 openssl x509 -req -days 365 -in webhookCA.csr -signkey webhookCA.key -out webhook.crt
 
 # Create certs secrets for k8s

--- a/kata-webhook/deploy/webhook-registration.yaml.tpl
+++ b/kata-webhook/deploy/webhook-registration.yaml.tpl
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-annotate-webhook


### PR DESCRIPTION
Description of problem
the kata-webhook/deploy/webhook-registration.yaml.tpl is using a deprecated apiVersion v1beta1

Expected result
oc apply -f deploy should be successful w/o warnings

Actual result
W1203 21:28:15.344945 28253 warnings.go:67] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
W1203 21:28:15.431559 28253 warnings.go:67] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration

with patch:
$ oc apply -f deploy
secret/pod-annotate-webhook-certs configured
mutatingwebhookconfiguration.admissionregistration.k8s.io/pod-annotate-webhook configured
deployment.apps/pod-annotate-webhook unchanged
service/pod-annotate-webhook unchanged

Fixes: #3093 
Signed-off-by: Peter Ruan (pruan@redhat.com)