### PR TITLE
ci/install_runtime: export PATH on sudo env properly

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -57,7 +57,7 @@ build_install_shim_v2(){
 	fi
 	pushd "$runtime_src_path"
 	make
-	sudo -E make install
+	sudo -E PATH=$PATH make install
 	popd
 }
 


### PR DESCRIPTION
The .ci/install_go.sh script is going to install go into /usr/local/go/bin. If
I have (or some script) exported PATH as PATH=/usr/local/go/bin:$PATH and run
.ci/install_runtime.sh it isn't guaranteed it will pick up that golang version to
build the runtime.  That happen because whether `sudo -E` will preserve PATH or not
depend on how sudoers security policy was configured. Thus, the script was changed
to pass PATH explicitly in the sudo's call.

Fixes #3174 

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>