### PR TITLE
static-checks: Do not inspect default-configs of QEMU

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -485,6 +485,7 @@ static_check_license_headers()
 			--exclude="*.patch" \
 			--exclude="*.diff" \
 			--exclude="tools/packaging/static-build/qemu.blacklist" \
+			--exclude="tools/packaging/qemu/default-configs/*" \
 			--exclude="src/agent/protocols/protos/gogo/*" \
 			--exclude="src/agent/protocols/protos/google/*" \
 			-EL $extra_args "\<${pattern}\>" \


### PR DESCRIPTION
Added tools/packaging/qemu/default-configs directory to the list
of exclusions for the license header checker.

Fixes #3275

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>