### PR TITLE
labels: Update related label to use kata 2.0

### DIFF
--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -110,7 +110,7 @@ categories:
   - name: related
     description: |
       Related project. Base set can be generated from
-      https://github.com/kata-containers/runtime/blob/master/versions.yaml.
+      https://github.com/kata-containers/kata-containers/blob/main/versions.yaml.
 
   - name: release
     description: Related to production of new versions.


### PR DESCRIPTION
This PR updates the related label to use the proper repository
for kata 2.0

Fixes #3248

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>