### PR TITLE
tests: Exclude *pb_test.go from SPDX header checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -460,6 +460,7 @@ static_check_license_headers()
 			--exclude="LICENSE" \
 			--exclude="*.md" \
 			--exclude="*.pb.go" \
+			--exclude="*pb_test.go" \
 			--exclude="*.png" \
 			--exclude="*.pub" \
 			--exclude="*.service" \


### PR DESCRIPTION
static_check_license_headers() correctly excludes *.pb.go files, which are
generated from .proto files.  However, it doesn't exclude *pb_test.go
which are also generated (from oci.proto and health.proto).  This can cause
bogus CI failures.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>