### PR TITLE
ci: vfio: skip cloud hypervisor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,9 @@ list-install-targets:
 	@echo $(INSTALL_TARGETS) | tr " " "\n"
 
 vfio:
-	bash -f functional/vfio/run.sh -s false -p clh -i image
-	bash -f functional/vfio/run.sh -s true -p clh -i image
+#	Skip: Issue: https://github.com/kata-containers/kata-containers/issues/1488
+#	bash -f functional/vfio/run.sh -s false -p clh -i image
+#	bash -f functional/vfio/run.sh -s true -p clh -i image
 	bash -f functional/vfio/run.sh -s false -p qemu -m pc -i image
 	bash -f functional/vfio/run.sh -s true -p qemu -m pc -i image
 	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i image


### PR DESCRIPTION
cloud hypervisor is not stable,
see https://github.com/kata-containers/kata-containers/issues/1488

fixes #3359

Signed-off-by: Julio Montes <julio.montes@intel.com>