### PR TITLE
test: docker: Adjust the `cpuset-cpus test`

### DIFF
--- a/integration/docker/cpu_test.go
+++ b/integration/docker/cpu_test.go
@@ -152,7 +152,12 @@ var _ = Describe("CPU constraints", func() {
 		quota      int = 20000
 		period     int = 15000
 		cpusetCpus int = 0
-		cpusetMems int = 0
+		// We are now not constraining the guest cgroup/cpuset
+		// values at all, e.g. we are allowing all onlined vCPUs
+		// to be used by the container. In this test, we use the
+		// hard-coded value below assuming the default vCPU is '1'
+		cpusetCpusExpected string = "0-1"
+		cpusetMems         int    = 0
 	)
 
 	BeforeEach(func() {
@@ -193,11 +198,11 @@ var _ = Describe("CPU constraints", func() {
 		})
 
 		Context(fmt.Sprintf("with cpuset-cpus to %d", cpusetCpus), func() {
-			It(fmt.Sprintf("%s should have %d", cpusetCpusSysPath, cpusetCpus), func() {
+			It(fmt.Sprintf("%s should have %s (with 'default_vCPU=1')", cpusetCpusSysPath, cpusetCpusExpected), func() {
 				args = append(args, "--cpuset-cpus", fmt.Sprintf("%d", cpusetCpus), Image, "cat", cpusetCpusSysPath)
 				stdout, _, exitCode := dockerRun(args...)
 				Expect(exitCode).To(BeZero())
-				Expect(fmt.Sprintf("%d", cpusetCpus)).To(Equal(strings.Trim(stdout, "\n\t ")))
+				Expect(cpusetCpusExpected).To(Equal(strings.Trim(stdout, "\n\t ")))
 			})
 		})
 


### PR DESCRIPTION
As we are fixing the `--cpuset-cpus` support in kata with
docker (kata-containers/runtime#3138), it exposes the `cpuset-cpus test`
is actually not testing the expected behavior of kata. By design, Kata
does not constrain the guest vCPUs at all, because we don't track the
mappings between guest vCPU and host CPUs. As a result, we are always
allowing containers to use all onlined vCPUs in the guest. The current
cpuset-cpus assumes the guest cgroups constrain the vCPU in the exactly
same way as the CPUs are constrained on the host. That is wrong.

This patch adjusts the `cpuset-cpus test` to respect the actual behavior
of kata with `docker --cpuset-cpus`.

Depends-on: github.com/kata-containers/runtime#3138

Fixes: #3241

Signed-off-by: Bo Chen <chen.bo@intel.com>