### PR TITLE
ci: Move to stable virtiofs

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -52,8 +52,6 @@ echo "Install runtime"
 case "${KATA_HYPERVISOR}" in
 	"cloud-hypervisor")
 		"${cidir}/install_cloud_hypervisor.sh"
-		echo "Installing experimental_qemu to install virtiofsd"
-		export experimental_qemu=true
 		install_qemu
 		;;
 	"firecracker")

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -154,6 +154,19 @@ main() {
 	else
 		build_and_install_kernel
 	fi
+
+	if [ "${experimental_kernel}" == "true" ]; then
+		info  "Symlink expermiental kernel to default kernel path"
+		local vmlinux_binary_name="vmlinux-${current_kernel_version}"
+		local vmlinux_binary_path="${kernel_dir}/${vmlinux_binary_name}"
+		vmlinux_symlink="${kernel_dir}/vmlinux.container"
+		sudo -E ln -sf "${vmlinux_binary_path}" "${vmlinux_symlink}"
+
+		local vmlinuz_binary_name="vmlinuz-${current_kernel_version}"
+		local vmlinuz_binary_path="${kernel_dir}/${vmlinuz_binary_name}"
+		vmlinuz_symlink="${kernel_dir}/vmlinuz.container"
+		sudo -E ln -sf "${vmlinuz_binary_path}" "${vmlinuz_symlink}"
+	fi
 }
 
 main

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -20,10 +20,12 @@ KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.tag")
 QEMU_TAR="kata-static-qemu-virtiofsd.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
-QEMU_PATH="${DESTDIR:-}/opt/kata/bin/qemu-virtiofs-system-x86_64"
-VIRTIOFS_PATH="${DESTDIR:-}/opt/kata/bin/virtiofsd"
+QEMU_PATH="${DESTDIR:-}/opt/kata/bin/qemu-virtiofs-system-${arch}"
 bindir="${DESTDIR:-}/usr/bin"
-qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
+DEST_QEMU_PATH="${bindir}/qemu-system-$(uname -m)"
+VIRTIOFSD_PATH="${DESTDIR:-}/opt/kata/bin/virtiofsd-experimental"
+DEST_VIRTIOFSD_PATH="${bindir}/virtiofsd"
+qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly-${arch}/${cached_artifacts_path}"
 
 uncompress_experimental_qemu() {
 	local qemu_tar_location="$1"
@@ -37,8 +39,8 @@ install_cached_qemu_experimental() {
 	curl -fsOL "${qemu_experimental_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_experimental_qemu "${QEMU_TAR}"
-	sudo -E ln -sf "${QEMU_PATH}" $bindir
-	sudo -E ln -sf "${VIRTIOFS_PATH}" $bindir
+	sudo -E ln -sf "${QEMU_PATH}" "${DEST_QEMU_PATH}"
+	sudo -E ln -sf "${VIRTIOFSD_PATH}" "${DEST_VIRTIOFSD_PATH}"
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -39,8 +39,6 @@ install_cached_qemu_experimental() {
 	curl -fsOL "${qemu_experimental_latest_build_url}/sha256sum-${QEMU_TAR}" || return 1
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_experimental_qemu "${QEMU_TAR}"
-	sudo -E ln -sf "${QEMU_PATH}" "${DEST_QEMU_PATH}"
-	sudo -E ln -sf "${VIRTIOFSD_PATH}" "${DEST_VIRTIOFSD_PATH}"
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"
 }
@@ -48,8 +46,6 @@ install_cached_qemu_experimental() {
 build_and_install_static_experimental_qemu() {
 	build_experimental_qemu
 	uncompress_experimental_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
-	sudo -E ln -sf "${QEMU_PATH}" $bindir
-	sudo -E ln -sf "${VIRTIOFS_PATH}" $bindir
 }
 
 build_experimental_qemu() {
@@ -72,6 +68,10 @@ main() {
 	else
 		build_and_install_static_experimental_qemu
 	fi
+
+	info "Symlink experimental qemu to deault qemu path"
+	sudo -E ln -sf "${QEMU_PATH}" "${DEST_QEMU_PATH}"
+	sudo -E ln -sf "${VIRTIOFSD_PATH}" "${DEST_VIRTIOFSD_PATH}"
 }
 
 main

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -49,7 +49,7 @@ PKGDEFAULTSDIR="${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 # Note: This will also install the config file.
 build_and_install "${runtime_repo}" "" "true" "${tag}"
-experimental_qemu="${experimental_qemu:-false}"
+SHARED_FS="${SHARED_FS:-9pfs}"
 
 if [ -e "${NEW_RUNTIME_CONFIG}" ]; then
 	# Remove the legacy config file
@@ -76,7 +76,7 @@ case "${KATA_HYPERVISOR}" in
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"
 		;;
 	"qemu")
-		if [ "$experimental_qemu" == "true" ]; then
+		if [ "$SHARED_FS" == "virtiofs" ]; then
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-virtiofs.toml"
 		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -46,6 +46,11 @@ init_ci_flags() {
 	# Use experimental kernel
 	# Values: true|false
 	export experimental_kernel="false"
+	# Use experimental qemu
+	export experimental_qemu="false"
+	# shared fs to use
+	# Values: 9pfs|virtiofs
+	export SHARED_FS="9pfs"
 	# Run the kata-check checks
 	export RUN_KATA_CHECK="true"
 
@@ -210,7 +215,6 @@ case "${CI_JOB}" in
 "CLOUD-HYPERVISOR-PODMAN")
         export KATA_HYPERVISOR="cloud-hypervisor"
         export TEST_CGROUPSV2="true"
-        export experimental_kernel="true"
         ;;
 "CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s
@@ -223,10 +227,11 @@ case "${CI_JOB}" in
 	export TEST_CGROUPSV2="true"
 	;;
 "VIRTIOFS-METRICS-BAREMETAL")
-	export experimental_qemu="true"
-	export experimental_kernel="true"
 	export METRICS_CI="true"
+	export SHARED_FS="virtiofs"
 	export METRICS_CI_PROFILE="virtiofs-baremetal"
+	export experimental_kernel="true"
+	export experimental_qemu="true"
 	;;
 "SANDBOX_CGROUP_ONLY")
 	# Used by runtime makefile to enable option on intall
@@ -241,7 +246,6 @@ case "${CI_JOB}" in
 	export OPENSHIFT="no"
 	export TEST_CRIO="false"
 	export TEST_DOCKER="true"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-DOCKER")
 	export CRIO="no"
@@ -251,7 +255,6 @@ case "${CI_JOB}" in
 	export OPENSHIFT="no"
 	export TEST_CRIO="false"
 	export TEST_DOCKER="true"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD")
 	init_ci_flags
@@ -259,7 +262,6 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CRIO-MINIMAL")
 	init_ci_flags
@@ -268,7 +270,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	export MINIMAL_K8S_E2E="true"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-MINIMAL")
 	init_ci_flags
@@ -277,7 +278,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	export MINIMAL_K8S_E2E="true"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-SHIMV2-MINIMAL")
 	init_ci_flags
@@ -286,7 +286,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	export MINIMAL_K8S_E2E="true"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CRIO-FULL")
 	init_ci_flags
@@ -295,7 +294,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	export MINIMAL_K8S_E2E="false"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL")
 	init_ci_flags
@@ -304,15 +302,20 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	export MINIMAL_K8S_E2E="false"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-METRICS-BAREMETAL")
 	init_ci_flags
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export METRICS_CI="true"
-	export experimental_kernel="true"
 	export METRICS_CI_PROFILE="clh-baremetal"
 	export METRICS_JOB_BASELINE="metrics/job/clh-master"
+	;;
+"VIRTIOFS")
+	init_ci_flags
+	export SHARED_FS="virtiofs"
+	export TEST_DOCKER=true
+	export TEST_CONFORMANCE=true
+
 	;;
 esac
 "${ci_dir_name}/setup.sh"
@@ -336,11 +339,6 @@ elif [ -n "${VFIO_CI}" ]; then
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
-	echo "Installing QEMU experimental to get virtiofsd"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
-
-	echo "Installing experimental kernel"
-	export experimental_kernel=true
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
 
 	echo "Installing Cloud Hypervisor"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -115,6 +115,12 @@ END
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" bash -c "make vfio"
 		;;
+	"VIRTIOFS")
+		echo "INFO: Running ${CI_JOB} functional tests"
+		sudo -E PATH="$PATH" bash -c "make compatibility"
+		sudo -E PATH="$PATH" bash -c "make conformance"
+		sudo -E PATH="$PATH" bash -c "make docker"
+		;;
 	"SNAP")
 		echo "INFO: Running docker tests ($PWD)"
 		sudo -E PATH="$PATH" bash -c "make docker"

--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
@@ -17,7 +17,7 @@ description = "measure container lifecycle timings"
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.99
-minpercent = 5.0
+minpercent = 10.0
 maxpercent = 5.0
 
 [[metric]]

--- a/config.go
+++ b/config.go
@@ -81,6 +81,9 @@ const (
 	// DefaultHypervisor default hypervisor
 	DefaultHypervisor = "qemu"
 
+	// QemuHypervisor is Qemu
+	QemuHypervisor = "qemu"
+
 	// FirecrackerHypervisor is firecracker
 	FirecrackerHypervisor = "firecracker"
 
@@ -144,6 +147,8 @@ func KataInit() {
 		KataHypervisor = CloudHypervisor
 	case "firecracker":
 		KataHypervisor = FirecrackerHypervisor
+	case "qemu":
+		KataHypervisor = QemuHypervisor
 	case "":
 		log.Printf("'-hypervisor' to ginkgo is not set, using 'DefaultHypervisor': '%v'\n", DefaultHypervisor)
 		KataHypervisor = DefaultHypervisor


### PR DESCRIPTION
Create a virtiofs job to explicitly export
variables for virtiofs testing, like qemu, kernel,
and test to run.

Add a variable shared_fs to define what shared fs will be used
virtiofs could run even witout qemu_experimental.

Fixes: github.com/kata-containers/runtime#3083

Depends-on: github.com/kata-containers/runtime#3122
Depends-on: github.com/kata-containers/packaging#1190

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>
