### PR TITLE
metrics: Enable iperf3 jitter test on metrics CI 2.0

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -57,8 +57,8 @@ run() {
 		# Run the time tests
 		bash time/launch_times.sh -i mirror.gcr.io/library/ubuntu:latest -n 20
 
-		# Run iperf3 bandwidth test
-		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b
+		# Run iperf3 network tests
+		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
 	fi
 
 	# Run storage tests

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -84,3 +84,16 @@ checktype = "mean"
 midval = 30811123135.60
 minpercent = 10.0
 maxpercent = 10.0
+
+[[metric]]
+name = "network-iperf3-jitter"
+type = "json"
+description = "measure container utc jitter using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3-jitter\".Results | .[] | .jitter.Result"
+checktype = "mean"
+midval = 0.0221
+minpercent = 20.0
+maxpercent = 20.0


### PR DESCRIPTION
This PR enables the iperf3 jitter test for the metrics CI for
kata 2.0

Fixes #3331

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>