### PR TITLE
github: Update ubuntu version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x, 1.15.x]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: off


### PR DESCRIPTION
This PR updates the ubuntu version from 18.04 to 20.04 that is being
used in the github actions.

Fixes #3197

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>