### PR TITLE
tests: Add some kubectl describe information to teardown of many k8s …

### DIFF
--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -36,6 +36,9 @@ setup() {
 }
 
 teardown(){
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	rm -f "${pod_config_dir}/test-lifecycle-events.yaml"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -65,6 +65,9 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	# Delete k8s resources
 	kubectl delete pod "$pod_name"
 	kubectl delete pvc "$volume_claim"

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -36,6 +36,9 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 	kubectl delete configmap "$config_name"
 }

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -74,6 +74,9 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -71,5 +71,8 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -55,6 +55,10 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+	kubectl describe "pod/$second_pod_name"
+
 	kubectl delete pod "$pod_name" "$second_pod_name"
 	kubectl delete secret "$secret_name"
 }

--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -28,5 +28,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -27,5 +27,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -27,5 +27,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-exec.bats
+++ b/integration/kubernetes/k8s-exec.bats
@@ -59,5 +59,8 @@ EOC"
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-limit-range.bats
+++ b/integration/kubernetes/k8s-limit-range.bats
@@ -34,6 +34,9 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 	kubectl delete namespaces "$namespace_name"
 }

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -68,5 +68,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -39,5 +39,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -31,5 +31,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -42,5 +42,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -56,6 +56,9 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	rm -f $TMP_FILE $SECOND_TMP_FILE
 	kubectl delete pod "$pod_name"
 	kubectl delete secret pass user

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -29,5 +29,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-shared-volume.bats
+++ b/integration/kubernetes/k8s-shared-volume.bats
@@ -45,5 +45,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -29,5 +29,8 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -51,6 +51,10 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$first_pod_name"
+	kubectl describe "pod/$second_pod_name"
+
 	kubectl delete pod "$first_pod_name"
 	kubectl delete pod "$second_pod_name"
 	rm -rf "$first_pod_config"

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -64,6 +64,9 @@ teardown() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
 	kubectl delete pvc "$volume_claim"
 	kubectl delete pv "$volume_name"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -44,6 +44,9 @@ setup() {
 }
 
 teardown() {
+	# Debugging information
+	kubectl describe "pod/$busybox_pod"
+
 	rm -f "${pod_config_dir}/test-${deployment}.yaml"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"


### PR DESCRIPTION
…tests

When kubernetes tests in the CI fail, it can be difficult to work out why.
In particular, one fairly likely failure mode is for a pod to be created
but never become ready.  If this happens, the CI output will show a timeout
on the kubectl wait command, but no indication of why the pod didn't become
ready.

This adds a kubectl describe to the teardown() path for many of the tests,
which will give at least a little more indication of where to look for a
problem.  Technically the debug command will be executed for both passing
and failing tests, however bats will suppress the output for passing tests,
so it shouldn't clutter the output except in cases where it is likely to be
useful.

This is by no means attempting to add exhaustive debugging information to
all the tests, just a basic start for a good selection.  Further debug
instrumentation in the teardown paths seems likely for future improvements
to debugability.

fixes #3210

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>