### PR TITLE
Prepare 2.x for OpenShift CI - part 4

### DIFF
--- a/.ci/openshift-ci/smoke/http-server.yaml
+++ b/.ci/openshift-ci/smoke/http-server.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: http-server
-      image: fedora
+      image: registry.fedoraproject.org/fedora
       ports:
         - containerPort: 8080
       command: ["python3"]

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -19,6 +19,7 @@ export PATH=/tmp/shared:$PATH
 oc version || die "Test cluster is unreachable"
 
 info "Install and configure kata into the test cluster"
+export SELINUX_PERMISSIVE="yes"
 ${script_dir}/cluster/install_kata.sh || die "Failed to install kata-containers"
 
 info "Run test suite: $suite"


### PR DESCRIPTION
This is the continuation of part 1 (https://github.com/kata-containers/tests/pull/3102), part 2 (https://github.com/kata-containers/tests/pull/3139)  and part 3 (https://github.com/kata-containers/tests/pull/3175) towards getting Kata Containers 2.x on-board into OpenShift CI.

The important fix is regarding set SELinux to permissive mode, with this I hope to have the last change in place to allow build, install and run a single smoke test on OpenShift CI. The other change is just a bonus.