### PR TITLE
tests: Update history script to use the proper repos for kata 2.0

### DIFF
--- a/cmd/history/history.sh
+++ b/cmd/history/history.sh
@@ -24,16 +24,11 @@ END=${END:-$(date -I -d "$defend")}
 
 # Where are we looking? Default to origin/master
 remote="${remote:-origin}"
-branch="${branch:-master}"
+branch="${branch:-main}"
 
 repo_base="github.com/kata-containers"
 repos="${repos:-
-	agent \
-	osbuilder \
-	packaging \
-	proxy \
-	runtime \
-	shim \
+	kata-containers \
 	tests \
 	}"
 


### PR DESCRIPTION
This PR updates the history script to use kata-containers and tests
repository for kata 2.0 as the others are not longer valid.

Fixes #3227

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>