### PR TITLE
tests: Introduce more time for the pods to be ready in unstable k8s

### DIFF
--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -32,7 +32,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	retries="10"
 

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -19,7 +19,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check volume mounts
 	cmd="mount | grep cache"

--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -30,7 +30,7 @@ setup() {
 	kubectl get jobs -l jobgroup=${job_name}
 
 	# Check the pods
-	kubectl wait --for=condition=Ready pod -l jobgroup=${job_name}
+	kubectl wait --for=condition=Ready --timeout=$timeout pod -l jobgroup=${job_name}
 
 	# Check output of the jobs
 	for i in $(kubectl get pods -l jobgroup=${job_name} -o name); do

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -38,7 +38,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check that the projected sources exists
 	cmd="ls /projected-volume | grep username"


### PR DESCRIPTION

This PR introduces waits for pods to be ready in some unstable k8s tests.

Fixes #3398

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>