### PR TITLE
test: Update ksm test to use ctr for kata 2.0

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -31,6 +31,8 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		# echo "INFO: Running pmem integration test"
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
+		echo "INFO: Running ksm test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
 		;;
 	"CRI_CONTAINERD_K8S_COMPLETE")
 		echo "INFO: Running e2e kubernetes tests"

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,9 @@ docker-stability:
 podman:
 	bash -f integration/podman/run_podman_tests.sh
 
+ksm:
+	bash -f integration/ksm/ksm_test.sh
+
 kubernetes:
 	bash -f .ci/install_bats.sh
 	bash -f integration/kubernetes/run_kubernetes_tests.sh

--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright (c) 2019,2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This will run two containers and will wait
+# to the KSM to settle down and then it will
+# check that the merged pages count is
+# increasing
+
+set -e
+
+dir_path=$(dirname "$0")
+source "${dir_path}/../../lib/common.bash"
+source "${dir_path}/../../metrics/lib/common.bash"
+
+KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-yes}"
+PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
+IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
+WAIT_TIME="60"
+
+function setup() {
+	sudo systemctl restart containerd
+	clean_env_ctr
+	check_processes
+	save_ksm_settings
+	set_ksm_aggressive
+}
+
+function teardown() {
+	clean_env_ctr
+	check_processes
+	restore_ksm_settings
+}
+
+trap teardown EXIT
+
+function run_with_ksm() {
+	setup
+
+	CONTAINERD_RUNTIME="io.containerd.kata.v2"
+	sudo ctr image pull "${IMAGE}"
+
+	# Running the first container
+	sudo ctr run -d --runtime="${CONTAINERD_RUNTIME}" "${IMAGE}" test  sh -c "${PAYLOAD_ARGS}"
+
+	echo "Entering KSM settle mode on first container"
+	wait_ksm_settle "${WAIT_TIME}"
+
+	# Checking the pages merged for the first container
+	first_pages_merged=$(cat "${KSM_PAGES_SHARED}")
+
+	echo "Pages merged $first_pages_merged"
+
+	# Running the second container
+	sudo ctr run -d --runtime="${CONTAINERD_RUNTIME}" "${IMAGE}" test1  sh -c "${PAYLOAD_ARGS}"
+
+	echo "Entering KSM settle mode on second container"
+	wait_ksm_settle "${WAIT_TIME}"
+
+	# Checking the pages merged for the second container
+	second_pages_merged=$(cat "${KSM_PAGES_SHARED}")
+
+	echo "Pages merged $second_pages_merged"
+
+	# Compared the pages merged between the containers
+	echo "Comparing merged pages between containers"
+	[ "$second_pages_merged" -gt "$first_pages_merged" ] || die "The merged pages on the second container is less than the first container"
+
+}
+
+echo "Starting KSM test"
+run_with_ksm


### PR DESCRIPTION
This PR updates the ksm test to use ctr for kata 2.0, this test runs
two containers and waits for the KSM to settle down and then checks
the merged pages count is increasing.

Fixes #3394

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>