### PR TITLE
tests: Wait for the pods to be ready

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -15,6 +15,8 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 export kata_repo="github.com/kata-containers/kata-containers"
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
 export kata_default_branch="${kata_default_branch:-main}"
+export timeout="60s"
+
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"

--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -28,7 +28,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test-lifecycle-events.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check postStart message
 	display_message="cat /usr/share/message"

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -28,7 +28,7 @@ setup() {
 	kubectl create -f "${pod_config}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Create a file
 	echo "$content" > "$file_name"
@@ -53,7 +53,7 @@ setup() {
 	kubectl create -f "${pod_config}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	kubectl logs "$pod_name" || true
 	kubectl describe pod "$pod_name" || true

--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -20,7 +20,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check dns config at /etc/resolv.conf
 	kubectl exec "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -22,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -20,7 +20,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check user
 	cmd="ps --user 1000 -f"

--- a/integration/kubernetes/k8s-shared-volume.bats
+++ b/integration/kubernetes/k8s-shared-volume.bats
@@ -22,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-shared-volume.yaml"
 
 	# Check pods
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Communicate containers
 	cmd="cat /tmp/pod-data"
@@ -38,7 +38,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/initContainer-shared-volume.yaml"
 
 	# Check pods
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	cmd='test $(cat /volume/initContainer) -lt $(cat /volume/container)'
 	kubectl exec "$pod_name" -c "$last_container" -- sh -c "$cmd"

--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -20,7 +20,7 @@ setup() {
 	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check sysctl configuration
 	cmd="cat /proc/sys/kernel/shm_rmid_forced"


### PR DESCRIPTION
This PR introduces waits for pods to be ready in some k8s integration
tests as they fail randomly.

Fixes #3337

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>