### PR TITLE
ci/lib.sh: fix bug of pid match error.

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -192,6 +192,7 @@ kill_stale_process()
 	extract_kata_env
 	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do
+		[ -z "${stale_process}" ] && continue
 		local pids=$(pgrep -d ' ' -f "${stale_process}")
 		if [ -n "$pids" ]; then
 			sudo kill -9 ${pids} || true


### PR DESCRIPTION
In .ci/lib.sh, `pgrep -d ' ' -f "${stale_process}"` will output all of the
pids in the system if "stale_process" is NULL. Then the next command -
`kill -9 $pids` will corrupt the system.

Fixes: #3141
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @chavafg @lifupan 