### PR TITLE
spellcheck: Add more words to dictionary

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -49,6 +49,7 @@ PCDIMM/AB
 PCI/AB
 PCIe/AB
 PID/AB
+pmem/B	# persistent memory
 PNG/AB
 POD/AB
 PR/AB
@@ -61,6 +62,7 @@ RDMA/AB
 RNG/AB
 SCSI/AB
 SDK/AB
+seccomp # secure computing mode
 SHA/AB
 SPDX/AB
 SRIOV/AB
@@ -86,6 +88,7 @@ Virtio-mem/AB
 VLAN/AB
 VM/AB
 VMCache/AB
+vmm
 VMM/AB
 VMX/AB
 VPP/AB

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -56,6 +56,7 @@ miniOS
 nack/A
 namespace/ABCD
 Nvidia
+OpenAPI
 OS/AB
 onwards
 parallelize/AC


### PR DESCRIPTION
New words we need to include: pmem, seccomp, vmm, OpenAPI.

Fixes: #3105

Signed-off-by: Bo Chen <chen.bo@intel.com>