### PR TITLE
2.x | integration,k8s: Rely on quay.io images instead of dockerhub ones

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: first-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     env:
     - name: CONTAINER_NAME
       value: "first-test-container"
@@ -21,7 +21,7 @@ spec:
         - sleep
         - "30"
   - name: second-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     env:
     - name: CONTAINER_NAME
       value: "second-test-container"

--- a/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -13,7 +13,7 @@ spec:
   shareProcessNamespace: true
   containers:
   - name: busybox
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
       - sleep
       - "120"

--- a/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -12,14 +12,14 @@ spec:
   runtimeClassName: kata
   initContainers:
   - name: first
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/initContainer" ]
     volumeMounts:
       - mountPath: /volume
         name: volume
   containers:
   - name: last
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/container; tail -f /dev/null" ]
     volumeMounts:
     - mountPath: /volume

--- a/integration/kubernetes/runtimeclass_workloads/job-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job-template.yaml
@@ -20,6 +20,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: test
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["tail", "-f", "/dev/null"]
       restartPolicy: Never

--- a/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -14,7 +14,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: pi
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["/bin/sh", "-c", "echo 'scale=5; 4*a(1)' | bc -l"]
       restartPolicy: Never
   backoffLimit: 4

--- a/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: handlers-container
-    image: "${nginx_version}"
+    image: quay.io/sjenning/${nginx_version}
     lifecycle:
       postStart:
         exec:

--- a/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginx
-        image: "${nginx_version}"
+        image: quay.io/sjenning/${nginx_version}
         ports:
         - containerPort: 80

--- a/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
@@ -12,5 +12,5 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-besteffort
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -7,7 +7,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: my-container
-      image: ubuntu:18.04
+      image: quay.io/footloose/ubuntu18.04
       command: ["tail", "-f", "/dev/null"]
       volumeDevices:
         - devicePath: DEVICE_PATH

--- a/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-burstable
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:

--- a/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["tail", "-f", "/dev/null"]
       env:
         - name: KUBE_CONFIG_1

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
@@ -12,5 +12,5 @@ spec:
   runtimeClassName: kata
   containers:
   - name: default-cpu-demo-ctr
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: first-cpu-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
         - sleep
         - "30"

--- a/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["tail", "-f", "/dev/null"]
   dnsPolicy: "None"
   dnsConfig:

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: test
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     volumeMounts:
       - name: host-empty-vol

--- a/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
@@ -52,7 +52,7 @@ spec:
   # These containers are run during pod initialization
   initContainers:
   - name: install
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["sh", "-c", "chmod 700 /root/.ssh"]
     volumeMounts:
     - name: ssh-dir

--- a/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-guaranteed
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:

--- a/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
@@ -14,7 +14,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: liveness
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     args:
     - /bin/sh
     - -c

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: memory-test-ctr
-    image: polinux/stress
+    image: containerstack/alpine-stress:latest
     resources:
       limits:
         memory: "${memory_size}"

--- a/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -12,13 +12,13 @@ spec:
   runtimeClassName: kata
   containers:
   - name: c1
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     resources:
       limits:
         cpu: "500m"
   - name: c2
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
       - sleep
       - "10"

--- a/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: test-projected-volume
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     volumeMounts:
     - name: all-in-one

--- a/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -21,5 +21,5 @@ spec:
       runtimeClassName: kata
       containers:
       - name: pod-quota-demo
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: envars-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     env:
     - name: SECRET_USERNAME

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["/bin/sh", "-c", "tail -f /dev/null"]
       volumeMounts:
           # name must match the volume name below

--- a/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -14,5 +14,5 @@ spec:
     runAsUser: 1000
   containers:
   - name: sec-text
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
@@ -16,14 +16,14 @@ spec:
     emptyDir: {}
   containers:
   - name: busybox-first-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     volumeMounts:
     - name: shared-data
       mountPath: /tmp
     command: ["/bin/sh"]
     args: ["-c", "tail -f /dev/null"]
   - name: busybox-second-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     volumeMounts:
     - name: shared-data
       mountPath: /tmp

--- a/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -18,11 +18,11 @@ spec:
   - name: test
     securityContext:
       privileged: true
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
   initContainers:
   - name: init-sys
     securityContext:
       privileged: true
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ['sh', '-c', 'echo "64000" > /proc/sys/vm/max_map_count']

--- a/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -16,7 +16,7 @@ spec:
        claimName: pv-claim
   containers:
     - name: pv-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       ports:
       command:
         - sleep

--- a/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: master
-        image: redis
+        image: quay.io/libpod/redis
         resources:
           requests:
             cpu: 100m

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginxtest
-        image: "${nginx_version}"
+        image: quay.io/sjenning/${nginx_version}
         ports:
         - containerPort: 80

--- a/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: c1
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
       - sh
     tty: true

--- a/versions.yaml
+++ b/versions.yaml
@@ -33,7 +33,7 @@ docker_images:
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
-    version: "1.17.0-alpine"
+    version: "1.15-alpine"
 
 externals:
   description: "Third-party projects used specifically for testing"


### PR DESCRIPTION
The reason for such change is the new Docke Hub pull rate limit,
which is hitting us quite hard.

https://www.docker.com/increase-rate-limits

Fixes: #3120

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>