### PR TITLE
ci: Increasing log file split size to reduce log files count

### DIFF
--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -102,8 +102,8 @@ collect_logs()
 			cp "${tracing_log_directory}/${tracing_log_filename}" "${tracing_log_path}"
 		fi
 
-		# Split them in 5 MiB subfiles to avoid too large files.
-		local -r subfile_size=5242880
+		# Split them in 50 MiB subfiles to avoid too large files.
+		local -r subfile_size=52428800
 
 		pushd "${log_copy_dest}"
 		split -b "${subfile_size}" -d "${containerd_shim_kata_v2_log_path}" "${containerd_shim_kata_v2_log_prefix}"


### PR DESCRIPTION
- Background

At the teardown phase, the log collection will split log files by size 5M,
this is the original log file size, after gzipped, the file size may be only 300k.

- Problem

In some cases of failings, there will be too many log files.

- How to fix

Increasing log split size from 5M to 50M should decrease the final log file count.

Fixes: #3328

Signed-off-by: bin liub <bin@hyper.sh>