### PR TITLE
metrics: update blogbench values for metric4

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-kata-metric4.toml
@@ -55,7 +55,7 @@ description = "measure container average of blogbench write"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
-midval = 842.25
+midval = 582.0
 minpercent = 10.0
 maxpercent = 10.0
 
@@ -68,6 +68,6 @@ description = "measure container average of blogbench read"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .read.Result"
 checktype = "mean"
-midval = 48055.25
+midval = 31460.0
 minpercent = 10.0
 maxpercent = 10.0


### PR DESCRIPTION
Tests are consistently failing. Let's update blogbench values based on
observed values.

Fixes: #3253

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>