### PR TITLE
versions: Update versions yaml to use kata 2.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -8,9 +8,9 @@
 
 description: |
   This file contains test specific version details.
-  For other version details, see the master database:
+  For other version details, see the main database:
 
-  https://github.com/kata-containers/runtime/blob/master/versions.yaml
+  https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
 
 docker_images:
   description: "Docker hub images used for testing"


### PR DESCRIPTION
This PR updates the version yaml to use the proper repositories
for kata 2.0

Fixes #3279

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>