### PR TITLE
ci: rename 2.0-dev to main

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -50,7 +50,7 @@ mkdir -p "${tests_repo_dir}"
 git clone "https://${tests_repo}.git" "${tests_repo_dir}"
 cd "${tests_repo_dir}"
 
-# Checkout to target branch: master, stable-X.Y, 2.0-dev etc
+# Checkout to target branch: master, stable-X.Y, main etc
 git checkout "origin/${ghprbTargetBranch}"
 
 # If the changes are in the repository to test:

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -14,7 +14,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo="github.com/kata-containers/kata-containers"
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
-export kata_default_branch="${kata_default_branch:-2.0-dev}"
+export kata_default_branch="${kata_default_branch:-main}"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -231,8 +231,8 @@ static_check_commits()
 	# ensure the utility is built before running it.
 	# for master branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
-	# for 2.0-dev branch
-	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin '2.0-dev' && git fetch -v)
+	# for main branch
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
 
 	# Check the commits in the branch
 	{
@@ -242,7 +242,7 @@ static_check_commits()
 			--ignore-fixes-for-subsystem "release" \
 			--verbose \
 			HEAD \
-			2.0-dev; \
+			main; \
 			rc="$?";
 	} || true
 
@@ -1202,7 +1202,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "2.0-dev" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "main" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/2.0-dev/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/2.0-dev/integration/cri-o)
-   - [Containerd](https://github.com/kata-containers/tests/tree/2.0-dev/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/2.0-dev/integration/stability)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
+   - [CRI-O](https://github.com/kata-containers/tests/tree/main/integration/cri-o)
+   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
 
 ## CI Content
 

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -50,7 +50,7 @@ create_file() {
 	local block_size=4096
 	local data_offset=$((1024*1024*2))
 	local dax_alignment=$((1024*1024*2))
-	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/tools/osbuilder/image-builder/nsdax.gpl.c"
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/osbuilder/image-builder/nsdax.gpl.c"
 
 	truncate -s "${SIZE}" "${FILE}"
 	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then


### PR DESCRIPTION
So that we can rename the default branch to main.

Fixes: #3181
Depends-on: github.com/kata-containers/kata-containers#1311
Signed-off-by: Peng Tao <bergwolf@hyper.sh>