### PR TITLE
ci: stopping docker.socket before remove package docker-ce

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -203,6 +203,7 @@ remove_docker(){
 	if [ -z "$pkg_name" ]; then
 		die "Docker not found in this system"
 	else
+		sudo systemctl stop docker.socket || true
 		sudo systemctl stop docker
 		version=$(get_docker_version)
 		log_message "Removing package: $pkg_name version: $version"


### PR DESCRIPTION
If the CI VM has already other docker-ce installed, for example 20.10,
the removing may be failed for the docker.socket is not stopped yet.
To gracefully delete docker-ce package, docker.socket needs to be stopped.

Fixes: #3103

Signed-off-by: bin liu <bin@hyper.sh>


## local test(not the same as CI's server)

### with `systemctl stop docker.socket`

Run this repeatedly:

```shell
$ systemctl stop docker && \
systemctl stop docker.socket && \
apt remove -y docker-ce && \
apt-get install docker-ce -y
```

All succeeded.

### without `systemctl stop docker.socket`

Run this repeatedly:

```shell
$ systemctl stop docker && \
apt remove -y docker-ce && \
apt-get install docker-ce -y
```

All failed, and with log (the same as [CI's log](http://jenkins.katacontainers.io/job/kata-containers-2.0-tests-ubuntu-PR/361/consoleFull)):

```
Dec 11 09:06:33 vagrant systemd[1]: /lib/systemd/system/dbus.socket:5: ListenStream= references a path below legacy directory /var/run/, updating /var/run/dbus/system_bus_socket → /run/dbus/system_bus_socket; please update the unit file accordingly.
Dec 11 09:06:33 vagrant systemd[1]: /lib/systemd/system/docker.socket:5: ListenStream= references a path below legacy directory /var/run/, updating /var/run/docker.sock → /run/docker.sock; please update the unit file accordingly.
Dec 11 09:06:33 vagrant systemd[1]: docker.socket: Socket unit configuration has changed while unit has been running, no open socket file descriptor left. The socket unit is not functional until restarted.
Dec 11 09:06:33 vagrant systemd[1]: Starting Docker Application Container Engine...
Dec 11 09:06:33 vagrant systemd-udevd[445]: Network interface NamePolicy= disabled on kernel command line, ignoring.
Dec 11 09:06:33 vagrant dockerd[58888]: time="2020-12-11T09:06:33.739861218Z" level=info msg="Starting up"
Dec 11 09:06:33 vagrant dockerd[58888]: failed to load listeners: no sockets found via socket activation: make sure the service was started by systemd
Dec 11 09:06:33 vagrant systemd[1]: docker.service: Main process exited, code=exited, status=1/FAILURE
Dec 11 09:06:33 vagrant systemd[1]: docker.service: Failed with result 'exit-code'.
Dec 11 09:06:33 vagrant systemd[1]: Failed to start Docker Application Container Engine.
Dec 11 09:06:33 vagrant systemd[1]: Reloading.

```
