### PR TITLE
ci: stopping docker.socket before remove package docker-ce

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -210,6 +210,7 @@ remove_docker(){
 	if [ -z "$pkg_name" ]; then
 		die "Docker not found in this system"
 	else
+		sudo systemctl stop docker.socket || true
 		sudo systemctl stop docker
 		version=$(get_docker_version)
 		log_message "Removing package: $pkg_name version: $version"


### PR DESCRIPTION
If system has docker already installed, then remove it
by also making sure docker.socket is stopped as well.

Fixes: #3103

Signed-off-by: bin liu <bin@hyper.sh>
Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>