### PR TITLE
ci/openshift-ci: Fix qemu_version on qemu-build-pre.sh

### DIFF
--- a/.ci/openshift-ci/qemu-build-pre.sh
+++ b/.ci/openshift-ci/qemu-build-pre.sh
@@ -23,9 +23,6 @@ source ./scripts/lib.sh
 qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url" "${kata_version}")
 
 qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version" "${kata_version}")
-if ! (git ls-remote --heads "${qemu_url}" | grep -q "refs/heads/${qemu_version}"); then
-        qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.tag" "${kata_version}")
-fi
 
 # Create a new dockerfile and replace the ARG statements with values
 # from versions.yml.


### PR DESCRIPTION
The commit e221c45d7a on kata-containers/kata-containers unified the
qemu's version and tag fields on versions.yaml. Now the version field
should be the only used, and currently it points to v5.2.0. So this
change is to adapt the qemu-build-pre.sh script properly.

Fixes #3357
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>