### PR TITLE
ci: arm: Use 5.4.x kernel tag, until 5.10.x is fixed.

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -41,7 +41,11 @@ get_current_kernel_version() {
 		kernel_version=$(get_version "assets.kernel-experimental.tag")
 		echo "${kernel_version}"
 	else
-		kernel_version=$(get_version "assets.kernel.version")
+		case "$(uname -m)" in
+			aarch64) kernel_version_query="assets.kernel.architecture.aarch64.version";;
+			*) kernel_version_query="assets.kernel.version";;
+		esac
+		kernel_version=$(get_version "${kernel_version_query}")
 		echo "${kernel_version/v/}"
 	fi
 }


### PR DESCRIPTION
Moving to linux 5.10.x breaks ARM CI. Allow
ARM CI keep using 5.4.x based kernel.

Fixes: #3362

Depends-on: github.com/kata-containers/kata-containers#1540

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>