### PR TITLE
ci: Init and document SHIMV2_TEST envvar.

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -79,6 +79,8 @@ init_ci_flags() {
 	# Generate a report using a jenkins job data
 	# Name of the job to get data from
 	export METRICS_JOB_BASELINE=""
+	# Configure test to use Kata SHIM V2
+	export SHIMV2_TEST="true"
 }
 
 # Run noninteractive on debian and ubuntu


### PR DESCRIPTION
This variable is used to enable shimv2 for some tests,
shimv2 is default in kata 2.0, lets document it and
make it explicit at init.

Fixes: #3194

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>
