### PR TITLE
openshift-ci: Enable the virtio-fs backend

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -75,9 +75,3 @@ unset VERSION
 "${cidir}/install_kata_image.sh"
 
 "${cidir}/install_runtime.sh"
-config_file="${DESTDIR}/${PREFIX}/share/defaults/kata-containers/configuration.toml"
-# TODO: currently the virtio-fs backend cannot be tested on OpenShift.
-# See issue https://github.com/kata-containers/kata-containers/issues/1238
-if [ -f "$config_file" ]; then
-	sed -i 's|^shared_fs = "virtio-fs"|shared_fs = "virtio-9p"|g' "$config_file"
-fi


### PR DESCRIPTION
Until now the openshift-ci CI job was testing Kata Containers with the
9p shared fs backend because the version 5.0 of QEMU have a bug which
prevents virtiofsd from working properly on OpenShift. With the recent bump
on the version (5.2) of QEMU, it is now possible to test with the virtio-fs
backend instead.

Fixes #3299
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>