### PR TITLE
tests/cri-containerd: Skip TestContainerListStatsWithSandboxIdFilter with QEMU

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -18,6 +18,7 @@ RUNTIME=${RUNTIME:-containerd-shim-kata-v2}
 SHIMV2_TEST=${SHIMV2_TEST:-""}
 FACTORY_TEST=${FACTORY_TEST:-""}
 KILL_VMM_TEST=${KILL_VMM_TEST:-""}
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 default_runtime_type="io.containerd.runtime.v1.linux"
 # Type of containerd runtime to be tested
@@ -260,7 +261,7 @@ main() {
 	TestSandboxCleanRemove
 	)
 
-	if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
+	if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 		issue="https://github.com/kata-containers/tests/issues/2318"
 		info "${KATA_HYPERVISOR} fails with TestContainerListStatsWithSandboxIdFilter }"
 		info "see ${issue}"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -261,7 +261,8 @@ main() {
 	TestSandboxCleanRemove
 	)
 
-	if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
+	if [[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" || \
+		"${KATA_HYPERVISOR}" == "qemu" ]]; then
 		issue="https://github.com/kata-containers/tests/issues/2318"
 		info "${KATA_HYPERVISOR} fails with TestContainerListStatsWithSandboxIdFilter }"
 		info "see ${issue}"


### PR DESCRIPTION
On commit fa5b6af50e8382f TestContainerListStatsWithSandboxIdFilter
is skipped from cri-containerd test suite for the Cloud Hypervisor.

This test is also failing with QEMU, so skip it as well.

Fixes #2329

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>