### PR TITLE
ci: Enable minimal kubernetes-e2e tests with CRI-O

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -242,6 +242,13 @@ case "${CI_JOB}" in
 		export TEST_CRIO="true"
 	fi
 	;;
+"CRIO_K8S_MINIMAL")
+	export MINIMAL_CONTAINERD_K8S_E2E="true"
+	export CRI_CONTAINERD="no"
+	export KUBERNETES="yes"
+	export CRIO="yes"
+	export OPENSHIFT="no"
+	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -34,6 +34,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
+	"CRIO_K8S_MINIMAL")
+		echo "INFO: Running kubernetes tests (minimal) with CRI-O"
+		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"
+		;;
 	"CLOUD-HYPERVISOR-K8S-CONTAINERD")
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"


### PR DESCRIPTION
In the saga to achieve tests-parity between containerd and CRI-O, let's
enable the minimal kubernetes-e2e tests to run also with CRI-O.

The main difference here between the containerd job is that this job is
running on a Fedora system, instead of using an Ubuntu one.

Fixes: #3075

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit f2de04635fd1d8109dd4f0a824795f847b5e5788)