### PR TITLE
static_check: bypass license check for kernel configs

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -465,7 +465,7 @@ static_check_license_headers()
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
 			--exclude="kata_config_version" \
-			--exclude="tools/packaging/kernel/configs/*" \
+			--exclude="kernel/configs/*" \
 			--exclude="virtcontainers/pkg/firecracker/*" \
 			--exclude="${ignore_clh_generated_code}*" \
 			--exclude="*.xml" \


### PR DESCRIPTION
License header should not be checked for kernel configs.
The path of checking excluding term "tools/packaging/kernel/configs/*"
is for kata 2.x and is pointless in packaging 1.x. So correct it here.

Fixes: #3189
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @GabyCT 