### PR TITLE
test: Update pmem integration test

### DIFF
--- a/integration/pmem/pmem_test.sh
+++ b/integration/pmem/pmem_test.sh
@@ -95,7 +95,7 @@ function wait_for_postgres {
 function test_database {
 	"${dir_path}/../../cmd/pmemctl/pmemctl.sh" -s 1G -f xfs -m "${test_directory}" xfs.img
 
-	rows=10000
+	rows=100
 	cont_image="docker.io/library/postgres:latest"
 	postgresql_cont_dir="/var/lib/postgresql/data"
 


### PR DESCRIPTION
This PR updates the pmem integration test by reducing the number of rows
for the database in order to avoid the random timeouts that we have seen
in the CI as this test is taking a lot of time to execute.

Fixes #3208

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>