### PR TITLE
metrics: Enable iperf3 bandwith test

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -309,7 +309,7 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="no"
+	export KUBERNETES="yes"
 	export OPENSHIFT="no"
 	export METRICS_CI=1
 ;;

--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -56,9 +56,13 @@ run() {
 
 		# Run the time tests
 		bash time/launch_times.sh -i mirror.gcr.io/library/ubuntu:latest -n 20
+
+		# Run iperf3 bandwidth test
+		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b
 	fi
 
 	# Run storage tests
+	sudo systemctl restart docker
 	bash storage/blogbench.sh
 
 	# Skip: Issue: https://github.com/kata-containers/tests/issues/3203

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -71,3 +71,16 @@ checktype = "mean"
 midval = 48055.25
 minpercent = 10.0
 maxpercent = 10.0
+
+[[metric]]
+name = "network-iperf3-bandwidth"
+type = "json"
+description = "measure container bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3-bandwidth\".Results | .[] | .bandwidth.Result"
+checktype = "mean"
+midval = 30811123135.60
+minpercent = 10.0
+maxpercent = 10.0

--- a/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -41,13 +41,13 @@ function iperf3_bandwidth() {
 	# Start server
 	local transmit_timeout="30"
 
-	kubectl exec -ti "$client_pod_name" -- sh -c "iperf3 -J -c ${server_ip_add} -t ${transmit_timeout}" | jq '.end.sum_received.bits_per_second' > "${iperf_file}"
+	kubectl exec -i "$client_pod_name" -- sh -c "iperf3 -J -c ${server_ip_add} -t ${transmit_timeout}" | jq '.end.sum_received.bits_per_second' > "${iperf_file}"
 	result=$(cat "${iperf_file}")
 
 	local json="$(cat << EOF
 	{
 		"bandwidth": {
-			"Result" : "$result",
+			"Result" : $result,
 			"Units" : "bits per second"
 		}
 	}
@@ -69,13 +69,13 @@ function iperf3_utc_jitter() {
 	# Start server
 	local transmit_timeout="30"
 
-	kubectl exec -ti "$client_pod_name" -- sh -c "iperf3 -J -c ${server_ip_add} -u -t ${transmit_timeout}" | jq '.end.sum.jitter_ms' > "${iperf_file}"
+	kubectl exec -i "$client_pod_name" -- sh -c "iperf3 -J -c ${server_ip_add} -u -t ${transmit_timeout}" | jq '.end.sum.jitter_ms' > "${iperf_file}"
 	result=$(cat "${iperf_file}")
 
 	local json="$(cat << EOF
 	{
 		"jitter": {
-			"Result" : "$result",
+			"Result" : $result,
 			"Units" : "ms"
 		}
 	}


### PR DESCRIPTION
This PR enables the iperf3 bandwidth test for the metrics CI.

Fixes #3320

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>