### PR TITLE
Prepare 2.x for OpenShift CI - part 1

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -11,6 +11,7 @@ set -o pipefail
 set -o errtrace
 
 cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
 rust_agent_repo="github.com/kata-containers/kata-containers"
 arch=$("${cidir}"/kata-arch.sh -d)
 PREFIX="${PREFIX:-/usr}"
@@ -20,30 +21,38 @@ image_name="${image_name:-kata-containers.img}"
 initrd_name="${initrd_name:-kata-containers-initrd.img}"
 AGENT_INIT="${AGENT_INIT:-no}"
 TEST_INITRD="${TEST_INITRD:-no}"
+build_method="${BUILD_METHOD:-distro}"
 
 build_rust_image() {
 	export RUST_AGENT="yes"
 	osbuilder_path="${GOPATH}/src/${rust_agent_repo}/tools/osbuilder"
-	distro="ubuntu"
 
 	sudo mkdir -p "${image_path}"
 
 	pushd "${osbuilder_path}"
-
-	if [ "${TEST_INITRD}" == "no" ]; then
-		echo "Building image with AGENT_INIT=${AGENT_INIT}"
-		sudo -E USE_DOCKER=1 DISTRO="${distro}" make -e image
-
-		echo "Install image to ${image_path}"
-		sudo install -D "${osbuilder_path}/${image_name}" "${image_path}"
-	else
-		echo "Building initrd with AGENT_INIT=${AGENT_INIT}"
-		sudo -E USE_DOCKER=1 DISTRO="${distro}" make -e initrd
-
-		echo "Install initrd to ${image_path}"
-		sudo install -D "${osbuilder_path}/${initrd_name}" "${image_path}"
+	target_image="image"
+	file_to_install="${osbuilder_path}/${image_name}"
+	if [ "${TEST_INITRD}" == "yes" ]; then
+		target_image="initrd"
+		file_to_install="${osbuilder_path}/${initrd_name}"
 	fi
-
+	info "Building ${target_image} with AGENT_INIT=${AGENT_INIT}"
+	case "$build_method" in
+		"distro")
+			distro="${osbuilder_distro:-ubuntu}"
+			use_docker="${osbuild_docker:-1}"
+			sudo -E USE_DOCKER="${use_docker}" DISTRO="${distro}" \
+				make -e "${target_image}"
+			;;
+		"dracut")
+			sudo -E BUILD_METHOD="dracut" make -e "${target_image}"
+			;;
+		*)
+			die "Unknown build method ${build_method}"
+			;;
+	esac
+	info "Install ${target_image} to ${image_path}"
+	sudo install -D "${file_to_install}" "${image_path}"
 	popd
 }
 

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -13,7 +13,9 @@ set -o errtrace
 cidir=$(dirname "$0")
 rust_agent_repo="github.com/kata-containers/kata-containers"
 arch=$("${cidir}"/kata-arch.sh -d)
-image_path="${image_path:-/usr/share/kata-containers}"
+PREFIX="${PREFIX:-/usr}"
+DESTDIR="${DESTDIR:-/}"
+image_path="${DESTDIR}${image_path:-${PREFIX}/share/kata-containers}"
 image_name="${image_name:-kata-containers.img}"
 initrd_name="${initrd_name:-kata-containers-initrd.img}"
 AGENT_INIT="${AGENT_INIT:-no}"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -18,8 +18,8 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 
 latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
 experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
-PREFIX=${PREFIX:-/usr}
-kernel_dir=${PREFIX}/share/kata-containers
+PREFIX="${PREFIX:-/usr}"
+kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
 kata_repo="github.com/kata-containers/kata-containers"
 export GOPATH=${GOPATH:-${HOME}/go}

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -19,7 +19,8 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
 MACHINETYPE="${MACHINETYPE:-pc}"
 METRICS_CI="${METRICS_CI:-}"
-PREFIX=${PREFIX:-/usr}
+PREFIX="${PREFIX:-/usr}"
+DESTDIR="${DESTDIR:-/}"
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 TEST_INITRD="${TEST_INITRD:-}"
 USE_VSOCK="${USE_VSOCK:-yes}"
@@ -43,7 +44,7 @@ export SHAREDIR=${PREFIX}/share
 runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 runtime_src_path="${GOPATH}/src/${KATA_REPO}/src/runtime"
 
-PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
+PKGDEFAULTSDIR="${DESTDIR}${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
 
@@ -53,7 +54,7 @@ build_install_shim_v2(){
 	fi
 	pushd "$runtime_src_path"
 	make
-	sudo make install
+	sudo -E make install
 	popd
 }
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -41,6 +41,9 @@ export SYSCONFDIR=/etc
 # Artifacts (kernel + image) live below here
 export SHAREDIR=${PREFIX}/share
 
+# Whether running on OpenShift CI or not.
+OPENSHIFT_CI="${OPENSHIFT_CI:-false}"
+
 runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
 runtime_src_path="${GOPATH}/src/${KATA_REPO}/src/runtime"
 
@@ -128,13 +131,16 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	echo "Configure use of VSOCK in ${runtime_config_path}"
 	sudo sed -i -e 's/^#use_vsock.*/use_vsock = true/' "${runtime_config_path}"
 
-	vsock_module="vhost_vsock"
-	echo "Check if ${vsock_module} is loaded"
-	if lsmod | grep -q "$vsock_module" &> /dev/null ; then
-		echo "Module ${vsock_module} is already loaded"
-	else
-		echo "Load ${vsock_module} module"
-		sudo modprobe "${vsock_module}"
+	# On OpenShift CI the vhost module should not be loaded on build time.
+	if [ "$OPENSHIFT_CI" == "false" ]; then
+		vsock_module="vhost_vsock"
+		echo "Check if ${vsock_module} is loaded"
+		if lsmod | grep -q "$vsock_module" &> /dev/null ; then
+			echo "Module ${vsock_module} is already loaded"
+		else
+			echo "Load ${vsock_module} module"
+			sudo modprobe "${vsock_module}"
+		fi
 	fi
 fi
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -135,7 +135,7 @@ if [ "$USE_VSOCK" == "yes" ]; then
 	if [ "$OPENSHIFT_CI" == "false" ]; then
 		vsock_module="vhost_vsock"
 		echo "Check if ${vsock_module} is loaded"
-		if lsmod | grep -q "$vsock_module" &> /dev/null ; then
+		if lsmod | grep -q "\<${vsock_module}\>" ; then
 			echo "Module ${vsock_module} is already loaded"
 		else
 			echo "Load ${vsock_module} module"


### PR DESCRIPTION
This pull request is meant to prepare the ci scripts for build and install Kata Containers (plus kernel, qemu, and image) in a DESTDIR. It will be necessary to on-board 2.x into OpenShift CI (likewise it was done for 1.x).

Except for the last commit (where I enable dracut based build on `install_kata_image.sh`) the others on this PR are forward-ports.