### PR TITLE
backport: Changes for stable-2.0

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -53,7 +53,7 @@ build_install_shim_v2(){
 	fi
 	pushd "$runtime_src_path"
 	make
-	sudo make install
+	sudo -E PATH=$PATH make install
 	popd
 }
 

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -260,7 +260,6 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
-	export experimental_kernel="true"
 	;;
 "CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
 	init_ci_flags
@@ -269,7 +268,14 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
-	export experimental_kernel="true"
+	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
+	init_ci_flags
+	export MINIMAL_CONTAINERD_K8S_E2E="false"
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
 	;;
 "VFIO")
 	init_ci_flags
@@ -291,11 +297,6 @@ if [ "${CI_JOB}" == "VFIO" ]; then
 	export AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_image.sh"
 
-	echo "Installing QEMU experimental to get virtiofsd"
-	sudo -E PATH=$PATH "${ci_dir_name}/install_qemu_experimental.sh"
-
-	echo "Installing experimental kernel"
-	export experimental_kernel=true
 	sudo -E PATH=$PATH "${ci_dir_name}/install_kata_kernel.sh"
 
 	echo "Installing Cloud Hypervisor"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -79,6 +79,8 @@ init_ci_flags() {
 	# Generate a report using a jenkins job data
 	# Name of the job to get data from
 	export METRICS_JOB_BASELINE=""
+	# Configure test to use Kata SHIM V2
+	export SHIMV2_TEST="true"
 }
 
 # Run noninteractive on debian and ubuntu

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -394,30 +394,6 @@ build_install_cmake() {
 	rm -fr "${tdir}"
 }
 
-build_install_musl() {
-	local version=$(get_version "externals.musl.version")
-	local url=$(get_version "externals.musl.url")
-	[ "${url}" != "null" ] && [ "${version}" != "null" ]
-	local file="musl-${version}.tar.gz"
-	local dir="musl-${version}"
-	local download="${url}/releases/${file}"
-	local tdir=$(mktemp -d)
-	local muslarch=$(uname -m)
-
-	pushd "${tdir}"
-	curl -sLO "${download}"
-	tar -zxf "${file}"
-	cd "${dir}"
-	sed -i "s/^ARCH = .*/ARCH = ${muslarch}/g"  dist/config.mak
-	./configure
-	make
-	sudo make install
-	sudo echo '"/usr/local/musl/lib"' > /etc/ld-musl-${muslarch}.path
-	export PATH=${PATH}:/usr/local/musl/bin
-	popd
-	rm -fr "${tdir}"
-}
-
 check_git_version() {
 	result="true"
 

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -14,6 +14,9 @@ source "${cidir}/lib.sh"
 echo "Update apt repositories"
 sudo -E apt update
 
+echo "Try to preemptively fix broken dependencies, if any"
+sudo -E apt --fix-broken install -y
+
 echo "Install chronic"
 sudo -E apt install -y moreutils
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -567,13 +567,12 @@ static_check_docs()
 
 		local version
 		local url
-		local dir
 
 		version=$(get_test_version "externals.xurls.version")
 		url=$(get_test_version "externals.xurls.url")
-		dir=$(echo "$url"|sed 's!https://!!g')
 
-		build_version "${dir}" "" "${version}"
+		# xurls is very fussy about how it's built.
+		GO111MODULE=on go get "${url}@${version}"
 	fi
 
 	info "Checking documentation"

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,11 @@ swarm:
 	cd integration/swarm && \
 	bats swarm.bats
 
+stability:
+	cd integration/stability && \
+	ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
+	cd integration/stability && ./hypervisor_stability_kill_test.sh
+
 shimv2:
 	bash integration/containerd/shimv2/shimv2-tests.sh
 	bash integration/containerd/shimv2/shimv2-factory-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,8 @@ ifeq (${CI}, true)
         endif
 endif
 
-# union for 'make test'
-UNION := functional debug-console $(DOCKER_DEPENDENCY) openshift crio docker-compose network \
-	docker-stability oci netmon kubernetes swarm vm-factory \
-	entropy ramdisk shimv2 tracing time-drift compatibility vcpus $(PODMAN_DEPENDENCY)
+# union for `make test`
+UNION := crio kubernetes pmem
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
         * [Requirements to run Kata Containers tests](#requirements-to-run-kata-containers-tests)
         * [Prepare an environment](#prepare-an-environment)
         * [Run the tests](#run-the-tests)
-        * [Running subsets of tests](#running-subsets-of-tests)
-            * [Running `Bats` based tests](#running-bats-based-tests)
-            * [Running `Ginkgo` based tests](#running-ginkgo-based-tests)
-    * [Metrics tests](#metrics-tests)
     * [Kata Admission controller webhook](#kata-admission-controller-webhook)
 
 This repository contains various types of tests and utilities (called
@@ -36,19 +32,11 @@ $ go get -d github.com/kata-containers/tests
 We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
-1. [Functional tests](https://github.com/kata-containers/tests/tree/master/functional)
-2. Integration tests to ensure compatibility with:
-   - [Docker](https://github.com/kata-containers/tests/tree/master/integration/docker)
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/master/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/master/integration/cri-o)
-   - [Containerd](https://github.com/kata-containers/tests/tree/master/integration/containerd)
-   - [OpenShift](https://github.com/kata-containers/tests/tree/master/integration/openshift)
-3. [Network tests](https://github.com/kata-containers/tests/tree/master/integration/network)
-4. [Stability tests](https://github.com/kata-containers/tests/tree/master/integration/stability)
-5. [Metrics](https://github.com/kata-containers/tests/tree/master/metrics)
-
-> **Note:** The unit tests of the different Kata Containers components are stored in each repository
-> along with the source code they test.
+1. Integration tests to ensure compatibility with:
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/2.0-dev/integration/kubernetes)
+   - [CRI-O](https://github.com/kata-containers/tests/tree/2.0-dev/integration/cri-o)
+   - [Containerd](https://github.com/kata-containers/tests/tree/2.0-dev/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/2.0-dev/integration/stability)
 
 ## CI Content
 
@@ -211,7 +199,7 @@ all steps from the beginning and not from the failed step.
 ### Run the tests
 
 If you have already installed the Kata Containers packages and a container
-manager (i.e. Docker or Kubernetes), and you want to execute the content
+manager (i.e. Kubernetes), and you want to execute the content
 for all the tests, run the following:
 
 ```
@@ -221,9 +209,9 @@ $ sudo -E PATH=$PATH make test
 ```
 
 You can also execute a single test suite. For example, if you want to execute
-the docker integration tests, run the following:
+the Kubernetes integration tests, run the following:
 ```
-$ sudo -E PATH=$PATH make docker
+$ sudo -E PATH=$PATH make kubernetes
 ```
 
 A list of available test suite `make` targets can be found by running the
@@ -261,29 +249,5 @@ kubernetes:
         bash -f integration/kubernetes/run_kubernetes_tests.sh
 ```
 
-#### Running Ginkgo based tests
-
-Ginkgo supports selecting, filtering and excluding tests to be run using command
-line parameters. The tests repository `Makefile` supports passing the environment
-variables `FOCUS` and `SKIP` through to the `ginkgo` command in most cases. Check
-the `Makefile` specifics before you use this functionality.
-
-Ginkgo accepts [Golang regexp](https://golang.org/pkg/regexp/) regular expressions
-for the `FOCUS` and `SKIP` arguments. See the
-[Ginkgo documentation](https://onsi.github.io/ginkgo/#focused-specs) for more
-specifics. Example:
-
-```sh
-$ make docker					# all tests
-$ export FOCUS=".*CPU.*"; $ make docker		# any test with 'CPU' in its name
-$ export FOCUS="CPU constraints"; $ make docker	# One specific test
-$ export SKIP="CPU constraints"; $ make docker	# Skip one specific test
-```
-
-## Metrics tests
-
-See the [metrics documentation](metrics).
-
 ## Kata Admission controller webhook
-
 See the [webhook documentation](kata-webhook).

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -18,6 +18,7 @@ RUNTIME=${RUNTIME:-containerd-shim-kata-v2}
 SHIMV2_TEST=${SHIMV2_TEST:-""}
 FACTORY_TEST=${FACTORY_TEST:-""}
 KILL_VMM_TEST=${KILL_VMM_TEST:-""}
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 default_runtime_type="io.containerd.runtime.v1.linux"
 # Type of containerd runtime to be tested
@@ -260,7 +261,7 @@ main() {
 	TestSandboxCleanRemove
 	)
 
-	if [ "${KATA_HYPERVISOR:-}" == "cloud-hypervisor" ]; then
+	if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 		issue="https://github.com/kata-containers/tests/issues/2318"
 		info "${KATA_HYPERVISOR} fails with TestContainerListStatsWithSandboxIdFilter }"
 		info "see ${issue}"

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -12,7 +12,6 @@ issue="https://github.com/cri-o/cri-o/issues/4353"
 setup() {
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
-	pod_name="test-env"
 	get_pod_config_dir
 	file_name="file.txt"
 	content="Hello"
@@ -21,7 +20,15 @@ setup() {
 @test "Copy file in a pod" {
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-env.yaml"
+	pod_name="pod-copy-file-from-host"
+	ctr_name="ctr-copy-file-from-host"
+
+	pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
+	cp "$pod_config_dir/busybox-template.yaml" "$pod_config"
+	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
+	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
+
+	kubectl create -f "${pod_config}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready pod "$pod_name"
@@ -39,13 +46,29 @@ setup() {
 @test "Copy from pod to host" {
 	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-env.yaml"
+	pod_name="pod-copy-file-to-host"
+	ctr_name="ctr-copy-file-to-host"
+
+	pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
+	cp "$pod_config_dir/busybox-template.yaml" "$pod_config"
+	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
+	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
+
+	kubectl create -f "${pod_config}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready pod "$pod_name"
 
+	kubectl logs "$pod_name" || true
+	kubectl describe pod "$pod_name" || true
+	kubectl get pods --all-namespaces
+
 	# Create a file in the pod
 	kubectl exec "$pod_name" -- sh -c "cd /tmp && echo $content > $file_name"
+
+	kubectl logs "$pod_name" || true
+	kubectl describe pod "$pod_name" || true
+	kubectl get pods --all-namespaces
 
 	# Copy file from pod to host
 	kubectl cp "$pod_name":/tmp/"$file_name" "$file_name"

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -7,9 +7,10 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
-issue="https://github.com/kata-containers/tests/issues/2574"
+issue="https://github.com/cri-o/cri-o/issues/4353"
 
 setup() {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="test-env"
 	get_pod_config_dir
@@ -18,6 +19,7 @@ setup() {
 }
 
 @test "Copy file in a pod" {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -35,6 +37,7 @@ setup() {
 }
 
 @test "Copy from pod to host" {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
@@ -52,6 +55,7 @@ setup() {
 }
 
 teardown() {
+	[ "${CI_JOB}" == "CRIO_K8S" ] && skip "test not working with CRI-O - see: ${issue}"
 	rm -f "$file_name"
 	kubectl delete pod "$pod_name"
 }

--- a/integration/kubernetes/k8s-uts+ipc-ns.bats
+++ b/integration/kubernetes/k8s-uts+ipc-ns.bats
@@ -11,18 +11,22 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 setup() {
 	busybox_image="busybox"
 	export KUBECONFIG="$HOME/.kube/config"
-	first_pod_name="first-test"
-	second_pod_name="second-test"
+	first_pod_name="pod-first-test"
+	first_ctr_name="ctr-first-test"
+	second_pod_name="pod-second-test"
+	second_ctr_name="ctr-second-test"
 	# Pull the images before launching workload.
 	sudo -E crictl pull "$busybox_image"
 
 	get_pod_config_dir
 	first_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$first_pod_config"
-	sed -i "s/NAME/${first_pod_name}/" "$first_pod_config"
+	sed -i "s/POD_NAME/${first_pod_name}/" "$first_pod_config"
+	sed -i "s/CTR_NAME/${first_ctr_name}/" "$first_pod_config"
 	second_pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
 	cp "$pod_config_dir/busybox-template.yaml" "$second_pod_config"
-	sed -i "s/NAME/${second_pod_name}/" "$second_pod_config"
+	sed -i "s/POD_NAME/${second_pod_name}/" "$second_pod_config"
+	sed -i "s/CTR_NAME/${second_ctr_name}/" "$second_pod_config"
 
 	uts_cmd="ls -la /proc/self/ns/uts"
 	ipc_cmd="ls -la /proc/self/ns/ipc"

--- a/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: first-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     env:
     - name: CONTAINER_NAME
       value: "first-test-container"
@@ -21,7 +21,7 @@ spec:
         - sleep
         - "30"
   - name: second-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     env:
     - name: CONTAINER_NAME
       value: "second-test-container"

--- a/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -6,14 +6,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: NAME
+  name: POD_NAME
 spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   shareProcessNamespace: true
   containers:
-  - name: busybox
-    image: busybox
+  - name: CTR_NAME
+    image: quay.io/prometheus/busybox:latest
     command:
       - sleep
       - "120"

--- a/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -12,14 +12,14 @@ spec:
   runtimeClassName: kata
   initContainers:
   - name: first
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/initContainer" ]
     volumeMounts:
       - mountPath: /volume
         name: volume
   containers:
   - name: last
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/container; tail -f /dev/null" ]
     volumeMounts:
     - mountPath: /volume

--- a/integration/kubernetes/runtimeclass_workloads/job-template.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job-template.yaml
@@ -20,6 +20,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: test
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["tail", "-f", "/dev/null"]
       restartPolicy: Never

--- a/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -14,7 +14,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: pi
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["/bin/sh", "-c", "echo 'scale=5; 4*a(1)' | bc -l"]
       restartPolicy: Never
   backoffLimit: 4

--- a/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: handlers-container
-    image: "${nginx_version}"
+    image: quay.io/sjenning/${nginx_version}
     lifecycle:
       postStart:
         exec:

--- a/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginx
-        image: "${nginx_version}"
+        image: quay.io/sjenning/${nginx_version}
         ports:
         - containerPort: 80

--- a/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
@@ -12,5 +12,5 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-besteffort
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -7,7 +7,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: my-container
-      image: ubuntu:18.04
+      image: quay.io/footloose/ubuntu18.04
       command: ["tail", "-f", "/dev/null"]
       volumeDevices:
         - devicePath: DEVICE_PATH

--- a/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-burstable
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:

--- a/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["tail", "-f", "/dev/null"]
       env:
         - name: KUBE_CONFIG_1

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
@@ -12,5 +12,5 @@ spec:
   runtimeClassName: kata
   containers:
   - name: default-cpu-demo-ctr
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: first-cpu-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
         - sleep
         - "30"

--- a/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["tail", "-f", "/dev/null"]
   dnsPolicy: "None"
   dnsConfig:

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: test
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     volumeMounts:
       - name: host-empty-vol

--- a/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: [ "sh", "-c"]
       args:
       - while true; do

--- a/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
@@ -52,7 +52,7 @@ spec:
   # These containers are run during pod initialization
   initContainers:
   - name: install
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["sh", "-c", "chmod 700 /root/.ssh"]
     volumeMounts:
     - name: ssh-dir

--- a/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: qos-guaranteed
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:

--- a/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
@@ -14,7 +14,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: liveness
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     args:
     - /bin/sh
     - -c

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: memory-test-ctr
-    image: polinux/stress
+    image: containerstack/alpine-stress:latest
     resources:
       limits:
         memory: "${memory_size}"

--- a/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -12,13 +12,13 @@ spec:
   runtimeClassName: kata
   containers:
   - name: c1
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     resources:
       limits:
         cpu: "500m"
   - name: c2
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
       - sleep
       - "10"

--- a/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: test-projected-volume
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
     volumeMounts:
     - name: all-in-one

--- a/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -21,5 +21,5 @@ spec:
       runtimeClassName: kata
       containers:
       - name: pod-quota-demo
-        image: busybox
+        image: quay.io/prometheus/busybox:latest
         command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: envars-test-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     env:
     - name: SECRET_USERNAME

--- a/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
@@ -12,7 +12,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: test-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       command: ["/bin/sh", "-c", "tail -f /dev/null"]
       volumeMounts:
           # name must match the volume name below

--- a/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -14,5 +14,5 @@ spec:
     runAsUser: 1000
   containers:
   - name: sec-text
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]

--- a/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
@@ -16,14 +16,14 @@ spec:
     emptyDir: {}
   containers:
   - name: busybox-first-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     volumeMounts:
     - name: shared-data
       mountPath: /tmp
     command: ["/bin/sh"]
     args: ["-c", "tail -f /dev/null"]
   - name: busybox-second-container
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     volumeMounts:
     - name: shared-data
       mountPath: /tmp

--- a/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -18,11 +18,11 @@ spec:
   - name: test
     securityContext:
       privileged: true
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ["tail", "-f", "/dev/null"]
   initContainers:
   - name: init-sys
     securityContext:
       privileged: true
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command: ['sh', '-c', 'echo "64000" > /proc/sys/vm/max_map_count']

--- a/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -16,7 +16,7 @@ spec:
        claimName: pv-claim
   containers:
     - name: pv-container
-      image: busybox
+      image: quay.io/prometheus/busybox:latest
       ports:
       command:
         - sleep

--- a/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: master
-        image: redis
+        image: quay.io/libpod/redis
         resources:
           requests:
             cpu: 100m

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginxtest
-        image: "${nginx_version}"
+        image: quay.io/sjenning/${nginx_version}
         ports:
         - containerPort: 80

--- a/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -11,7 +11,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: c1
-    image: busybox
+    image: quay.io/prometheus/busybox:latest
     command:
       - sh
     tty: true

--- a/kata-webhook/Dockerfile
+++ b/kata-webhook/Dockerfile
@@ -5,6 +5,7 @@ FROM golang:latest AS builder
 
 WORKDIR /go/src/kata-pod-annotate
 
+COPY ../vendor ./
 COPY . ./
 RUN CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -231,6 +231,16 @@ clean_env()
 	fi
 }
 
+clean_env_ctr()
+{
+	check_containers=$(sudo ctr c list -q | wc -l)
+	if ((${check_containers})); then
+		sudo ctr tasks kill $(sudo ctr task list -q)
+		sudo ctr tasks rm -f $(sudo ctr task list -q)
+		sudo ctr c rm $(sudo ctr c list -q)
+	fi
+}
+
 get_pod_config_dir() {
 	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	info "k8s configured to use runtimeclass"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -14,7 +14,7 @@ VC_POD_DIR="${VC_POD_DIR:-/run/vc/sbs}"
 RUN_SBS_DIR="${RUN_SBS_DIR:-/run/vc/sbs}"
 
 # Kata tests directory used for storing various test-related artifacts.
-KATA_TESTS_BASEDIR="${KATA_TESTS_LOGDIR:-/var/log/kata-tests}"
+KATA_TESTS_BASEDIR="${KATA_TESTS_BASEDIR:-/var/log/kata-tests}"
 
 # Directory that can be used for storing test logs.
 KATA_TESTS_LOGDIR="${KATA_TESTS_LOGDIR:-${KATA_TESTS_BASEDIR}/logs}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -33,7 +33,7 @@ docker_images:
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
-    version: "1.17.0-alpine"
+    version: "1.15-alpine"
 
 externals:
   description: "Third-party projects used specifically for testing"

--- a/versions.yaml
+++ b/versions.yaml
@@ -45,8 +45,8 @@ externals:
   xurls:
     description: |
       Tool used by the CI to check URLs in documents and code comments.
-    url: "https://mvdan.cc/xurls/cmd/xurls"
-    version: "70405f5eab516c9f7b626d803b043415809499a6"
+    url: "mvdan.cc/xurls/v2/cmd/xurls"
+    version: "v2.2.0"
 
   go-md2man:
     description: "cri-o dependency used for building documentation"


### PR DESCRIPTION
6ae704da tests: Update instructions for running tests for kata 2.0
9e583fbb integration,k8s: Rely on quay.io images instead of dockerhub ones
6e121816 integration/kubernetes: Strength the k8s-block-volume test
09259b03 k8s: Change pod spec used in k8s-copy-file.bats
4cbcde98 k8s: Skip "k8s-copy-file" tests with CRI-O
f34717aa tests/cri-containerd: Set default value to KATA_HYPERVISOR
2111bc77 kata-webhook: simplify building kata-webhook container
1a4f4f99 CI: Fix xurls url
c16e0a72 lib/common.bash: Fix overwrite of KATA_TESTS_BASEDIR
da6593b5 ci: Init and document SHIMV2_TEST envvar.
3850b74f ci: Not use experimental kernel and qemu
1aa06ca3 ubuntu: Preemptively do an 'apt --fix-broken install'
22acc49e tests: Remove unused build_install_musl function
8e97469a tests: Enable hypervisor stability kill test
3992a628 ci/install_runtime: export PATH on sudo env properly