### PR TITLE
makefile: Update the list of tests that will work with kata 2.0 docum…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq (${CI}, true)
 endif
 
 # union for 'make test'
-UNION := crio kubernetes pmem
+UNION := kubernetes
 
 # filter scheme script for docker integration test suites
 FILTER_FILE = .ci/filter/filter_docker_test.sh


### PR DESCRIPTION
…entation

This PR updates the list of the tests that will work with documentation of
how to run the tests for kata 2.0

Fixes #3156

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>