### PR TITLE
Prepare 2.x for OpenShift CI - part 3

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -75,3 +75,9 @@ unset VERSION
 "${cidir}/install_kata_image.sh"
 
 "${cidir}/install_runtime.sh"
+config_file="${DESTDIR}/${PREFIX}/share/defaults/kata-containers/configuration.toml"
+# TODO: currently the virtio-fs backend cannot be tested on OpenShift.
+# See issue https://github.com/kata-containers/kata-containers/issues/1238
+if [ -f "$config_file" ]; then
+	sed -i 's|^shared_fs = "virtio-fs"|shared_fs = "virtio-9p"|g' "$config_file"
+fi

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -66,8 +66,6 @@ wait_for_reboot() {
 	done
 }
 
-[ "$(id -u)" -ne 0 ] && die "$0 must be executed by privileged user"
-
 oc project default
 
 worker_nodes=$(oc get nodes |  awk '{if ($3 == "worker") { print $1 } }')

--- a/.ci/openshift-ci/qemu-build-pre.sh
+++ b/.ci/openshift-ci/qemu-build-pre.sh
@@ -34,4 +34,5 @@ sed -i -e 's#\(ARG QEMU_REPO\).*#\1="'"$qemu_url"'"#' static-build/qemu/Dockerfi
 sed -i -e 's#\(ARG QEMU_VERSION\).*#\1="'${qemu_version}'"#' static-build/qemu/Dockerfile.ci
 sed -i -e 's#\(ARG PREFIX\).*#\1="'${prefix}'"#' static-build/qemu/Dockerfile.ci
 sed -i -e 's/\(ARG QEMU_TARBALL\).*/\1="kata-static-qemu.tar.gz"/' static-build/qemu/Dockerfile.ci
+sed -i -e 's#\(ARG QEMU_DESTDIR\).*#\1="/tmp/qemu-static"#' static-build/qemu/Dockerfile.ci
 popd


### PR DESCRIPTION
This is the continuation of part 1 (https://github.com/kata-containers/tests/pull/3102) and part 2 (https://github.com/kata-containers/tests/pull/3139) towards getting Kata Containers 2.x on-board into OpenShift CI.

Here I fixed some issues found while running the scripts on the CI environment.
