### PR TITLE
test: Modify vcpu test to use ctr

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -23,6 +23,8 @@ case "${CI_JOB}" in
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+		echo "INFO: Running vcpus test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vcpus"
 		echo "INFO: Skipping pmem test: Issue: https://github.com/kata-containers/tests/issues/3223"
 		# echo "INFO: Running pmem integration test"
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"


### PR DESCRIPTION
This PR modifies the vcpu test to use ctr in order to be
supported in kata 2.0

Fixes #3283

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>