### PR TITLE
ci: Disable the `CPU constraints` docker tests for firecracker

### DIFF
--- a/.ci/hypervisors/firecracker/configuration_firecracker.yaml
+++ b/.ci/hypervisors/firecracker/configuration_firecracker.yaml
@@ -26,6 +26,7 @@ docker:
     - docker volume
     - docker env
     - CPUs and CPU set
+    - CPU constraints
     - docker exit code
     - run container with docker
     - run hot plug block devices


### PR DESCRIPTION
As we fixed the CPU constraints docker tests in #3242, the firecracker
CI is now failing on this test as expected as firecracker is missing the
CPU hotplug functionality. Let's skip the `CPU constraints` docker tests
along with all other CPU related tests in firecracker CI.

Fixes: #3250

Signed-off-by: Bo Chen <chen.bo@intel.com>