### PR TITLE
ci: Enable clh+crio kata 2.x testing

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -256,6 +256,12 @@ case "${CI_JOB}" in
 	export CRIO="yes"
 	export OPENSHIFT="no"
 	;;
+"CLOUD-HYPERVISOR-K8S-CRIO")
+	init_ci_flags
+	export KUBERNETES=yes
+	export CRIO=yes
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -43,6 +43,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests (minimal) with CRI-O"
 		sudo -E PATH="$PATH" bash -c "make kubernetes-e2e"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CRIO")
+		echo "INFO: Running kubernetes tests"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
 	"CLOUD-HYPERVISOR-K8S-CONTAINERD")
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"


### PR DESCRIPTION
This PR enables the clh+crio kata 2.x kubernetes testing.

Fixes #2997

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>