### PR TITLE
ci: fix scripts for centos 8

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -75,6 +75,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
+	[make]="make" \
 )
 
 main()

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -50,7 +50,7 @@ echo "Install chronic"
 sudo -E yum -y install moreutils
 
 if [ "$centos_version" == "8" ]; then
-	chronic sudo -E yum install pkgconf-pkg-config
+	chronic sudo -E yum install -y pkgconf-pkg-config
 fi 
 
 declare -A minimal_packages=( \


### PR DESCRIPTION
Fix various issues to be able to run `jenkins_job_build.sh` on centos 8. Right now, I hardcoded the docker version, until we decide which is the right one to pick. For more details check  #3245

cc @fidencio 