### PR TITLE
integration/kubernetes: tests improvements - part 1

### DIFF
--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -45,7 +45,7 @@ setup() {
 	# Check the total of requests
 	total_requests_container=$(kubectl exec $pod_name -c $container_name cat $sharessyspath)
 
-	[ $total_requests_container -eq $total_requests ]
+	[ "$total_requests_container" -eq "$total_requests" ]
 
 	# Check the cpus inside the container
 
@@ -55,7 +55,7 @@ setup() {
 
 	division_quota_period=$(echo $((total_cpu_quota/total_cpu_period)))
 
-	[ $division_quota_period -eq $total_cpu_container ]
+	[ "$division_quota_period" -eq "$total_cpu_container" ]
 }
 
 teardown() {

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -31,10 +31,12 @@ setup() {
 
 	retries="10"
 
+	num_cpus_cmd='grep -e "^processor" /proc/cpuinfo |wc -l'
 	# Check the total of cpus
 	for _ in $(seq 1 "$retries"); do
 		# Get number of cpus
-		total_cpus_container=$(kubectl exec pod/"$pod_name" -c "$container_name" cat /proc/cpuinfo |grep processor|wc -l)
+		total_cpus_container=$(kubectl exec pod/"$pod_name" -c "$container_name" \
+			-- sh -c "$num_cpus_cmd")
 		# Verify number of cpus
 		[ "$total_cpus_container" -le "$total_cpus" ]
 		[ "$total_cpus_container" -eq "$total_cpus" ] && break
@@ -43,15 +45,18 @@ setup() {
 	[ "$total_cpus_container" -eq "$total_cpus" ]
 
 	# Check the total of requests
-	total_requests_container=$(kubectl exec $pod_name -c $container_name cat $sharessyspath)
+	total_requests_container=$(kubectl exec $pod_name -c $container_name \
+		-- sh -c "cat $sharessyspath")
 
 	[ "$total_requests_container" -eq "$total_requests" ]
 
 	# Check the cpus inside the container
 
-	total_cpu_quota=$(kubectl exec $pod_name -c $container_name cat $quotasyspath)
+	total_cpu_quota=$(kubectl exec $pod_name -c $container_name \
+		-- sh -c "cat $quotasyspath")
 
-	total_cpu_period=$(kubectl exec $pod_name -c $container_name cat $periodsyspath)
+	total_cpu_period=$(kubectl exec $pod_name -c $container_name \
+		-- sh -c "cat $periodsyspath")
 
 	division_quota_period=$(echo $((total_cpu_quota/total_cpu_period)))
 

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -26,9 +26,11 @@ setup() {
 	retries="10"
 	max_number_cpus="3"
 
+	num_cpus_cmd='cat /proc/cpuinfo |grep processor|wc -l'
 	for _ in $(seq 1 "$retries"); do
 		# Get number of cpus
-		number_cpus=$(kubectl exec pod/"$pod_name" -c "$container_name" cat /proc/cpuinfo |grep processor|wc -l)
+		number_cpus=$(kubectl exec pod/"$pod_name" -c "$container_name" \
+			-- sh -c "$num_cpus_cmd")
 		# Verify number of cpus
 		[ "$number_cpus" -le "$max_number_cpus" ]
 		[ "$number_cpus" -eq "$max_number_cpus" ] && break

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -25,13 +25,15 @@ setup() {
 	kubectl wait --for=condition=Ready pod "$pod_name"
 
 	# Check PID from first container
-	first_pid_container=$(kubectl exec $pod_name -c $first_container_name ps | grep "/pause")
+	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \
+		-- ps | grep "/pause")
 	# Verify that is not empty
 	check_first_pid=$(echo $first_pid_container | wc -l)
 	[ "$check_first_pid" == "1" ]
 
 	# Check PID from second container
-	second_pid_container=$(kubectl exec $pod_name -c $second_container_name ps | grep "/pause")
+	second_pid_container=$(kubectl exec $pod_name -c $second_container_name \
+		-- ps | grep "/pause")
 	# Verify that is not empty
 	check_second_pid=$(echo $second_pid_container | wc -l)
 	[ "$check_second_pid" == "1" ]


### PR DESCRIPTION
This PR containers improvements to the kubernetes bats tests.

It is fixed:

* Issue #3134 - On k8s-cpu-ns.bats test there some checks where the variables aren't double-quoted and that can end up on "unary operator expected" like below:

17:21:33 # /tmp/bats-run-123469/bats.123514.src: line 48: [: -eq: unary operator expected
17:21:33 # pod "constraints-cpu-test" deleted
17:21:33 Failed at 86: bats "${K8S_TEST_ENTRY}"

* Issue #3135 - The `kubectl exec POD CMD` is deprecated in favor of `kubectl exec POD -- CMD` but some of our tests still use the former syntax.
