### PR TITLE
metrics: clh: Update the midval for memory footprint for kata 1.x

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-clh-baremetal-kata-metric3.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 141664.95
+midval = 173539.56
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 141659.35
+midval = 173532.7
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
The metrics CI on cloud-hypervisor for kata 1.x is now broken because of
increased memory footprint. A similar issue on metrics CI for qemu was
also reported recently in issue #3335. Following the fix/work-around on
the qemu+kata 1.x metrics CI (PR #3336), we will need to update the mid-val
of reference memory footprint for cloud-hypervisor w/ kata 1.x. This
patch increase mid-val for cloud-hypervisor by 22.5% which is the same
increase percentage on qemu's metrics CI.

Fixes: #3379

Signed-off-by: Bo Chen <chen.bo@intel.com>