### PR TITLE
ci: drop golint

### DIFF
--- a/.ci/.golangci.yml
+++ b/.ci/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - deadcode
     - gocyclo
     - gofmt
-    - golint
     - gosimple
     - govet
     - ineffassign


### PR DESCRIPTION
Per https://github.com/golang/lint/blob/master/README.md

```
The suggestions made by golint are exactly that: suggestions. Golint is
not perfect, and has both false positives and false negatives. Do not
treat its output as a gold standard. We will not be adding pragmas or
other knobs to suppress specific warnings, so do not expect or require
code to be completely "lint-free". In short, this tool is not, and will
never be, trustworthy enough for its suggestions to be enforced
automatically, for example as part of a build process
```

So the official readme is telling us not to include it in a build process. Let's follow its suggestion...
