### PR TITLE
docs: Update url for the versions database

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You need to install the following to run Kata Containers tests:
 - [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
-  [versions database](https://github.com/kata-containers/runtime/blob/master/versions.yaml).
+  [versions database](https://github.com/kata-containers/kata-containers/blob/main/versions.yaml).
 
 - `make`.
 


### PR DESCRIPTION
This PR updates the url for the versions database in order to use
the kata 2.0 url.

Fixes #3233

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>