### PR TITLE
metrics: Define new memory footprint value for kata 1.x

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-kata-metric3.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 135767.0
+midval = 165251.0
 minpercent = 5.0
 maxpercent = 7.0
 


### PR DESCRIPTION
This PR defines a new memory footprint limit value for kata 1.x

Fixes #3335

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>