### PR TITLE
CI: Fix xurls url

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -570,13 +570,12 @@ static_check_docs()
 
 		local version
 		local url
-		local dir
 
 		version=$(get_test_version "externals.xurls.version")
 		url=$(get_test_version "externals.xurls.url")
-		dir=$(echo "$url"|sed 's!https://!!g')
 
-		build_version "${dir}" "" "${version}"
+		# xurls is very fussy about how it's built.
+		GO111MODULE=on go get "${url}@${version}"
 	fi
 
 	info "Checking documentation"

--- a/versions.yaml
+++ b/versions.yaml
@@ -45,8 +45,8 @@ externals:
   xurls:
     description: |
       Tool used by the CI to check URLs in documents and code comments.
-    url: "https://mvdan.cc/xurls/cmd/xurls"
-    version: "70405f5eab516c9f7b626d803b043415809499a6"
+    url: "mvdan.cc/xurls/v2/cmd/xurls"
+    version: "v2.2.0"
 
   go-md2man:
     description: "cri-o dependency used for building documentation"


### PR DESCRIPTION
The `xurls` tool used by the `static-checks.sh` script to look for
broken URLs has changed its URL (oh the irony!), so update the versions
database and switch to using the latest version.

Fixes: #3206.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>