### PR TITLE
test: Enable sandbox cgroup test for kata 2.0

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -26,6 +26,9 @@ case "${CI_JOB}" in
 		echo "INFO: Running vcpus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vcpus"
 		echo "INFO: Skipping pmem test: Issue: https://github.com/kata-containers/tests/issues/3223"
+		echo "INFO: Running stability test with sandbox_cgroup_only"
+		export TEST_SANDBOX_CGROUP_ONLY=true
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		# echo "INFO: Running pmem integration test"
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		;;

--- a/.ci/toggle_sandbox_cgroup_only.sh
+++ b/.ci/toggle_sandbox_cgroup_only.sh
@@ -64,6 +64,10 @@ if [ -f "${KATA_ETC_CONFIG_PATH}" ] && [ "${KATA_ETC_CONFIG_PATH}" != ${kata_con
 fi
 
 if [ "${KATA_ETC_CONFIG_PATH}" != "${kata_config_path}" ]; then
+	kata_etc_dir="/etc/kata-containers"
+	if [ ! -d "${kata_etc_dir}" ]; then
+		sudo mkdir -p "${kata_etc_dir}"
+	fi
 	info "Creating etc config based on ${kata_config_path}"
 	sudo cp "${kata_config_path}" "${KATA_ETC_CONFIG_PATH}"
 fi

--- a/integration/sandbox_cgroup/sandbox_cgroup_test.sh
+++ b/integration/sandbox_cgroup/sandbox_cgroup_test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 Intel Corporation
+# Copyright (c) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 # This will enable the sandbox_cgroup_only
-# to true in order to test that docker is
+# to true in order to test that ctr is
 # working properly when this feature is
 # enabled
 
@@ -26,20 +26,22 @@ if [ -z "${TEST_SANDBOX_CGROUP_ONLY}" ]; then
 fi
 
 function setup() {
-	clean_env
+	sudo systemctl restart containerd
+	clean_env_ctr
+	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_processes
 }
 
-function test_docker() {
+function test_stability() {
 	pushd "${GOPATH}/src/${tests_repo}"
 	".ci/toggle_sandbox_cgroup_only.sh" true
-	sudo -E PATH="$PATH" bash -c "make docker"
+	sudo -E PATH="$PATH" bash -c "make stability"
 	".ci/toggle_sandbox_cgroup_only.sh" false
 	popd
 }
 
 function teardown() {
-	clean_env
+	clean_env_ctr
 	check_processes
 }
 
@@ -48,5 +50,5 @@ trap teardown EXIT
 echo "Running setup"
 setup
 
-echo "Running docker integration tests with sandbox cgroup enabled"
-test_docker
+echo "Running stability integration tests with sandbox cgroup enabled"
+test_stability


### PR DESCRIPTION
This PR enables the sandbox cgroup test for kata 2.0 in order to use
ctr stability tests instead of docker integration tests.

Fixes #3291

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>