### PR TITLE
k8s/e2e: Make cleanup() fault tolerant

### DIFF
--- a/integration/kubernetes/e2e_conformance/run.sh
+++ b/integration/kubernetes/e2e_conformance/run.sh
@@ -152,13 +152,22 @@ run_sonobuoy() {
 }
 
 cleanup() {
-	info "Results directory "${e2e_result_dir}" will not be deleted"
-	info "View results"
-	cat ${e2e_result_dir}/plugins/e2e/results/global/e2e.log
-	info "View sonobuoy status"
-	sonobuoy status
-	# Remove sonobuoy execution pods
-	sonobuoy delete
+	if [ -d "${e2e_result_dir:-}" ]; then
+		info "Results directory "${e2e_result_dir}" will not be deleted"
+		log_file="${e2e_result_dir}/plugins/e2e/results/global/e2e.log"
+		if [ -f "${log_file}" ]; then
+			info "View results"
+			cat ${log_file}
+		else
+			warn "Tests results file ${log_file} not found"
+		fi
+	fi
+	{
+		info "View sonobuoy status"
+		sonobuoy status
+		# Remove sonobuoy execution pods
+		sonobuoy delete
+	} || true
 }
 
 trap "{ cleanup; }" EXIT


### PR DESCRIPTION
Sonobuoy may crash on start up, then cleanup() is called and
it will try to access resources that doesn't exist. So this fixes
some failures on that function:
 - e2e_result_dir "unbound variable"
 - Cannot print the log file if it wasn't created
 - sonobuoy status/delete can fail

This isn't going to fix #3101 , actually it is just an improvement for when the sonobuoy fail. 