### PR TITLE
ubuntu: Preemptively do an 'apt --fix-broken install'

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -14,6 +14,9 @@ source "${cidir}/lib.sh"
 echo "Update apt repositories"
 sudo -E apt update
 
+echo "Try to preemptively fix broken dependencies, if any"
+sudo -E apt --fix-broken install -y
+
 echo "Install chronic"
 sudo -E apt install -y moreutils
 


### PR DESCRIPTION
Seems that our ubuntu images are broken due to:
```
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
 linux-headers-5.10.0-051000-generic : Depends: linux-headers-5.10.0-051000 but it is not installable
 linux-headers-5.10.0-051000-generic-64k : Depends: linux-headers-5.10.0-051000 but it is not installable
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
Failed at 18: sudo -E apt install -y moreutils
```

One possible way to solve this is preemptively doing an:
`apt --fix-broken install`

Fixes: #3177

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>