### PR TITLE
static: rustfmt check output the details on the files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -347,7 +347,7 @@ static_check_rust_arch_specific()
 		return
 	fi
 
-	{ find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check > /dev/null 2>&1; ret=$?; } || true
+	{ find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check; ret=$?; } || true
 
 	[ $ret -eq 0 ] || die "crate not formatted by rustfmt."
 }


### PR DESCRIPTION
It's better to output the details onto the log about
the rustfmt check, such it's better for developers to know
which files needed to be formated.

Fixes: #3294

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>