### PR TITLE
ci/s390x: Build QEMU from source

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -157,7 +157,7 @@ main() {
 		"ppc64le"|"s390x")
 			packaged_qemu_version=$(get_packaged_qemu_version)
 			short_current_qemu_version=${CURRENT_QEMU_VERSION#*-}
-			if [ "$packaged_qemu_version" == "$short_current_qemu_version" ] && [ -z "${CURRENT_QEMU_TAG}" ] || [ "${QEMU_ARCH}" == "s390x" ]; then
+			if [ "$packaged_qemu_version" == "$short_current_qemu_version" ] && [ -z "${CURRENT_QEMU_TAG}" ]; then
 				install_packaged_qemu || build_and_install_qemu
 			else
 				build_and_install_qemu

--- a/.ci/s390x/lib_install_qemu_s390x.sh
+++ b/.ci/s390x/lib_install_qemu_s390x.sh
@@ -31,35 +31,3 @@ get_packaged_qemu_version() {
 install_packaged_qemu() {
 	sudo apt install -y "$PACKAGED_QEMU"
 }
-
-build_and_install_qemu() {
-	QEMU_REPO=$(get_version "assets.hypervisor.qemu.url")
-	# Remove 'https://' from the repo url to be able to clone the repo using 'go get'
-	QEMU_REPO_PATH=${QEMU_REPO/https:\/\//}
-
-	PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
-	QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
-
-	if [ ! -d "${GOPATH}/src/${QEMU_REPO_PATH}" ]; then
-		mkdir -p "${GOPATH}/src/${QEMU_REPO_PATH}"
-		pushd "${GOPATH}/src/${QEMU_REPO_PATH}"
-		chronic git clone "${QEMU_REPO}" "."
-		popd
-	fi
-
-	clone_kata_repo
-
-	pushd "${GOPATH}/src/${QEMU_REPO_PATH}"
-	git fetch
-	git checkout "$CURRENT_QEMU_VERSION"
-	[ -d "capstone" ] || git clone https://github.com/qemu/capstone.git capstone
-	[ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
-
-	echo "Build Qemu"
-	"${QEMU_CONFIG_SCRIPT}" "qemu" | xargs ./configure
-	make -j $(nproc)
-
-	echo "Install Qemu"
-	sudo -E make install
-	popd
-}


### PR DESCRIPTION
- Originally, QEMU was preferrably to be installed from a distro package
  on s390x because configure-hypervisor.sh was not yet ported (see
  #1130). Since https://github.com/kata-containers/packaging/pull/333
  fixed this, QEMU should be built from source on s390x as well.
- Remove s390x-specific build_and_install_qemu to ease maintenance
e.g. to enable patches

Fixes: #3381
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

This aids the enablement of virtio-fs support on s390x (see https://github.com/kata-containers/kata-containers/issues/1469) since the required QEMU 5.2.0 is generally not packaged.
/cc @jschintag 
Backport required.