### PR TITLE
ci: Do not install musl Rust target for s390x

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -28,7 +28,7 @@ export PATH="${PATH}:${HOME}/.cargo/bin"
 echo "Install rust"
 rustup toolchain install ${version}
 rustup default ${version}
-if [ "${rustarch}" == "powerpc64le" ]; then
+if [ "${rustarch}" == "powerpc64le" ] || [ "${rustarch}" == "s390x" ] ; then
 	rustup target add ${rustarch}-unknown-linux-gnu
 else
 	rustup target add ${rustarch}-unknown-linux-musl


### PR DESCRIPTION
s390x uses a glibc Rust target since musl is not available, therefore, a GNU target should be added on s390x when installing Rust.

Fixes: #3159