### PR TITLE
.ci/setup_env_centos.sh: Fix "too many arguments" error

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -22,7 +22,7 @@ fi
 echo "skip_missing_names_on_install=0" | sudo tee -a /etc/yum.conf
 
 # Check EPEL repository is enabled on CentOS
-if [ -z $(yum repolist | grep "Extra Packages") ]; then
+if [ -z "$(yum repolist | grep 'Extra Packages')" ]; then
 	echo >&2 "ERROR: EPEL repository is not enabled on CentOS."
 	# Enable EPEL repository on CentOS
 	sudo -E yum install -y wget rpm


### PR DESCRIPTION
In case the environment has already the extra packages repository
set, the script will fail with "too many arguments" message. Fixed
it by double-quoting the command.

Fixes #3137

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>