### PR TITLE
ci: vfio: wait for container to be ready before checking MACs

### DIFF
--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -126,9 +126,9 @@ run_test() {
 	waitForProcess 15 3 "sudo -E kubectl exec ${pod_name} -- ip a"
 
 	# Expecting 2 network interaces -> 2 mac addresses
-	mac_addrs=$(sudo -E kubectl exec -t "${pod_name}" -- ip a | grep "link/ether" | wc -l)
+	mac_addrs=$(sudo -E kubectl exec "${pod_name}" -- ip a | grep "link/ether" | wc -l)
 	if [ ${mac_addrs} -ne 2 ]; then
-		die "Error: expecting 2 network interfaces, Got: $(kubectl exec -t "${pod_name}" -- ip a)"
+		die "Error: expecting 2 network interfaces, Got: $(kubectl exec "${pod_name}" -- ip a)"
 	else
 		info "Success: found 2 network interfaces"
 	fi

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -122,6 +122,9 @@ run_test() {
 	pod_name=vfio
 	sudo -E kubectl wait --for=condition=Ready pod "${pod_name}"
 
+	# wait for the container to be ready
+	waitForProcess 15 3 "sudo -E kubectl exec ${pod_name} -- ip a"
+
 	# Expecting 2 network interaces -> 2 mac addresses
 	mac_addrs=$(sudo -E kubectl exec -t "${pod_name}" -- ip a | grep "link/ether" | wc -l)
 	if [ ${mac_addrs} -ne 2 ]; then


### PR DESCRIPTION
Make sure the container in the POD is up and running before
checking its MAC addresses.

fixes #3236

Signed-off-by: Julio Montes <julio.montes@intel.com>