### PR TITLE
kernel: get kernel version arch-indepently.

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -41,11 +41,7 @@ get_current_kernel_version() {
 		kernel_version=$(get_version "assets.kernel-experimental.tag")
 		echo "${kernel_version}"
 	else
-		case "$(uname -m)" in
-			aarch64) kernel_version_query="assets.kernel.architecture.aarch64.version";;
-			*) kernel_version_query="assets.kernel.version";;
-		esac
-		kernel_version=$(get_version "${kernel_version_query}")
+		kernel_version=$(get_version "assets.kernel.version")
 		echo "${kernel_version/v/}"
 	fi
 }


### PR DESCRIPTION
As the bug in kernel 5.10.x on arm64 is fixed, remove the
special kernel version tag for arm64.

Fixes: #3387
Depends-on: github.com/kata-containers/kata-containers#1597
Change-Id: I2d1e33cb9e77a577a86323dfe814ef829a7b54d5
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jcvenegas @GabyCT 