### PR TITLE
test: Update image for the stability test for kata 2.0

### DIFF
--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -14,7 +14,7 @@ cidir=$(dirname "$0")
 source "${cidir}/../../metrics/lib/common.bash"
 
 # Environment variables
-IMAGE="${IMAGE:-docker.io/library/busybox:latest}"
+IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
 CONTAINER_NAME="${CONTAINER_NAME:-test}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 


### PR DESCRIPTION
To avoid the failure of using docker images due to the pull limits,
this PR updates the image to use for the test.

Fixes #3323

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>