### PR TITLE
checkmetrics: Update history tool to update jenkins jobs

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -17,8 +17,8 @@ NUM_BUILDS=5
 
 # What is the default set of repos (Jenkins jobs) we evaluate
 default_repos=()
-default_repos+=("kata-containers-2.0-metrics-ubuntu-18-04-PR")
-default_repos+=("kata-containers-2.0-tests-metrics-ubuntu-18-04-PR")
+default_repos+=("kata-containers-2.0-metrics-ubuntu-20-04-PR")
+default_repos+=("kata-containers-2.0-tests-metrics-ubuntu-20-04-PR")
 repos=()
 
 # What test results do we evaluate for each build


### PR DESCRIPTION
This PR updates the checkmetrics history tool to use ubuntu 20.04
instead of 18.04 jenkins jobs which are being used in kata 2.x

Fixes #3309

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>