### PR TITLE
test: Update checkversions script to use kata-containers repository

### DIFF
--- a/cmd/checkversions/checkversions.sh
+++ b/cmd/checkversions/checkversions.sh
@@ -25,7 +25,7 @@
 #  - tabulates the results and prints a report
 #  - returns the number of components that could be updated (fails) as the return value
 
-runtime_repo="github.com/kata-containers/runtime"
+runtime_repo="github.com/kata-containers/kata-containers"
 runtime_repo_dir="$GOPATH/src/${runtime_repo}"
 versions_file="${runtime_repo_dir}/versions.yaml"
 YQ=$(which yq)


### PR DESCRIPTION
This PR updates the checkversions script to use the kata-containers
repository for kata 2.0

Fixes #3231

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>