### PR TITLE
kata-webhook: simplify building kata-webhook container

### DIFF
--- a/kata-webhook/Dockerfile
+++ b/kata-webhook/Dockerfile
@@ -5,6 +5,7 @@ FROM golang:latest AS builder
 
 WORKDIR /go/src/kata-pod-annotate
 
+COPY ../vendor ./
 COPY . ./
 RUN CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate
 


### PR DESCRIPTION
Before one can build the container image the vendor directory from the
parent directory has to be copied to the kata-webhook directory.
Otherwise the build will fail because it can't find all necessary
packages. See issue https://github.com/kata-containers/tests/issues/2479

This is solved on the master branch for Kata 1.x by adding a manual step
to the README.md.

We can avoid this manual step  by copying in the vendor directory during
the docker build.

The vendor directory is ~28 megs and it takes less than a second to copy
it into the build env, so no noticeable slow down.

When this is accepted I can send a similar PR for the master branch.

Fixes: #3230
Signed-off-by: Jens Freimann <jfreimann@redhat.com>