### PR TITLE
tests: Don't bother using chronic in test scripts

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -25,10 +25,10 @@ if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
 
-	chronic sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list
+	sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list
 	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-	chronic sudo -E apt update
-	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
+	sudo -E apt update
+	sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
 	url="https://packages.cloud.google.com/yum/repos/kubernetes-el7-${ARCH}"
 	echo "Install ${url} for ${ARCH}"
@@ -42,14 +42,14 @@ elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
 	gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF"
 
-	chronic sudo -E sed -i 's/^[ \t]*//' /etc/yum.repos.d/kubernetes.repo
+	sudo -E sed -i 's/^[ \t]*//' /etc/yum.repos.d/kubernetes.repo
 	install_kubernetes_version=$(echo $kubernetes_version | cut -d'-' -f1)
-	chronic sudo -E yum install -y kubelet-"$install_kubernetes_version" kubeadm-"$install_kubernetes_version" kubectl-"$install_kubernetes_version" --disableexcludes=kubernetes
+	sudo -E yum install -y kubelet-"$install_kubernetes_version" kubeadm-"$install_kubernetes_version" kubectl-"$install_kubernetes_version" --disableexcludes=kubernetes
 
 	# Disable selinux
 	if  [ "$(getenforce)" != "Disabled" ]; then
-		chronic sudo -E setenforce 0
-		chronic sudo -E sed -i 's/^SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
+		sudo -E setenforce 0
+		sudo -E sed -i 's/^SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
 	fi
 
 	# Packets traversing the bridge should be sent to iptables for processing

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -54,11 +54,8 @@ if [ "$centos_version" == "8" ]; then
 	sudo yum-config-manager --enable powertools
 fi
 
-echo "Install chronic"
-sudo -E yum -y install moreutils
-
 if [ "$centos_version" == "8" ]; then
-	chronic sudo -E yum install -y pkgconf-pkg-config
+	sudo -E yum install pkgconf-pkg-config
 fi 
 
 declare -A minimal_packages=( \
@@ -114,13 +111,13 @@ main()
 		# is replaced.
 		yum_install_args+=" --allowerasing"
 	fi
-	chronic sudo -E yum -y install $yum_install_args $pkgs_to_install
+	sudo -E yum -y install $yum_install_args $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
+		sudo -E yum install ${KATA_KSM_THROTTLER_JOB}
 	fi
 }
 

--- a/.ci/setup_env_debian.sh
+++ b/.ci/setup_env_debian.sh
@@ -12,9 +12,6 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
 export DEBIAN_FRONTEND=noninteractive
 
-echo "Install chronic"
-sudo -E apt -y install moreutils
-
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-gb hunspell-en-us pandoc" \
 	[xml_validator]="libxml2-utils" \
@@ -61,13 +58,13 @@ main()
 		done
 	fi
 
-	chronic sudo -E apt -y install $pkgs_to_install
+	sudo -E apt -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
+		sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
 	fi
 }
 

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -12,9 +12,6 @@ source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
-echo "Install chronic"
-sudo -E dnf -y install moreutils
-
 if [ "${TEST_CGROUPSV2}" == "true" ]; then
 	echo "Install podman"
 	version=$(get_test_version "externals.podman.version")
@@ -65,16 +62,16 @@ main()
 		done
 	fi
 
-	chronic sudo -E dnf -y install $pkgs_to_install
+	sudo -E dnf -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
 	echo "Install kata containers dependencies"
-	chronic sudo -E dnf -y groupinstall "Development tools"
+	sudo -E dnf -y groupinstall "Development tools"
 
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
+		sudo -E dnf -y install ${KATA_KSM_THROTTLER_JOB}
 	fi
 }
 

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -15,9 +15,6 @@ source "${cidir}/lib.sh"
 echo "Remove openSUSE cloud repo"
 sudo zypper rr openSUSE-Leap-Cloud-Tools
 
-echo "Install chronic"
-sudo -E zypper -n install moreutils
-
 declare -A minimal_packages=( \
 	[spell-check]="hunspell myspell-en_GB myspell-en_US pandoc" \
 	[xml_validator]="libxml2-tools" \
@@ -62,11 +59,11 @@ main()
 		done
 	fi
 
-	chronic sudo -E zypper -n install $pkgs_to_install
+	sudo -E zypper -n install $pkgs_to_install
 
 	echo "Install YAML validator"
-	chronic sudo -E easy_install pip
-	chronic sudo -E pip install yamllint
+	sudo -E easy_install pip
+	sudo -E pip install yamllint
 }
 
 main "$@"

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -18,9 +18,6 @@ sudo -E yum install -y "$epel_url"
 echo "Update repositories"
 sudo -E yum -y update
 
-echo "Install chronic"
-sudo -E yum install -y moreutils
-
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-GB hunspell-en-US pandoc" \
 	[xml_validator]="libxml2" \
@@ -64,7 +61,7 @@ main()
 		done
 	fi
 
-	chronic sudo -E yum -y install $pkgs_to_install
+	sudo -E yum -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
 

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -34,9 +34,6 @@ sudo -E zypper refresh
 echo "Add repo for hunspell and pandoc packages"
 sudo -E SUSEConnect -p PackageHub/${VERSION_ID}/${arch}
 
-echo "Install chronic"
-sudo -E zypper -n install moreutils
-
 declare -A minimal_packages=( \
 	[spell-check]="hunspell myspell-en_GB myspell-en_US pandoc" \
 	[xml_validator]="libxml2-tools" \
@@ -78,26 +75,26 @@ main()
 		done
 	fi
 
-	chronic sudo -E zypper -n install $pkgs_to_install
+	sudo -E zypper -n install $pkgs_to_install
 
 	echo "Install YAML validator"
-	chronic sudo -E easy_install pip
-	chronic sudo -E pip install yamllint
+	sudo -E easy_install pip
+	sudo -E pip install yamllint
 
 	echo "Add redis repo and install redis"
 	redis_repo="https://download.opensuse.org/repositories/server:database/SLE_${VERSION//-/_}/server:database.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${redis_repo}
-	chronic sudo -E zypper refresh
-	chronic sudo -E zypper -n install redis
+	sudo -E zypper addrepo --no-gpgcheck ${redis_repo}
+	sudo -E zypper refresh
+	sudo -E zypper -n install redis
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
 	echo "Add crudini repo"
 	VERSIONID="12_SP1"
 	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
-	chronic sudo -E zypper refresh
-	chronic sudo -E zypper -n install crudini
+	sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
+	sudo -E zypper refresh
+	sudo -E zypper -n install crudini
 }
 
 main "$@"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -17,9 +17,6 @@ sudo -E apt update
 echo "Try to preemptively fix broken dependencies, if any"
 sudo -E apt --fix-broken install -y
 
-echo "Install chronic"
-sudo -E apt install -y moreutils
-
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-gb hunspell-en-us pandoc" \
 	[xml_validator]="libxml2-utils" \
@@ -95,21 +92,21 @@ main()
 		pkgs_to_install+=" ${rust_agent_pkgs[@]}"
 	fi
 
-	chronic sudo -E apt -y install $pkgs_to_install
+	sudo -E apt -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
 	if [ "$VERSION_ID" == "16.04" ] && [ "$(arch)" != "ppc64le" ]; then
-		chronic sudo -E add-apt-repository ppa:alexlarsson/flatpak -y
-		chronic sudo -E apt update
+		sudo -E add-apt-repository ppa:alexlarsson/flatpak -y
+		sudo -E apt update
 	fi
 
 	echo "Install os-tree"
-	chronic sudo -E apt install -y libostree-dev
+	sudo -E apt install -y libostree-dev
 
 	if [ "$KATA_KSM_THROTTLER" == "yes" ]; then
 		echo "Install ${KATA_KSM_THROTTLER_JOB}"
-		chronic sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
+		sudo -E apt install -y ${KATA_KSM_THROTTLER_JOB}
 	fi
 }
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -109,12 +109,6 @@ long_options=(
 yamllint_cmd="yamllint"
 have_yamllint_cmd=$(command -v "$yamllint_cmd" || true)
 
-chronic=chronic
-
-# Disable chronic on OSX to avoid having to update the Travis config files
-# for additional packages on that platform.
-[ "$(uname -s)" == "Darwin" ] && chronic=
-
 usage()
 {
 	cat <<EOT
@@ -986,7 +980,7 @@ static_check_xml()
 
 		local ret
 
-		{ $chronic xmllint -format - <<< "$contents"; ret=$?; } || true
+		{ xmllint -format - <<< "$contents"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "failed to check XML file '$file'"
 	done
@@ -1023,7 +1017,7 @@ static_check_shell()
 
 		local ret
 
-		{ $chronic bash -n "$script"; ret=$?; } || true
+		{ bash -n "$script"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "check for script '$script' failed"
 	done
@@ -1060,7 +1054,7 @@ static_check_json()
 
 		local ret
 
-		{ $chronic jq -S . "$json"; ret=$?; } || true
+		{ jq -S . "$json"; ret=$?; } || true
 
 		[ "$ret" -eq 0 ] || die "failed to check JSON file '$json'"
 	done

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -300,7 +300,7 @@ check_collect_script()
 
 	info "Checking $msg"
 
-	sudo -E PATH="$PATH" chronic $cmd
+	sudo -E PATH="$PATH" $cmd
 }
 
 main()


### PR DESCRIPTION
A number of steps in the test/CI setup scripts use the "chronic" tool.
This is a simple utility that suppresses output from a command, unless it
returns a failure code.  That sounds useful but:
 * Only some of the many commands in the scripts use chronic, so the logs
   are still a huge swath of information that chronic doesn't do much to
   mitigate
 * When running in a CI, it's conceivable that information from these
   commands, even when successful, could be useful for debugging a later
   failure
 * It's another external dependency, albeit a pretty easy to supply one.

I think it's more trouble than it's worth, so simply remove it.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>