### PR TITLE
tests: Make copyright header check less picky

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -425,7 +425,7 @@ static_check_license_headers()
 	local -r spdx_tag="SPDX-License-Identifier"
 	local -r spdx_license="Apache-2.0"
 	local -r license_pattern="${spdx_tag}: ${spdx_license}"
-	local -r copyright_pattern="Copyright \(c\) [[:digit:]]{4}"
+	local -r copyright_pattern="Copyright"
 
 	local header_checks=()
 


### PR DESCRIPTION
The copyright header check in static_check_license_headers() requires
a "(C)" and a year.  Red Hat, for one, recommends to its employees omitting
both of those from copyright headers because:
 * The (C) is legally redundant with the word "Copyright"
 * The years are difficult to keep up to date and unnecessary

In order to allow copyright headers as recommended by Red Hat (and maybe
others), make static_check_license_headers() less picky.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>