### PR TITLE
tests: Update conformance tests to use ctr for kata 2.0

### DIFF
--- a/conformance/posixfs/fstests.sh
+++ b/conformance/posixfs/fstests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2021 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,23 +12,24 @@ source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
 # Env variables
-IMAGE="${IMAGE:-fstest}"
+IMAGE="${IMAGE:-docker.io/library/fstest:latest}"
 DOCKERFILE="${SCRIPT_PATH}/Dockerfile"
 CONT_NAME="${CONT_NAME:-fstest}"
-RUNTIME="${RUNTIME:-kata-runtime}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 
 function main() {
-	clean_env
-	check_dockerfiles_images "$IMAGE" "$DOCKERFILE"
-	docker run -d --runtime $RUNTIME --name $CONT_NAME $IMAGE $PAYLOAD_ARGS
+	sudo systemctl restart containerd
+	clean_env_ctr
+	CONTAINERD_RUNTIME="io.containerd.kata.v2"
+	check_ctr_images "$IMAGE" "$DOCKERFILE"
+	sudo ctr run --runtime=$CONTAINERD_RUNTIME -d $IMAGE $CONT_NAME sh -c $PAYLOAD_ARGS
 
 	echo "WARNING: Removing failing tests (Issue https://github.com/kata-containers/runtime/issues/826" >&2
-	REMOVE_FILES="cd pjdfstest/tests && rm -f chown/00.t chmod/12.t link/00.t mkdir/00.t symlink/03.t mkfifo/00.t mknod/00.t mknod/11.t open/00.t"
-	docker exec $CONT_NAME bash -c "${REMOVE_FILES}"
-	docker exec $CONT_NAME bash -c "cd /pjdfstest && prove -r"
+	REMOVE_FILES="cd pjdfstest/tests && rm -f chown/00.t chmod/12.t link/00.t mkdir/00.t symlink/03.t mkfifo/00.t mknod/00.t mknod/11.t utimensat/06.t open/00.t"
+	sudo ctr t exec --exec-id 1 $CONT_NAME sh -c "${REMOVE_FILES}"
+	sudo ctr t exec --exec-id 1 $CONT_NAME sh -c "cd /pjdfstest && prove -r"
 
-	clean_env
+	clean_env_ctr
 }
 
 main "$@"


### PR DESCRIPTION
This PR updates the conformance tests to use ctr instead of
docker for kata 2.0

Fixes #3346

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>