### PR TITLE
2.x | centos: PowerTools repo got renamed to powertools

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -43,7 +43,7 @@ sudo -E yum -y update
 if [ "$centos_version" == "8" ]; then
 	echo "Enable PowerTools repository"
 	sudo -E yum install -y yum-utils
-	sudo yum-config-manager --enable PowerTools
+	sudo yum-config-manager --enable powertools
 fi
 
 echo "Install chronic"


### PR DESCRIPTION
CentOS decided to rename all its repos names in a minor release,
resulting in breakage in several CIs, including Kata Container's
one.

Just renaming the repo from PowerTools to powertools solves the
issue.

Reference: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes

Fixes: #3116

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>