### PR TITLE
Prepare 2.x for OpenShift CI - part 2

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is evoked within an OpenShift Build to product the binary image,
+# which will contain the Kata Containers installation into a given destination
+# directory.
+#
+
+set -e
+
+export PATH="${GOPATH}/bin:$PATH"
+
+cidir="$(dirname "$0")/.."
+source /etc/os-release
+
+source "${cidir}/lib.sh"
+
+[ -z "$1" ] && die "Usage: $0 path/to/install/dir"
+export DESTDIR="$1"
+info "Build and install Kata Containers at ${DESTDIR}"
+
+[ "$(id -u)" -ne 0 ] && die "$0 must be executed by privileged user"
+
+# Let the scripts know it is in OpenShift CI context.
+export OPENSHIFT_CI="true"
+
+# This script is evoked within a variant of CentOS container image in the
+# OpenShift Build process. So it was implemented for running in CentOS.
+[ "$ID" != "centos" ] && die "Expect the build root to be CentOS"
+# The scripts rely on sudo which is not installed in the build environment.
+yum install -y sudo
+"${cidir}/setup_env_centos.sh" default
+
+# The build root container has already golang installed, let's remove it
+# so that it will use the version required by kata.
+yum remove -y golang
+"${cidir}/install_go.sh" -p -f
+
+# Let's ensure scripts don't try things with Podman.
+export TEST_CGROUPSV2="false"
+
+# Configure to use the standard QEMU.
+export experimental_qemu="false"
+export experimental_kernel="false"
+
+# Configure to use the initrd rootfs.
+export TEST_INITRD="yes"
+
+# Build a dracut-based image.
+export BUILD_METHOD="dracut"
+
+# Configure to use vsock.
+export USE_VSOCK="yes"
+
+# Configure the QEMU machine type.
+export MACHINETYPE="q35"
+
+# Enable SELinux.
+export FEATURE_SELINUX="yes"
+
+# The default /usr prefix makes the deployment on Red Hat CoreOS (rhcos) more
+# complex because that directory is read-only by design. Another prefix than
+# /opt/kata is problematic too because QEMU either got from Kata Containers
+# Jenkins or built locally is uncompressed in that directory.
+export PREFIX="/opt/kata"
+
+"${cidir}/install_kata_kernel.sh"
+
+# osbuilder's make define a VERSION variable which value might clash with
+# VERSION sourced from /etc/os-release.
+unset VERSION
+"${cidir}/install_kata_image.sh"
+
+"${cidir}/install_runtime.sh"

--- a/.ci/openshift-ci/cluster/configs/crio_kata.conf
+++ b/.ci/openshift-ci/cluster/configs/crio_kata.conf
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+[crio.runtime]
+manage_ns_lifecycle = true
+
+[crio.runtime.runtimes.runc]
+runtime_path = ""
+runtime_type = "oci"
+runtime_root = "/run/runc"
+
+[crio.runtime.runtimes.kata]
+runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
+runtime_type = "vm"
+runtime_root = "/run/vc"

--- a/.ci/openshift-ci/cluster/configs/selinux.conf
+++ b/.ci/openshift-ci/cluster/configs/selinux.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+SELINUX=permissive
+SELINUXTYPE=targeted

--- a/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start the kata-containers installer daemonset on worker nodes
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: ${DAEMONSET_NAME}
+spec:
+    selector:
+        matchLabels:
+            name: ${DAEMONSET_LABEL}
+    template:
+        metadata:
+            labels: {name: ${DAEMONSET_LABEL}}
+        spec:
+            nodeSelector:
+              node-role.kubernetes.io/worker: ""
+            containers:
+              - name: kata-installer
+                image: ${KATA_INSTALLER_IMG}
+                securityContext:
+                  privileged: true
+                  runAsUser: 0
+                  stdin: true
+                  stdinOnce: true
+                  tty: true
+                volumeMounts:
+                  - mountPath: /host
+                    name: host
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                  fieldRef:
+                   fieldPath: spec.nodeName
+            hostNetwork: true
+            hostPID: true
+            #nodeName: $NODE_NAME
+            restartPolicy: Always
+            volumes:
+              - name: host
+                hostPath:
+                  path: /
+                  type: Directory
+updateStrategy:
+    rollingUpdate:
+        maxUnavailable: 1
+    type: RollingUpdate

--- a/.ci/openshift-ci/cluster/deployments/machineconfig_kata_runtime.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/machineconfig_kata_runtime.yaml.in
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configure the kata-containers drop-in for CRI-O on worker nodes
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-kata
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+              source: data:text/plain;charset=utf-8;base64,${KATA_CRIO_CONF_BASE64}
+        filesystem: root
+        mode: 0420
+        path: /etc/crio/crio.conf.d/50-kata

--- a/.ci/openshift-ci/cluster/deployments/machineconfig_selinux.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/machineconfig_selinux.yaml.in
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configure SELinux on worker nodes.
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 51-kata-selinux
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+              source: data:text/plain;charset=utf-8;base64,${SELINUX_CONF_BASE64}
+        filesystem: root
+        mode: 0644
+        path: /etc/selinux/config

--- a/.ci/openshift-ci/cluster/deployments/runtimeclass_kata.yaml
+++ b/.ci/openshift-ci/cluster/deployments/runtimeclass_kata.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Define the "kata" runtime class
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+  name: kata
+handler: kata
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script installs the built kata-containers in the test cluster,
+# and configure a runtime.
+
+scripts_dir=$(dirname $0)
+deployments_dir=${scripts_dir}/deployments
+configs_dir=${scripts_dir}/configs
+
+source ${scripts_dir}/../../lib.sh
+
+# Set to 'yes' if you want to configure SELinux to permissive on the cluster
+# workers.
+#
+SELINUX_PERMISSIVE=${SELINUX_PERMISSIVE:-no}
+
+# The daemonset name.
+#
+export DAEMONSET_NAME="kata-deploy"
+
+# The label attached to the nodes which should have Kata Containers installed.
+#
+export DAEMONSET_LABEL="kata-deploy"
+
+# Wait all worker nodes reboot.
+#
+# Params:
+#   $1 - timeout in seconds (default to 900).
+#
+wait_for_reboot() {
+	local delta="${1:-900}"
+	local sleep_time=60
+	declare -A BOOTIDS
+	local workers=($(oc get nodes | \
+		awk '{if ($3 == "worker") { print $1 } }'))
+	# Get the boot ID to compared it changed over time.
+	for node in ${workers[@]}; do
+		BOOTIDS[$node]=$(oc get -o jsonpath='{.status.nodeInfo.bootID}'\
+			node/$node)
+		echo "Wait $node reboot"
+	done
+
+	echo "Set timeout to $delta seconds"
+	timer_start=$(date +%s)
+	while [ ${#workers[@]} -gt 0 ]; do
+		sleep $sleep_time
+		now=$(date +%s)
+		if [ $(($timer_start + $delta)) -lt $now ]; then
+			echo "Timeout: not all workers rebooted"
+			return 1
+		fi
+		echo "Checking after $(($now - $timer_start)) seconds"
+		for i in ${!workers[@]}; do
+			current_id=$(oc get \
+				-o jsonpath='{.status.nodeInfo.bootID}' \
+				node/${workers[i]})
+			if [ "$current_id" != ${BOOTIDS[${workers[i]}]} ]; then
+				echo "${workers[i]} rebooted"
+				unset workers[i]
+			fi
+		done
+	done
+}
+
+[ "$(id -u)" -ne 0 ] && die "$0 must be executed by privileged user"
+
+oc project default
+
+worker_nodes=$(oc get nodes |  awk '{if ($3 == "worker") { print $1 } }')
+num_nodes=$(echo $worker_nodes | wc -w)
+[ $num_nodes -ne 0 ] || \
+	die "No worker nodes detected. Something is wrong with the cluster"
+
+info "Set installing state annotation and label on all worker nodes"
+for node in $worker_nodes; do
+	info "Deploy kata Containers in worker node $node"
+	oc annotate --overwrite nodes $node \
+		kata-install-daemon.v1.openshift.com/state=installing
+	oc label --overwrite node $node "${DAEMONSET_LABEL}=true"
+done
+
+info "Applying the Kata Containers installer daemonset"
+if [ -z "$KATA_INSTALLER_IMG" ]; then
+	# The yaml file uses $IMAGE_FORMAT which gives the
+	# registry/image_stream:image format
+	export KATA_INSTALLER_IMG=$(echo $IMAGE_FORMAT"kata-installer" \
+		| envsubst)
+fi
+envsubst < ${deployments_dir}/daemonset_kata-installer.yaml.in | oc apply -f -
+
+oc get pods
+oc get ds
+ds_pods=($(oc get pods | awk -v ds=$DAEMONSET_NAME '{if ($1 ~ ds) { print $1 } }'))
+cnt=5
+while [[ ${#ds_pods[@]} -gt 0 && $cnt -ne 0 ]]; do
+	sleep 120
+	for i in ${!ds_pods[@]}; do
+		info "Check daemonset ${ds_pods[i]} is running"
+		rc=$(oc exec ${ds_pods[i]} -- cat /tmp/kata_install_status 2> \
+			/dev/null)
+		if [ -n "$rc" ]; then
+			info "Finished with status: $rc"
+			oc describe pods ${ds_pods[i]}
+			oc logs ${ds_pods[i]}
+			unset ds_pods[i]
+		else
+			info "Running"
+		fi
+	done
+	cnt=$((cnt-1))
+done
+
+if [ $cnt -eq 0 ]; then
+	for p in ${ds_pods[@]}; do
+		info "daemonset $p did not finish"
+		oc describe pods $p
+		oc logs $p
+	done
+	die "Kata Containers seems not installed on some nodes"
+fi
+
+# Finally remove the installer daemonset
+info "Deleting the Kata Containers installer daemonset"
+oc delete ds/${DAEMONSET_NAME}
+
+# Apply the CRI-O configuration
+info "Configuring Kata Containers runtime for CRI-O"
+if [ -z "$KATA_CRIO_CONF_BASE64" ]; then
+	export KATA_CRIO_CONF_BASE64=$(echo \
+		$(cat $configs_dir/crio_kata.conf|base64) | sed -e 's/\s//g')
+fi
+envsubst < ${deployments_dir}/machineconfig_kata_runtime.yaml.in | oc apply -f -
+oc get -f ${deployments_dir}/machineconfig_kata_runtime.yaml.in || \
+	die "kata machineconfig not found"
+
+# The machineconfig which installs the kata drop-in in CRI-O will trigger a
+# worker reboot.
+wait_for_reboot
+
+# Add a runtime class for kata
+info "Adding the kata runtime class"
+oc apply -f ${deployments_dir}/runtimeclass_kata.yaml
+oc get runtimeclass/kata || die "kata runtime class not found"
+
+# Set SELinux to permissive mode
+if [ ${SELINUX_PERMISSIVE} == "yes" ]; then
+	info "Configuring SELinux"
+	if [ -z "$SELINUX_CONF_BASE64" ]; then
+		export SELINUX_CONF_BASE64=$(echo \
+			$(cat $configs_dir/selinux.conf|base64) | \
+			sed -e 's/\s//g')
+	fi
+	envsubst < ${deployments_dir}/machineconfig_selinux.yaml.in | \
+		oc apply -f -
+	oc get machineconfig/51-kata-selinux || \
+		die "SELinux machineconfig not found"
+	# The new SELinux configuration will trigger another reboot.
+	wait_for_reboot
+fi
+
+# At this point kata is installed on workers
+info "Set state annotation to installed on all worker nodes"
+for node in $worker_nodes; do
+	oc annotate --overwrite nodes $node \
+		kata-install-daemon.v1.openshift.com/state=installed
+done

--- a/.ci/openshift-ci/images/Dockerfile.installer
+++ b/.ci/openshift-ci/images/Dockerfile.installer
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Red Hat Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the image which wraps the kata-containers installation along with the
+# install script. It is used on a daemonset to deploy kata on OpenShift.
+#
+FROM centos:7
+
+RUN yum install -y rsync
+
+# Load the installation files.
+COPY ./_out ./_out
+
+# QEMU was built separated from other components (agent, runtime...) so the
+# tarball's content should be merged with the remain of the installation.
+COPY ./kata-static-qemu.tar.gz .
+RUN tar -C ./_out/build_install -xvzf ./kata-static-qemu.tar.gz
+
+COPY ./entrypoint.sh /usr/bin
+
+ENTRYPOINT /usr/bin/entrypoint.sh

--- a/.ci/openshift-ci/images/entrypoint.sh
+++ b/.ci/openshift-ci/images/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Synchronize the kata-containers installation with in the host filesystem.
+#
+set -e
+set -o nounset
+
+install_status=1
+
+SRC="${PWD}/_out/build_install"
+
+# Expect the host filesystem to be mounted in following path.
+HOST_MOUNT=/host
+
+function terminate()
+{
+	# Sending a termination message. Can be used by an orchestrator that
+	# will look into this file to check the installation has finished
+	# and is good.
+	#
+	echo "INFO: the installation status is $install_status"
+	echo "$install_status" >> /tmp/kata_install_status
+
+	# By using it in an openshift daemonset it should spin forever until an
+	# orchestrator kills it.
+	#
+	echo "INFO: spinning until the orchestrator kill this process"
+	tail -f /dev/null
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "ERROR: $0 must be executed by privileged user"
+	terminate
+fi
+
+# Some files are copied over /usr which on Red Hat CoreOS (rhcos) is mounted
+# read-only by default. So re-mount it as read-write, otherwise files won't
+# get copied.
+echo "INFO: re-mount ${HOST_MOUNT}/usr on rw mode"
+mount -o remount,rw "${HOST_MOUNT}/usr"
+
+# The host's '/opt' and '/usr/local' are symlinks to, respectively, '/var/opt'
+# and '/var/usrlocal'. Adjust the installation files accordingly.
+#
+cd $SRC
+if [ -d 'opt' ]; then
+	mkdir -p var
+	mv opt var
+fi
+
+if [ -d "usr/local" ]; then
+	mkdir -p var
+	mv usr/local var/usrlocal
+fi
+
+# Copy the installation over the host filesystem.
+echo "INFO: copy the Kata Containers installation over $HOST_MOUNT"
+rsync -O -a . "$HOST_MOUNT"
+
+# Ensure the binaries are searcheable via PATH. Notice it expects that
+# kata has been built with PREFIX=/opt/kata.
+#
+chroot "$HOST_MOUNT" sh -c 'for t in /opt/kata/bin/*; do ln -s "$t" /var/usrlocal/bin/; done'
+
+# Check the installation is good (or not).
+echo "INFO: run kata-check to check the installation is fine"
+chroot "$HOST_MOUNT" /opt/kata/bin/kata-runtime kata-check
+install_status=$?
+
+terminate

--- a/.ci/openshift-ci/qemu-build-pre.sh
+++ b/.ci/openshift-ci/qemu-build-pre.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is used to create a modified copy the QEMU dockerfile so that QEMU
+# can be built on OpenShift CI build pipeline.
+#
+
+set -e
+
+export GOPATH="${GOPATH:-/go}"
+script_dir="$(realpath $(dirname $0))"
+source "${script_dir}/../lib.sh"
+pkg_dir="${kata_repo_dir}/tools/packaging"
+
+kata_version=${kata_version:-}
+prefix=${PREFIX:-/opt/kata}
+
+pushd "$pkg_dir" > /dev/null
+source ./scripts/lib.sh
+qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url" "${kata_version}")
+
+qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version" "${kata_version}")
+if ! (git ls-remote --heads "${qemu_url}" | grep -q "refs/heads/${qemu_version}"); then
+        qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.tag" "${kata_version}")
+fi
+
+# Create a new dockerfile and replace the ARG statements with values
+# from versions.yml.
+cp -f static-build/qemu/{Dockerfile,Dockerfile.ci}
+sed -i -e 's#\(ARG QEMU_REPO\).*#\1="'"$qemu_url"'"#' static-build/qemu/Dockerfile.ci
+sed -i -e 's#\(ARG QEMU_VERSION\).*#\1="'${qemu_version}'"#' static-build/qemu/Dockerfile.ci
+sed -i -e 's#\(ARG PREFIX\).*#\1="'${prefix}'"#' static-build/qemu/Dockerfile.ci
+sed -i -e 's/\(ARG QEMU_TARBALL\).*/\1="kata-static-qemu.tar.gz"/' static-build/qemu/Dockerfile.ci
+popd

--- a/.ci/openshift-ci/run_smoke_test.sh
+++ b/.ci/openshift-ci/run_smoke_test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run a smoke test.
+#
+
+script_dir=$(dirname $0)
+source ${script_dir}/../lib.sh
+
+pod='http-server'
+
+# Create a pod.
+#
+info "Creating the ${pod} pod"
+oc apply -f ${script_dir}/smoke/${pod}.yaml || \
+	die "failed to create ${pod} pod"
+
+# Check it eventually goes to 'running'
+#
+wait_time=600
+sleep_time=10
+cmd="oc get pod/${pod} -o jsonpath='{.status.containerStatuses[0].state}' | \
+	grep running > /dev/null"
+info "Wait until the pod gets running"
+waitForProcess $wait_time $sleep_time "$cmd" || timed_out=$?
+if [ -n "$timed_out" ]; then
+	oc describe pod/${pod}
+	oc delete pod/${pod}
+	die "${pod} not running"
+fi
+info "${pod} is running"
+
+# Add a file with the hello message
+#
+hello_file=/tmp/hello
+hello_msg='Hello World'
+oc exec ${pod} -- sh -c "echo $hello_msg > $hello_file"
+
+info "Creating the service and route"
+oc apply -f ${script_dir}/smoke/service.yaml
+sleep 60
+
+host=$(oc get route/http-server-route -o jsonpath={.spec.host})
+# The route to port 80 should work and it should serve the pod's '/' filesystem
+#
+curl ${host}:80${hello_file} -s -o hello_msg.txt
+grep "${hello_msg}" hello_msg.txt > /dev/null
+test_status=$?
+if [ $test_status -eq 0 ]; then
+	info "HTTP server is working"
+else
+	info "HTTP server is unreachable"
+fi
+
+info "Deleting resources created"
+oc delete -f ${script_dir}/smoke/service.yaml
+
+# Delete the pod.
+#
+info "Deleting the ${pod} pod"
+oc delete pod/${pod} || test_status=$?
+
+exit $test_status

--- a/.ci/openshift-ci/smoke/http-server.yaml
+++ b/.ci/openshift-ci/smoke/http-server.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Define the pod for a http server app.
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-server
+  labels:
+    app: http-server-app
+spec:
+  containers:
+    - name: http-server
+      image: fedora
+      ports:
+        - containerPort: 8080
+      command: ["python3"]
+      args: [ "-m", "http.server", "8080"]
+  runtimeClassName: kata

--- a/.ci/openshift-ci/smoke/service.yaml
+++ b/.ci/openshift-ci/smoke/service.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create the service on port 80 for the http-server app.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-server-service
+spec:
+  selector:
+    app: http-server-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+# Create the route to the app's service '/'.
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: http-server-route
+spec:
+  path: "/"
+  to:
+    kind: Service
+    name: http-server-service

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -x
+
+script_dir=$(dirname $0)
+source ${script_dir}/../lib.sh
+
+# Make oc and kubectl visible
+export PATH=/tmp/shared:$PATH
+
+oc version || die "Test cluster is unreachable"
+
+info "Install and configure kata into the test cluster"
+${script_dir}/cluster/install_kata.sh || die "Failed to install kata-containers"

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -5,10 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -x
-
 script_dir=$(dirname $0)
 source ${script_dir}/../lib.sh
+
+suite=$1
+if [ -z "$1" ]; then
+	suite='smoke'
+fi
 
 # Make oc and kubectl visible
 export PATH=/tmp/shared:$PATH
@@ -17,3 +20,8 @@ oc version || die "Test cluster is unreachable"
 
 info "Install and configure kata into the test cluster"
 ${script_dir}/cluster/install_kata.sh || die "Failed to install kata-containers"
+
+info "Run test suite: $suite"
+test_status='PASS'
+${script_dir}/run_${suite}_test.sh || test_status='FAIL'
+info "Test suite: $suite: $test_status"


### PR DESCRIPTION
This is the continuation of part 1 (https://github.com/kata-containers/tests/pull/3102) towards getting Kata Containers 2.x on-board into OpenShift CI.

This PR add scripts and files to build and install Kata in a Openshift cluster as well as run a smoke test. Most of the commits are forward-ports (simple cherry-pick and squash).
