### PR TITLE
ci: Use CRI-O as CRI_RUNTIME for vfio tests in 2.0

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -296,9 +296,8 @@ case "${CI_JOB}" in
 ;;
 "VFIO")
 	init_ci_flags
-	export CRIO="no"
-	export CRI_CONTAINERD="yes"
-	export CRI_RUNTIME="containerd"
+	export CRIO="yes"
+	export CRI_CONTAINERD="no"
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	export OPENSHIFT="no"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -73,7 +73,7 @@ case "${CI_JOB}" in
 		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"
+		sudo -E PATH="$PATH" CRI_RUNTIME="crio" bash -c "make vfio"
 		;;
 	"METRICS")
 		export RUNTIME="kata-runtime"


### PR DESCRIPTION
This PR updates to use CRI-O as a CRI_RUNTIME for vfio tests in
2.0 in order to avoid the random failures that we got with
containerd.

Fixes #3318

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>