### PR TITLE
ci: Install ninja-build package on Ubuntu

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -28,7 +28,7 @@ declare -A minimal_packages=( \
 
 declare -A packages=( \
 	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils" \
-	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev" \
+	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev ninja-build" \
 	[kernel_dependencies]="libelf-dev flex" \
 	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev thin-provisioning-tools" \
 	[bison_binary]="bison" \


### PR DESCRIPTION
The ninja-build package is needed on Ubuntu for building QEMU 5.2
onward.

Fixes #3263

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>