### PR TITLE
tests: Skip k8s oom test to unblock CI

### DIFF
--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -7,14 +7,17 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/3349"
 
 setup() {
+	skip "test not working, see ${issue}"
 	export KUBECONFIG="$HOME/.kube/config"
 	pod_name="pod-oom"
 	get_pod_config_dir
 }
 
 @test "Test OOM events for pods" {
+	skip "test not working, see ${issue}"
 	wait_time=20
 	sleep_time=2
 
@@ -31,6 +34,7 @@ setup() {
 }
 
 teardown() {
+	skip "test not working, see ${issue}"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 


### PR DESCRIPTION
This PR skips the k8s oom test in order to get other PRs
to land.

Fixes #3354

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>