### PR TITLE
backport: Enable firecracker in stable-2.0

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -50,7 +50,7 @@ mkdir -p "${tests_repo_dir}"
 git clone "https://${tests_repo}.git" "${tests_repo_dir}"
 cd "${tests_repo_dir}"
 
-# Checkout to target branch: master, stable-X.Y, 2.0-dev etc
+# Checkout to target branch: master, stable-X.Y, main etc
 git checkout "origin/${ghprbTargetBranch}"
 
 # If the changes are in the repository to test:

--- a/.ci/containerd_devmapper_setup.sh
+++ b/.ci/containerd_devmapper_setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
+containerd_config_dir="/etc/containerd"
+containerd_config_file="${containerd_config_dir}/config.toml"
+
+if [ "$KATA_HYPERVISOR" != "firecracker" ]; then
+	echo "WARNING: Devicemapper configuration is only for Firecracker. Exiting"
+	exit 0
+fi
+
+sudo rm -rf /var/lib/containerd/devmapper/data-disk.img
+sudo rm -rf /var/lib/containerd/devmapper/meta-disk.img
+sudo mkdir -p /var/lib/containerd/devmapper
+sudo truncate --size 10G /var/lib/containerd/devmapper/data-disk.img
+sudo truncate --size 10G /var/lib/containerd/devmapper/meta-disk.img
+
+sudo mkdir -p /etc/systemd/system
+
+cat<<EOT | sudo tee /etc/systemd/system/containerd-devmapper.service
+[Unit]
+Description=Setup containerd devmapper device
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=lvm2-activation-early.service
+Wants=systemd-udev-settle.service
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=-/sbin/losetup /dev/loop20 /var/lib/containerd/devmapper/data-disk.img
+ExecStart=-/sbin/losetup /dev/loop21 /var/lib/containerd/devmapper/meta-disk.img
+[Install]
+WantedBy=local-fs.target
+EOT
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now containerd-devmapper
+
+# Time to setup the thin pool for consumption.
+# The table arguments are such.
+# start block in the virtual device
+# length of the segment (block device size in bytes / Sector size (512)
+# metadata device
+# block data device
+# data_block_size Currently set it 512 (128KB)
+# low_water_mark. Copied this from containerd snapshotter test setup
+# no. of feature arguments
+# Skip zeroing blocks for new volumes.
+sudo dmsetup create contd-thin-pool \
+	--table "0 20971520 thin-pool /dev/loop21 /dev/loop20 512 32768 1 skip_block_zeroing"
+
+sudo mkdir -p "$containerd_config_dir"
+if [ -f "$containerd_config_file" ]
+then
+	sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"4096MB\"|' "$containerd_config_file"
+	sudo sed -i 's|\(\[plugins.cri.containerd\]\).*|\1\n      snapshotter = \"devmapper\"|' "$containerd_config_file"
+else
+	cat<<EOT | sudo tee $containerd_config_file
+[plugins]
+  [plugins.devmapper]
+    pool_name = "contd-thin-pool"
+    base_image_size = "4096MB"
+  [plugins.cri]
+    [plugins.cri.containerd]
+      snapshotter = "devmapper"
+EOT
+fi
+
+sudo systemctl restart containerd

--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -18,7 +18,7 @@ if [ "$KATA_DEV_MODE" = true ]; then
 	die "KATA_DEV_MODE set so not running the test"
 fi
 
-docker_version=$(docker version --format '{{.Server.Version}}' | cut -d '.' -f1-2)
+docker_version=$(sudo docker version --format '{{.Server.Version}}' | cut -d '.' -f1-2)
 
 if [ "$docker_version" != "18.06" ]; then
 	die "Firecracker hypervisor only works with docker 18.06"

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -19,10 +19,6 @@ cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_version=$(get_version "externals.kubernetes.version")
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	die "Kubernetes will not work with $KATA_HYPERVISOR"
-fi
-
 if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -280,6 +280,15 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"FIRECRACKER")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export CRIO="no"
+	export KATA_HYPERVISOR="firecracker"
+	export KUBERNETES="yes"
+	export OPENSHIFT="no"
+;;
 "VFIO")
 	init_ci_flags
 	export CRIO="no"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -271,6 +271,15 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
+	init_ci_flags
+	export MINIMAL_CONTAINERD_K8S_E2E="false"
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export experimental_kernel="true"
+	;;
 "VFIO")
 	init_ci_flags
 	export CRIO="no"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -14,7 +14,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo="github.com/kata-containers/kata-containers"
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
-export kata_default_branch="${kata_default_branch:-2.0-dev}"
+export kata_default_branch="${kata_default_branch:-main}"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -192,6 +192,7 @@ kill_stale_process()
 	extract_kata_env
 	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do
+		[ -z "${stale_process}" ] && continue
 		local pids=$(pgrep -d ' ' -f "${stale_process}")
 		if [ -n "$pids" ]; then
 			sudo kill -9 ${pids} || true

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -53,6 +53,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running complete e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"FIRECRACKER")
+		echo "INFO: Running Kubernetes tests with Firecracker"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -49,6 +49,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
+		echo "INFO: Running complete e2e kubernetes tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
+		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -20,6 +20,7 @@ CI=${CI:-false}
 # values indicating whether related intergration tests have been supported
 CRIO="${CRIO:-yes}"
 CRI_CONTAINERD="${CRI_CONTAINERD:-no}"
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KUBERNETES="${KUBERNETES:-yes}"
 OPENSHIFT="${OPENSHIFT:-yes}"
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
@@ -114,6 +115,11 @@ install_extra_tools() {
 		bash -f "${cidir}/install_cri_containerd.sh" &&
 		bash -f "${cidir}/configure_containerd_for_kata.sh" ||
 		echo "containerd not installed"
+
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] &&
+		echo "Configure devicemapper for firecracker" &&
+		bash -f "${cidir}/containerd_devmapper_setup.sh" ||
+		echo "Devicemapper not configured"
 
 	[ "${KUBERNETES}" = "yes" ] &&
 		echo "Install Kubernetes" &&

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -231,8 +231,8 @@ static_check_commits()
 	# ensure the utility is built before running it.
 	# for master branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
-	# for 2.0-dev branch
-	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin '2.0-dev' && git fetch -v)
+	# for main branch
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
 
 	# Check the commits in the branch
 	{
@@ -242,7 +242,7 @@ static_check_commits()
 			--ignore-fixes-for-subsystem "release" \
 			--verbose \
 			HEAD \
-			2.0-dev; \
+			main; \
 			rc="$?";
 	} || true
 
@@ -1199,7 +1199,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "2.0-dev" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "main" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -62,7 +62,7 @@ create_user_data() {
 	ssh_pub_key="$(cat "${ssh_pub_key_file}")"
 	dnf_proxy=""
 	service_proxy=""
-	docker_user_proxy=""
+	docker_user_proxy="{}"
 	environment=$(env | egrep "ghprb|WORKSPACE|KATA|GIT|JENKINS|_PROXY|_proxy" | \
 	                    sed -e "s/'/'\"'\"'/g" \
 	                        -e "s/\(^[[:alnum:]_]\+\)=/\1='/" \

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,9 @@ vcpus:
 ipv6:
 	bash -f integration/ipv6/ipv6.sh
 
+pmem:
+	bash -f integration/pmem/pmem_test.sh
+
 test: ${UNION}
 
 check: checkcommits log-parser
@@ -271,4 +274,5 @@ help:
 	tracing \
 	vcpus \
 	vfio \
-	vm-factory
+	vm-factory \
+	pmem

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ ifeq (${CI}, true)
 endif
 
 # union for 'make test'
-UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
-	docker-stability oci netmon kubernetes swarm vm-factory \
-	entropy ramdisk shimv2 tracing time-drift compatibility vcpus $(PODMAN_DEPENDENCY)
+UNION := crio kubernetes pmem
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/2.0-dev/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/2.0-dev/integration/cri-o)
-   - [Containerd](https://github.com/kata-containers/tests/tree/2.0-dev/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/2.0-dev/integration/stability)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
+   - [CRI-O](https://github.com/kata-containers/tests/tree/main/integration/cri-o)
+   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
 
 ## CI Content
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
         * [Requirements to run Kata Containers tests](#requirements-to-run-kata-containers-tests)
         * [Prepare an environment](#prepare-an-environment)
         * [Run the tests](#run-the-tests)
-        * [Running subsets of tests](#running-subsets-of-tests)
-            * [Running `Bats` based tests](#running-bats-based-tests)
-            * [Running `Ginkgo` based tests](#running-ginkgo-based-tests)
-    * [Metrics tests](#metrics-tests)
     * [Kata Admission controller webhook](#kata-admission-controller-webhook)
 
 This repository contains various types of tests and utilities (called
@@ -36,19 +32,11 @@ $ go get -d github.com/kata-containers/tests
 We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
-1. [Functional tests](https://github.com/kata-containers/tests/tree/master/functional)
-2. Integration tests to ensure compatibility with:
-   - [Docker](https://github.com/kata-containers/tests/tree/master/integration/docker)
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/master/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/master/integration/cri-o)
-   - [Containerd](https://github.com/kata-containers/tests/tree/master/integration/containerd)
-   - [OpenShift](https://github.com/kata-containers/tests/tree/master/integration/openshift)
-3. [Network tests](https://github.com/kata-containers/tests/tree/master/integration/network)
-4. [Stability tests](https://github.com/kata-containers/tests/tree/master/integration/stability)
-5. [Metrics](https://github.com/kata-containers/tests/tree/master/metrics)
-
-> **Note:** The unit tests of the different Kata Containers components are stored in each repository
-> along with the source code they test.
+1. Integration tests to ensure compatibility with:
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/2.0-dev/integration/kubernetes)
+   - [CRI-O](https://github.com/kata-containers/tests/tree/2.0-dev/integration/cri-o)
+   - [Containerd](https://github.com/kata-containers/tests/tree/2.0-dev/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/2.0-dev/integration/stability)
 
 ## CI Content
 
@@ -211,7 +199,7 @@ all steps from the beginning and not from the failed step.
 ### Run the tests
 
 If you have already installed the Kata Containers packages and a container
-manager (i.e. Docker or Kubernetes), and you want to execute the content
+manager (i.e. Kubernetes), and you want to execute the content
 for all the tests, run the following:
 
 ```
@@ -221,9 +209,9 @@ $ sudo -E PATH=$PATH make test
 ```
 
 You can also execute a single test suite. For example, if you want to execute
-the docker integration tests, run the following:
+the Kubernetes integration tests, run the following:
 ```
-$ sudo -E PATH=$PATH make docker
+$ sudo -E PATH=$PATH make kubernetes
 ```
 
 A list of available test suite `make` targets can be found by running the
@@ -261,29 +249,5 @@ kubernetes:
         bash -f integration/kubernetes/run_kubernetes_tests.sh
 ```
 
-#### Running Ginkgo based tests
-
-Ginkgo supports selecting, filtering and excluding tests to be run using command
-line parameters. The tests repository `Makefile` supports passing the environment
-variables `FOCUS` and `SKIP` through to the `ginkgo` command in most cases. Check
-the `Makefile` specifics before you use this functionality.
-
-Ginkgo accepts [Golang regexp](https://golang.org/pkg/regexp/) regular expressions
-for the `FOCUS` and `SKIP` arguments. See the
-[Ginkgo documentation](https://onsi.github.io/ginkgo/#focused-specs) for more
-specifics. Example:
-
-```sh
-$ make docker					# all tests
-$ export FOCUS=".*CPU.*"; $ make docker		# any test with 'CPU' in its name
-$ export FOCUS="CPU constraints"; $ make docker	# One specific test
-$ export SKIP="CPU constraints"; $ make docker	# Skip one specific test
-```
-
-## Metrics tests
-
-See the [metrics documentation](metrics).
-
 ## Kata Admission controller webhook
-
 See the [webhook documentation](kata-webhook).

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -50,7 +50,7 @@ create_file() {
 	local block_size=4096
 	local data_offset=$((1024*1024*2))
 	local dax_alignment=$((1024*1024*2))
-	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/tools/osbuilder/image-builder/nsdax.gpl.c"
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/osbuilder/image-builder/nsdax.gpl.c"
 
 	truncate -s "${SIZE}" "${FILE}"
 	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FILE=""
+FS=""
+MNT_DIR=""
+SIZE=""
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+warn() {
+	echo -e "WARNING: $*" >&2
+}
+
+info() {
+	echo -e "INFO: $*"
+}
+
+help() {
+cat << EOF
+$0 is a command line tool to create raw files that can be used as pmem
+volumes that support DAX[1] in Kata Containers.
+
+USAGE:
+	$0 [OPTIONS] FILE
+
+EXAMPLE:
+	$0 -s 10G -f xfs -m ~/dax_volume ~/file.dax
+
+OPTIONS:
+	-f FS   filesystem, only xfs(5) and ext4(5) support DAX[1]
+	-m DIR  mount point in the host. Create a loop device for the file
+	        and mount it in the DIR specified, DIR can be used as a volume
+	        and Kata Containers will use it as a pmem volume that support DAX
+	-s SIZE file size. SIZE must be aligned to 128M, hence the minimum
+	        supported size for a file is 128M
+
+	[1]- https://www.kernel.org/doc/Documentation/filesystems/dax.txt
+EOF
+}
+
+create_file() {
+	local reserved_blocks_percentage=3
+	local block_size=4096
+	local data_offset=$((1024*1024*2))
+	local dax_alignment=$((1024*1024*2))
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/tools/osbuilder/image-builder/nsdax.gpl.c"
+
+	truncate -s "${SIZE}" "${FILE}"
+	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then
+		rm -f "${FILE}"
+		die "SIZE must be aligned to 128M"
+	fi
+
+	if [ ! -x nsdax ]; then
+		curl -Ls "${nsdax_src_url}" | gcc -x c -o nsdax -
+	fi
+	./nsdax "${FILE}" ${data_offset} ${dax_alignment}
+	sync
+
+	device=$(sudo losetup --show -Pf --offset ${data_offset} "${FILE}")
+	if [ "${FS}" == "xfs" ]; then
+		# DAX and reflink cannot be used together!
+		# Explicitly disable reflink, if reflink is listed in the metadata (-m) option
+		if mkfs.xfs 2>&1 | grep "\-m" | grep "reflink"; then
+			sudo mkfs.xfs -m reflink=0 -q -f -b size="${block_size}" "${device}"
+		else
+			sudo mkfs.xfs -q -f -b size="${block_size}" "${device}"
+		fi
+	else
+		sudo mkfs.ext4 -q -F -b "${block_size}" "${device}"
+		info "Set filesystem reserved blocks percentage to ${reserved_blocks_percentage}%"
+		sudo tune2fs -m "${reserved_blocks_percentage}" "${device}"
+	fi
+
+	if [ -z "${MNT_DIR}" ]; then
+		info "pmem volume will not be mounted"
+		info "It can be mounted later running: sudo mount \$(sudo losetup --show -Pf --offset ${data_offset} ${FILE}) \$MNT_DIR"
+		sudo losetup -d "${device}"
+	else
+		info "Mounting pmem volume at ${MNT_DIR}"
+		sudo mount "${device}" "${MNT_DIR}"
+	fi
+}
+
+main() {
+	local OPTIND
+	while getopts "f:hm:s:" opt;do
+		case ${opt} in
+			f)
+				FS="${OPTARG}"
+				;;
+			h)
+				help
+				exit 0
+				;;
+			m)
+				MNT_DIR="${OPTARG}"
+				;;
+			s)
+				SIZE="${OPTARG}"
+				;;
+			?)
+				# parse failure
+				help
+				die "Failed to parse arguments"
+		    ;;
+		esac
+	done
+	shift $((OPTIND-1))
+
+	FILE=$1
+
+	if [ -z "${FILE}" ]; then
+		die "mandatory FILE not supplied"
+	fi
+
+	if [ -z "${FS}" ]; then
+		FS="xfs"
+		warn "filesystem not supplied, using ${FS}"
+	elif [ "${FS}" != "xfs" ] &&  [ "${FS}" != "ext4" ]; then
+		die "Unsupported filesystem ${FS}"
+	fi
+
+	if [ -z "${SIZE}" ]; then
+		SIZE="128M"
+		warn "size not supplied, using ${SIZE}"
+	fi
+
+	create_file
+}
+
+main $@

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -133,6 +133,13 @@ create_containerd_config() {
 [plugins.linux]
        shim = "${containerd_shim_path}"
 EOT
+
+if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+	sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"4096MB\"|' ${CONTAINERD_CONFIG_FILE}
+	echo "Devicemapper configured"
+	cat "${CONTAINERD_CONFIG_FILE}"
+fi
+
 }
 
 cleanup() {

--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -8,7 +8,9 @@ jobs:
   CRI_CONTAINERD_K8S_MINIMAL:
     passed: 12
   CRI_CONTAINERD_K8S_COMPLETE:
-    passed: 273
+    passed: 269
+  CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
+    passed: 274
   minimal:
     focus:
       - ConfigMap should be consumable from pods in volume

--- a/integration/kubernetes/e2e_conformance/setup.sh
+++ b/integration/kubernetes/e2e_conformance/setup.sh
@@ -29,4 +29,6 @@ if ! bash ./init.sh; then
 	bash ./init.sh
 fi
 crictl --version
+kubectl get runtimeclass
+kubectl apply -f "runtimeclass_workloads/kata-runtimeclass.yaml"
 kubectl get pods --all-namespaces

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -7,8 +7,13 @@
 # are not running correctly using kata-runtime.
 
 containerd:
-  - SchedulerPredicates
-  - Daemon set \[Serial\] should rollback without unnecessary restarts
+  - \[sig-api-machinery\] Aggregator should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
 
 crio:
   - Daemon set \[Serial\] should rollback without unnecessary restarts
+
+hypervisor:
+  cloud-hypervisor:
+    - \[sig-apps]\ Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]
+    - \[sig-api-machinery\] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
+    - \[k8s.io\] Security Context When creating a pod with privileged should run the container as unprivileged when false \[LinuxOnly\] \[NodeConformance\]

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -7,8 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="constraints-cpu-test"
 	container_name="first-cpu-container"
@@ -23,6 +26,8 @@ setup() {
 }
 
 @test "Check CPU constraints" {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
 
@@ -59,5 +64,7 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -7,13 +7,18 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Credentials using secrets" {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	secret_name="test-secret"
 	pod_name="secret-test-pod"
 	second_pod_name="secret-envars-test-pod"
@@ -48,6 +53,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	kubectl delete pod "$pod_name" "$second_pod_name"
 	kubectl delete secret "$secret_name"
 }

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -7,13 +7,18 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
 }
 
 @test "Projected volume" {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	password="1f2d1e2e67df"
 	username="admin"
 	pod_name="test-projected-volume"
@@ -49,6 +54,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	rm -f $TMP_FILE $SECOND_TMP_FILE
 	kubectl delete pod "$pod_name"
 	kubectl delete secret pass user

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -9,9 +9,11 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
+fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
 	export KUBECONFIG="$HOME/.kube/config"
 	get_pod_config_dir
@@ -27,6 +29,8 @@ setup() {
 
 @test "Create Persistent Volume" {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	wait_time=10
 	sleep_time=2
 	volume_name="pv-volume"
@@ -58,6 +62,8 @@ setup() {
 
 teardown() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
 	kubectl delete pod "$pod_name"
 	kubectl delete pvc "$volume_claim"
 	kubectl delete pv "$volume_name"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -16,10 +16,6 @@ arch="$(uname -m)"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
-	die "Kubernetes tests will not run with $KATA_HYPERVISOR"
-fi
-
 # Using trap to ensure the cleanup occurs when the script exists.
 trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 

--- a/integration/pmem/data/dbinsert.sh
+++ b/integration/pmem/data/dbinsert.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is intended to run in a postgres container
+
+script_dir="$(realpath $(dirname $0))"
+source "${script_dir}/lib.sh"
+
+rows=${1:-500}
+script_dir="$(dirname $(realpath $0))"
+sql_file="/var/lib/postgresql/data/sql.sql"
+cat > "${sql_file}" <<EOF
+CREATE TABLE ${db_table_name} (
+	id serial PRIMARY KEY,
+	name varchar NOT NULL,
+	age int NOT NULL,
+	phone varchar NOT NULL,
+	birth varchar NOT NULL,
+	country varchar NOT NULL,
+	company varchar NOT NULL,
+	email varchar NOT NULL
+);
+EOF
+
+# to avoid jenkins kills the process due to inactivity
+for i in $(seq 1 1000); do echo -n .; sleep 5; done &
+dots_pid=$!
+trap "kill -9 ${dots_pid}" EXIT
+
+echo "generating sql file"
+count=0
+stop=false
+
+export IFS=$'\n'
+users=($(cat "${script_dir}/users.txt"));
+while [ "${stop}" != "true" ]; do
+	for line in ${users[*]}; do
+		if [ ${count} -ge ${rows} ]; then
+			stop=true
+			break;
+		fi
+
+		IFS=' ' a=(${line//|/ }); IFS=$'\n'
+		echo "INSERT INTO ${db_table_name} (name, age, phone, birth, country, company, email) VALUES ('${a[0]}', ${a[1]}, '${a[2]}', '${a[3]}', '${a[4]}', '${a[5]}', '${a[6]}');" >> \
+			 "${sql_file}"
+
+		((count++))
+	done
+done
+unset IFS
+
+createdb "${db_name}"
+echo "running sql file"
+time psql -d "${db_name}" -f "${sql_file}" > /dev/null
+rm -f "${sql_file}"

--- a/integration/pmem/data/lib.sh
+++ b/integration/pmem/data/lib.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+db_name="test"
+db_table_name="users"

--- a/integration/pmem/data/users.txt
+++ b/integration/pmem/data/users.txt
@@ -1,0 +1,50 @@
+Mia|8|1-878-506-7293|09-12-06|San Marino|Erat Vitae Risus Industries|mauris.Integer.sem@luctuset.edu
+April|9|1-476-475-4935|06-23-13|Congo, the Democratic Republic of the|Dui Ltd|porttitor.eros.nec@aliquet.co.uk
+Desirae|4|1-323-211-1417|05-22-17|Saint Pierre and Miquelon|Dictum Eu Placerat Consulting|Integer.urna@sit.org
+Keaton|3|1-731-750-8259|01-31-20|Samoa|Nibh Institute|quis.diam.luctus@dapibus.co.uk
+Fulton|6|1-839-967-2181|05-29-17|Chile|Orci Corp.|purus.Maecenas.libero@lacuspede.org
+Conan|8|1-947-556-4165|03-05-12|Nauru|In Dolor Fusce Foundation|molestie@ipsum.edu
+Isaiah|3|1-979-982-1576|10-11-20|Norway|Rutrum Fusce Corp.|Vivamus.rhoncus@pedePraesent.co.uk
+Dolan|5|1-731-522-4184|07-20-19|New Caledonia|Libero Est Corp.|Aliquam.nisl.Nulla@eleifendnec.co.uk
+Colt|3|1-104-481-3139|10-11-00|Netherlands|Consequat Nec Ltd|Nullam@elementumsemvitae.org
+Jenna|8|1-392-845-1268|09-16-19|South Sudan|Ac Arcu Institute|non.cursus@elitpedemalesuada.net
+Roth|7|1-282-966-7511|09-21-06|Algeria|Diam Dictum Sapien Foundation|mollis.vitae.posuere@interdum.com
+Ciaran|8|1-568-638-7495|07-17-02|Kazakhstan|Auctor PC|et@etnetus.org
+Heidi|1|1-838-317-9035|09-18-05|El Salvador|Nunc Mauris Sapien Associates|ultrices@semvitae.ca
+David|5|1-495-952-2285|08-22-18|Swaziland|Sit Amet Dapibus PC|aliquam.iaculis.lacus@malesuada.co.uk
+Bethany|6|1-224-887-6250|02-07-14|Grenada|Diam Sed Company|Aenean.eget@vellectus.com
+Ryan|10|1-433-743-3598|05-03-18|Macao|Vestibulum Associates|Sed@dignissim.co.uk
+Kimberley|3|1-414-236-8418|07-18-12|Christmas Island|Sociis Natoque Penatibus Associates|fringilla.purus@Etiamimperdiet.ca
+Shelley|1|1-600-985-2890|06-05-11|Norfolk Island|Maecenas Malesuada Fringilla LLC|Nam.porttitor@ultrices.org
+Timothy|5|1-861-196-7838|11-14-06|Egypt|Nascetur LLC|malesuada.fames.ac@Morbivehicula.ca
+Jasper|9|1-850-517-0401|05-29-15|Holy See (Vatican City State)|Parturient Montes Nascetur Limited|Nunc@Vestibulumaccumsan.net
+Jordan|2|1-670-715-6431|02-03-18|Netherlands|Enim Company|nulla@natoquepenatibuset.net
+Heather|1|1-141-274-3979|05-21-17|Japan|Nulla Dignissim Maecenas LLC|elit.Nulla@eu.co.uk
+Darius|4|1-137-939-6498|12-15-05|Georgia|Accumsan Sed LLC|et@etmagnis.co.uk
+Hadley|2|1-687-457-7782|09-18-14|Kuwait|Sagittis Duis Gravida PC|Nulla.tincidunt.neque@loremDonecelementum.org
+Gloria|1|1-287-641-5914|09-15-10|Guinea-Bissau|Sed Et Libero Corporation|eu.eros.Nam@tinciduntvehicularisus.net
+Barry|2|1-846-581-1886|05-22-18|Luxembourg|Odio Phasellus Incorporated|vulputate@acrisusMorbi.co.uk
+Shad|2|1-639-780-2457|05-01-20|Senegal|Nec Tellus Corporation|ultricies.adipiscing@posuerecubilia.com
+Hilary|4|1-591-123-0234|11-23-09|Gabon|Tempor Diam Associates|eget.metus.In@famesacturpis.edu
+Burton|5|1-475-741-3332|08-16-16|Costa Rica|Nunc Inc.|commodo.tincidunt@duinec.net
+Adrian|5|1-467-133-2165|09-28-20|Marshall Islands|Vitae Industries|amet.luctus@Crasegetnisi.edu
+Baxter|8|1-240-908-5513|02-01-03|Malawi|Integer Foundation|non.justo.Proin@enim.edu
+Elliott|10|1-237-956-0542|10-16-14|Uganda|Nec Ante Corporation|lorem.lorem.luctus@mauris.net
+Olivia|7|1-506-903-7178|09-29-00|Vanuatu|Aenean Eget Metus PC|a@sem.net
+Lucian|7|1-622-647-9202|07-24-17|Albania|At Velit Consulting|suscipit@enimdiamvel.co.uk
+Jena|10|1-182-376-8455|03-27-13|Thailand|Et Magnis Dis Company|eu.dolor.egestas@arcuet.org
+Jocelyn|4|1-519-152-6133|08-09-14|New Zealand|Magna Corporation|dolor.Nulla.semper@enim.org
+Melissa|10|1-106-662-9720|12-14-12|Ecuador|Sed Est LLP|Cras@mieleifendegestas.ca
+Shana|5|1-340-840-0262|03-07-07|Cayman Islands|Amet Lorem Semper Limited|nascetur.ridiculus.mus@etarcuimperdiet.co.uk
+Lillian|5|1-373-254-6047|06-19-05|Czech Republic|Mattis Incorporated|sit.amet.diam@quisarcuvel.co.uk
+Cruz|9|1-759-816-4647|10-17-01|Dominica|In Lobortis Tellus Inc.|luctus@leoinlobortis.ca
+Cassandra|8|1-813-754-6078|09-30-09|New Caledonia|Cras Lorem Lorem Ltd|est@egettincidunt.co.uk
+Luke|10|1-350-972-1874|10-22-13|Botswana|Eleifend Cras Industries|mus.Aenean@Vivamusmolestiedapibus.edu
+Jared|10|1-136-782-5495|04-27-21|Algeria|Neque Institute|Nam.ligula.elit@euaccumsansed.ca
+Denise|10|1-372-600-8336|09-10-10|Venezuela|Non Lobortis PC|mattis@necligula.net
+Shannon|5|1-799-868-2692|10-18-19|Qatar|Mauris Integer Sem Corp.|euismod.urna.Nullam@orcilobortis.net
+Clarke|9|1-636-409-6331|02-17-06|Central African Republic|Sagittis Limited|diam.dictum.sapien@metussitamet.com
+Fletcher|2|1-701-579-5420|09-06-14|Lithuania|Nulla Ltd|pede@felisorci.org
+Scott|5|1-405-626-4008|12-06-17|Brazil|Donec Company|in.molestie@nonfeugiatnec.ca
+Theodore|8|1-350-456-9220|04-07-20|Turkey|Aliquam Tincidunt LLC|commodo.at.libero@Vivamussit.com
+Vivien|4|1-310-936-6729|11-12-20|Zambia|Tempor Augue Ac Corporation|ad.litora@neque.ca

--- a/integration/pmem/pmem_test.sh
+++ b/integration/pmem/pmem_test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+dir_path=$(dirname "$0")
+source "${dir_path}/../../lib/common.bash"
+source "${dir_path}/../../.ci/lib.sh"
+source "${dir_path}/data/lib.sh"
+source /etc/os-release || source /usr/lib/os-release
+osbuilder_repository="github.com/kata-containers/osbuilder"
+osbuilder_repository_path="${GOPATH}/src/${osbuilder_repository}"
+test_directory_name="test_pmem1"
+test_directory=$(mktemp -d --suffix="${test_directory_name}")
+TEST_INITRD="${TEST_INITRD:-no}"
+experimental_qemu="${experimental_qemu:-false}"
+# List of containers to remove before exit
+list_containers=()
+
+if [ "$TEST_INITRD" == "yes" ]; then
+	echo "Skip pmem test: nvdimm is disabled when initrd is used as rootfs"
+	exit 0
+fi
+
+if [ "$experimental_qemu" == "true" ]; then
+	echo "Skip pmem test: experimental qemu doesn't have libpmem support"
+	exit 0
+fi
+
+function setup() {
+	clean_env
+	check_processes
+	if [ ! -d "${osbuilder_repository_path}" ]; then
+		go get -d "${osbuilder_repository}" || true
+	fi
+}
+
+function ctr_rm_rf {
+	container=$1
+	while [ -n "$(ctr t list | grep RUNNING | grep "${container}")" ]; do
+		ctr t kill -a "${container}"
+		sleep 1
+	done
+	ctr c rm "${container}"
+}
+
+function test_pmem_mount {
+	local container_name="test-pmem"
+	local payload="tail -f /dev/null"
+	local image="docker.io/library/fedora:latest"
+
+	"${dir_path}/../../cmd/pmemctl/pmemctl.sh" -s 128M -f xfs -m "${test_directory}" xfs.img
+
+	ctr image pull "${image}"
+
+	list_containers+=(${container_name})
+
+	# Running container
+	ctr run -d --runtime ${RUNTIME} --mount type=bind,src="${test_directory}",dst="/${test_directory_name}",options=rbind:rw "${image}" "${container_name}" sh -c "${payload}"
+
+	# Check container
+	ctr t exec --exec-id 1 "${container_name}" mount | grep ${test_directory_name} | grep '/dev/pmem' | grep 'dax'
+
+	ctr_rm_rf "${container_name}"
+	sudo umount "${test_directory}"
+	sudo losetup -D
+	rm -f xfs.img
+}
+
+function wait_for_postgres {
+	container="$1"
+	for i in $(seq 1 20); do
+		if ctr t exec --exec-id 1 "${container}" su - postgres -c "psql -c '\l'"; then
+			break
+		fi
+		sleep 5
+	done
+}
+
+function test_database {
+	"${dir_path}/../../cmd/pmemctl/pmemctl.sh" -s 1G -f xfs -m "${test_directory}" xfs.img
+
+	rows=10000
+	cont_image="docker.io/library/postgres:latest"
+	postgresql_cont_dir="/var/lib/postgresql/data"
+
+	ctr image pull "${cont_image}"
+
+	producer_cont="producer"
+	list_containers+=(${producer_cont})
+	ctr run --runtime ${RUNTIME} -d \
+		--mount type=bind,src="${test_directory}",dst="${postgresql_cont_dir}",options=rbind:rw \
+		--mount type=bind,src=$(realpath ${dir_path}/data),dst=/data,options=rbind:rw \
+		--env POSTGRES_PASSWORD=mysecretpassword --env PGDATA="${postgresql_cont_dir}/pgdata" ${cont_image} "${producer_cont}"
+	ctr t exec --exec-id 1 "${producer_cont}" sh -c "mount | grep ${postgresql_cont_dir} | grep dax"
+	ctr t exec --exec-id 1 "${producer_cont}" chown postgres "${postgresql_cont_dir}"
+	wait_for_postgres "${producer_cont}"
+
+	echo "Inserting into the database..."
+	ctr t exec --exec-id 1 "${producer_cont}" su - postgres -c "/data/dbinsert.sh ${rows}"
+	ctr_rm_rf "${producer_cont}"
+
+	consumer_cont="consumer"
+	list_containers+=(${consumer_cont})
+	ctr run --runtime ${RUNTIME} -d \
+		--mount type=bind,src="${test_directory}",dst="${postgresql_cont_dir}/",options=rbind:rw \
+		--env POSTGRES_PASSWORD=mysecretpassword --env PGDATA="${postgresql_cont_dir}/pgdata" ${cont_image} "${consumer_cont}"
+	wait_for_postgres "${consumer_cont}"
+
+	echo "Checking the data base..."
+	ctr t exec --exec-id 1 "${consumer_cont}" su - postgres -c "psql -d \"${db_name}\" \
+		-c \"select count(*) from ${db_table_name}\" | grep ${rows}"
+
+	[ -n "$(ctr t exec --exec-id 1 "${consumer_cont}" su - postgres -c "psql -d \"${db_name}\" \
+	  --tuples-only -c \"select name from ${db_table_name} where id=1;\"")" ]
+
+	[ -n "$(ctr t exec --exec-id 1 "${consumer_cont}" su - postgres -c "psql -d \"${db_name}\" \
+	  --tuples-only -c \"select name from ${db_table_name} where id=${rows+100};\"")" ]
+
+	# check random rows
+	for i in $(seq 1 20); do
+		[ -n "$(ctr t exec --exec-id 1 "${consumer_cont}" su - postgres -c "psql -d \"${db_name}\" \
+		  --tuples-only -c \"select name from ${db_table_name} where id=$((RANDOM%rows+1));\"")" ]
+	done
+
+	ctr_rm_rf "${consumer_cont}"
+}
+
+function teardown() {
+	sudo umount "${test_directory}"
+	sudo losetup -D
+	sudo rm -rf "${test_directory}"
+	for c in ${list_containers[*]}; do
+		ctr_rm_rf "${c}" 2&> /dev/null || true
+	done
+
+	clean_env
+	check_processes
+}
+
+trap teardown EXIT
+
+echo "Running setup"
+setup
+
+echo "Running pmem mount test"
+test_pmem_mount
+
+echo "Running database pmem test"
+test_database


### PR DESCRIPTION
95da0fa8  ci: rename 2.0-dev to main
f8b5d40b integration: Add PMEM test for 2.0
0da05670 integration: Add PMEM test for 2.0
211e39fd tests: Update instructions for running tests for kata 2.0
b42fc188 ci/lib.sh: fix bug of pid match error.
e71604b2 ci: vfio: fix warning: Error loading config file
6f5c819b ci: Enable Firecracker CI for kata 2.x
241e5e21 ci: Enable clh+containerd k8s e2e testing