### PR TITLE
tests: Introduce more time for the pods to be ready in k8s

### DIFF
--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -22,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
@@ -39,7 +39,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-http-liveness.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
@@ -57,7 +57,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-tcp-liveness.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -43,7 +43,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	rm -f "${pod_config_dir}/test_within_memory.yaml"
 	kubectl delete pod "$pod_name"


### PR DESCRIPTION
This PR introduces waits for pods to be ready in some k8s integration
tests in order to be ready in order to avoid random failures.

Fixes #3392

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>