### PR TITLE
ci: fix qemu install on ppc64le

### DIFF
--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.tag")
+CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.version")
 stable_branch=$(echo $CURRENT_QEMU_TAG | tr -d 'v' | awk 'BEGIN { FS = "." } {print $1 "." $2 ".x"}')
 PACKAGED_QEMU="qemu-system-ppc"
 BUILT_QEMU="qemu-system-ppc64"


### PR DESCRIPTION
Reads qemu version from version line in Kata's versions.yaml instead of
the now removed tag line.

Fixes #3372

Signed-off-by: MatthieuSarter <matthieu.sarter@ibm.com>