### PR TITLE
tests: Enable hypervisor stability kill test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ swarm:
 stability:
 	cd integration/stability && \
 	ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
+	cd integration/stability && ./hypervisor_stability_kill_test.sh
 
 shimv2:
 	bash integration/containerd/shimv2/shimv2-tests.sh

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -171,6 +171,16 @@ clean_env()
 	fi
 }
 
+clean_env_ctr()
+{
+	check_containers=$(sudo ctr c list -q | wc -l)
+	if ((${check_containers})); then
+		sudo ctr tasks kill $(sudo ctr task list -q)
+		sudo ctr tasks rm -f $(sudo ctr task list -q)
+		sudo ctr c rm $(sudo ctr c list -q)
+	fi
+}
+
 get_pod_config_dir() {
 	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	info "k8s configured to use runtimeclass"


### PR DESCRIPTION
This PR updates the hypervisor stability test to work with ctr.

Fixes #3166

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>