### PR TITLE
k8s: Change pod spec used in k8s-copy-file.bats

### DIFF
--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -11,18 +11,22 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 setup() {
 	busybox_image="busybox"
 	export KUBECONFIG="$HOME/.kube/config"
-	first_pod_name="first-test"
-	second_pod_name="second-test"
+	first_pod_name="pod-first-test"
+	first_ctr_name="ctr-first-test"
+	second_pod_name="pod-second-test"
+	second_ctr_name="ctr-second-test"
 	# Pull the images before launching workload.
 	sudo -E crictl pull "$busybox_image"
 
 	get_pod_config_dir
 	first_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$first_pod_config"
-	sed -i "s/NAME/${first_pod_name}/" "$first_pod_config"
+	sed -i "s/POD_NAME/${first_pod_name}/" "$first_pod_config"
+	sed -i "s/CTR_NAME/${first_ctr_name}/" "$first_pod_config"
 	second_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$second_pod_config"
-	sed -i "s/NAME/${second_pod_name}/" "$second_pod_config"
+	sed -i "s/POD_NAME/${second_pod_name}/" "$second_pod_config"
+	sed -i "s/CTR_NAME/${second_ctr_name}/" "$second_pod_config"
 
 	uts_cmd="ls -la /proc/self/ns/uts"
 	ipc_cmd="ls -la /proc/self/ns/ipc"

--- a/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -6,13 +6,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: NAME
+  name: POD_NAME
 spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   shareProcessNamespace: true
   containers:
-  - name: busybox
+  - name: CTR_NAME
     image: quay.io/prometheus/busybox:latest
     command:
       - sleep


### PR DESCRIPTION
Found that with this new spec (runtimeclass_workloads/busybox-template.yaml),
the k8s-copy-file.bats is stable. Use this new spec to bring stability to the
CI while we debug the current failure.

Related:
https://github.com/kata-containers/kata-containers/issues/1227
https://github.com/kata-containers/tests/issues/3061

Fixes: #3140.
Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>