### PR TITLE
static-check: Change branch to main for kata 2.0

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -35,7 +35,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-master}
+branch=${branch:-main}
 
 # Which static check functions to consider.
 handle_funcs="all"


### PR DESCRIPTION
This PR changes the branch from master to main in order to test kata 2.0

Fixes #3258

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>