### PR TITLE
tests: Update history tool to use the proper jenkins jobs

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -17,8 +17,8 @@ NUM_BUILDS=5
 
 # What is the default set of repos (Jenkins jobs) we evaluate
 default_repos=()
-default_repos+=("kata-metrics-runtime-ubuntu-16-04-PR")
-default_repos+=("kata-metrics-tests-ubuntu-16-04-PR")
+default_repos+=("kata-containers-2.0-metrics-ubuntu-18-04-PR")
+default_repos+=("kata-containers-2.0-tests-metrics-ubuntu-18-04-PR")
 repos=()
 
 # What test results do we evaluate for each build


### PR DESCRIPTION
This PR updates the history tool in order to gathered the metrics
results from the kata containers 2.0 jenkins jobs.

Fixes #3213

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>