### PR TITLE
tests: Modify pmem integration test

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -23,6 +23,8 @@ case "${CI_JOB}" in
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+		echo "INFO: Running pmem integration test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		;;
 	"CRI_CONTAINERD_K8S_COMPLETE")
 		echo "INFO: Running e2e kubernetes tests"


### PR DESCRIPTION
This PR adds the pmem integration test to run in the containerd CI. Also, it checks that ctr processes are not
running in order to properly clean the environment.

Fixes #3191

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>