### PR TITLE
Enable: Experimental virtiofs testing

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -83,11 +83,7 @@ install_cached_kernel(){
 	else
 		sudo -E curl -fL --progress-bar "${latest_build_url}/${kernel_binary_name}" -o "${kernel_binary_path}" || return 1
 	fi
-	if [ "${experimental_kernel}" == "true" ]; then
-		kernel_symlink="${kernel_dir}/${kernel_binary}-virtiofs.container"
-	else
-		kernel_symlink="${kernel_dir}/${kernel_binary}.container"
-	fi
+	kernel_symlink="${kernel_dir}/${kernel_binary}.container"
 	info "Installing ${kernel_binary_path} and symlink ${kernel_symlink}"
 	sudo -E ln -sf "${kernel_binary_path}" "${kernel_symlink}"
 }

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -58,6 +58,18 @@ build_and_install_kernel() {
 		"${kernel_repo_dir}/kernel/build-kernel.sh" -e setup
 		"${kernel_repo_dir}/kernel/build-kernel.sh" -e build
 		sudo -E PATH="$PATH" "${kernel_repo_dir}/kernel/build-kernel.sh" -e install
+
+		local vmlinux_symlink="${kernel_dir}/vmlinux.container"
+		local vmlinux_experimental_path=$(readlink -f "${kernel_dir}/vmlinux-experimental.container")
+		[ -e "$vmlinux_experimental_path" ] || die "Not found experimental kernel installed '${vmlinux_experimental_path}'"
+		info "Installing ${vmlinux_experimental_path} and symlink ${vmlinux_symlink}"
+		sudo -E ln -sf "${vmlinux_experimental_path}" "${vmlinux_symlink}"
+
+		local vmlinuz_symlink="${kernel_dir}/vmlinuz.container"
+		local vmlinuz_experimental_path=$(readlink -f "${kernel_dir}/vmlinuz-experimental.container")
+		[ -e "$vmlinuz_experimental_path" ] || die "Not found experimental kernel installed '${vmlinuz_experimental_path}'"
+		info "Installing ${vmlinuz_experimental_path} and symlink ${vmlinuz_symlink}"
+		sudo -E ln -sf "${vmlinuz_experimental_path}" "${vmlinuz_symlink}"
 		popd >> /dev/null
 	else
 		# Always build and install the kernel version found locally

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -90,11 +90,7 @@ case "${KATA_HYPERVISOR}" in
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"
 		;;
 	"qemu")
-		if [ "$experimental_qemu" == "true" ]; then
-			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-virtiofs.toml"
-		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
-		fi
 		if [ "$arch" == "x86_64" ]; then
 			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
 			# All CI now uses qemu 5.0+, disabled in the time..

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -81,6 +81,7 @@ init_ci_flags() {
 	export METRICS_JOB_BASELINE=""
 	# Configure test to use Kata SHIM V2
 	export SHIMV2_TEST="true"
+	export CTR_RUNTIME="io.containerd.run.kata.v2"
 }
 
 # Run noninteractive on debian and ubuntu
@@ -302,6 +303,11 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	export OPENSHIFT="no"
+	;;
+"VIRTIOFS_EXPERIMENTAL")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export KUBERNETES="yes"
 	;;
 "METRICS")
 	init_ci_flags

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -312,6 +312,7 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export KUBERNETES="yes"
 	export experimental_qemu="true"
+	export experimental_kernel="true"
 	;;
 "METRICS")
 	init_ci_flags

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -62,6 +62,9 @@ init_ci_flags() {
 	# Use experimental kernel
 	# Values: true|false
 	export experimental_kernel="false"
+	# Use experimental qemu
+	# Values: true|false
+	export experimental_qemu="false"
 	# Run the kata-check checks
 	export RUN_KATA_CHECK="true"
 
@@ -308,6 +311,7 @@ case "${CI_JOB}" in
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export KUBERNETES="yes"
+	export experimental_qemu="true"
 	;;
 "METRICS")
 	init_ci_flags

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -94,6 +94,9 @@ case "${CI_JOB}" in
 		echo "INFO: Running cloud hypervisor metrics tests"
 		sudo -E PATH="$PATH" ".ci/run_metrics_PR_ci.sh"
 		;;
+	"VIRTIOFS_EXPERIMENTAL")
+		sudo -E PATH="$PATH" bash -c "make filesystem"
+		;;
 	*)
 		echo "INFO: Running checks"
 		sudo -E PATH="$PATH" bash -c "make check"

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,9 @@ vcpus:
 pmem:
 	bash -f integration/pmem/pmem_test.sh
 
+filesystem:
+	bash -f ./conformance/posixfs/fstests.sh
+
 test: ${UNION}
 
 check: checkcommits log-parser
@@ -191,6 +194,7 @@ help:
 	crio \
 	docker \
 	docker-stability \
+	filesystem \
 	ginkgo \
 	$(INSTALL_TARGETS) \
 	podman \

--- a/conformance/posixfs/fstests.sh
+++ b/conformance/posixfs/fstests.sh
@@ -12,20 +12,15 @@ source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
 # Env variables
-IMAGE="${IMAGE:-fstest}"
+IMAGE="docker.io/library/local-fstest:latest"
 DOCKERFILE="${SCRIPT_PATH}/Dockerfile"
 CONT_NAME="${CONT_NAME:-fstest}"
 RUNTIME="${RUNTIME:-kata-runtime}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 
 function main() {
-	clean_env
-	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
-	ctr run --rm --runtime=${CTR_RUNTIME} $IMAGE test $CMD
-
-	docker exec $CONT_NAME bash -c "cd /pjdfstest && prove -r"
-
-	clean_env
+	check_ctr_images "$IMAGE" "$DOCKERFILE"
+	ctr run --rm --runtime=${CTR_RUNTIME} $IMAGE fstest bash -c "cd /pjdfstest && prove -r"
 }
 
 main "$@"

--- a/conformance/posixfs/fstests.sh
+++ b/conformance/posixfs/fstests.sh
@@ -21,11 +21,8 @@ PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 function main() {
 	clean_env
 	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
-	docker run -d --runtime $RUNTIME --name $CONT_NAME $IMAGE $PAYLOAD_ARGS
+	ctr run --rm --runtime=${CTR_RUNTIME} $IMAGE test $CMD
 
-	echo "WARNING: Removing failing tests (Issue https://github.com/kata-containers/runtime/issues/826" >&2
-	REMOVE_FILES="cd pjdfstest/tests && rm -f chown/00.t chmod/12.t link/00.t mkdir/00.t symlink/03.t mkfifo/00.t mknod/00.t mknod/11.t open/00.t"
-	docker exec $CONT_NAME bash -c "${REMOVE_FILES}"
 	docker exec $CONT_NAME bash -c "cd /pjdfstest && prove -r"
 
 	clean_env


### PR DESCRIPTION
Today kata containers uses qemu vanilla, but some new features  for virtiofs maybe helpful for some users or even to identify potencial issues with virtiofs new features.  Enable a job that  runs experimental virtiofs.

- Add new VIRTIOFS-EXPERIMENTAL job
- Enable posix filesystem test

Depends-on: https://github.com/kata-containers/kata-containers/pull/1422