### PR TITLE
[DNM] ci: Debug on the failures from CRI_CONTAINERD_K8S CI job

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -20,11 +20,14 @@ case "${CI_JOB}" in
 	"CRI_CONTAINERD_K8S")
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 
 		# Make sure the feature works with K8s + containerd
+		echo "INFO: Containerd checks with 'sandbox_cgroup_only=true'"
 		"${cidir}/toggle_sandbox_cgroup_only.sh" true
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		echo "INFO: Running kubernetes tests with 'sandbox_cgroup_only=true'"
 		"${cidir}/toggle_sandbox_cgroup_only.sh" true
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		# remove config created by toggle_sandbox_cgroup_only.sh


### PR DESCRIPTION
To help debug on the failures from the CRI_CONTAINERD_K8S CI job, this
patch prints more information in the '.ci/run.sh' script.

Depends-on: github.com/kata-containers/runtime#3138

Signed-off-by: Bo Chen <chen.bo@intel.com>