### PR TITLE
CI: Remove CentOS 7 support

### DIFF
--- a/.ci/openshift-ci/images/Dockerfile.installer
+++ b/.ci/openshift-ci/images/Dockerfile.installer
@@ -5,7 +5,7 @@
 # Build the image which wraps the kata-containers installation along with the
 # install script. It is used on a daemonset to deploy kata on OpenShift.
 #
-FROM centos:7
+FROM registry.centos.org/centos:8
 
 RUN yum install -y rsync
 

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -23,14 +23,8 @@ fi
 # Send error when a package is not available in the repositories
 echo "skip_missing_names_on_install=0" | sudo tee -a /etc/yum.conf
 
-# Check EPEL repository is enabled on CentOS
-if [ -z "$(dnf repolist | grep 'Extra Packages')" ]; then
-	echo >&2 "ERROR: EPEL repository is not enabled on CentOS."
-	# Enable EPEL repository on CentOS
-	sudo -E dnf install -y wget rpm
-	wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-${centos_version}.noarch.rpm
-	sudo -E rpm -ivh epel-release-latest-${centos_version}.noarch.rpm
-fi
+# Ensure EPEL repository is configured
+sudo -E dnf -y install epel-release
 
 # Enable priority to CentOS Base repo in order to
 # avoid perl updating issues

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -28,15 +28,16 @@ sudo -E dnf -y install epel-release
 
 # Enable priority to CentOS Base repo in order to
 # avoid perl updating issues
-repo_file=""
-if [ -f /etc/yum.repos.d/CentOS-Base.repo ]; then
-	repo_file="/etc/yum.repos.d/CentOS-Base.repo"
-elif [ -f /etc/yum.repos.d/CentOS-Linux-BaseOS.repo ]; then
-	repo_file="/etc/yum.repos.d/CentOS-Linux-BaseOS.repo"
-else
-	die "Unable to find the CentOS base repository file"
-fi
+for repo_file_path in /etc/yum.repos.d/CentOS-Base.repo \
+	/etc/yum.repos.d/CentOS-Linux-BaseOS.repo; do
+	if [ -f "$repo_file_path" ]; then
+		repo_file="$repo_file_path"
+		break
+	fi
+done
+[ -n "${repo_file:-}" ] || die "Unable to find the CentOS base repository file"
 echo "priority=1" | sudo tee -a "$repo_file"
+
 sudo -E dnf -y clean all
 
 echo "Update repositories"

--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,6 @@ else ifeq ($(ARCH),$(filter $(ARCH), aarch64 s390x ppc64le))
 else ifneq (${FOCUS},)
 	./ginkgo -failFast -v -focus "${FOCUS}" -skip "${SKIP}" \
 		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
-else ifeq (centos7,$(ID)$(VERSION_ID))
-# Run tests sequentially, parallel tests fail randomly in Centos 7
-	./ginkgo -failFast -v -skip "${SKIP}" \
-		./integration/docker/ -- -runtime=${RUNTIME} -timeout=${TIMEOUT}
 else
 # Run tests in parallel, skip tests that need to be run serialized
 	./ginkgo -failFast -p -stream -v -skip "${SKIP}" -skip "\[Serial Test\]" \


### PR DESCRIPTION
I don't think it makes sense to maintain the CI scripts for CentOS 7, so I propose its removal on this PR. While ago @fidencio sent a similar PR but at that time I was using CentOS 7 to build kata on openshift-ci; recently I changed it to use CentOS 8 which allow us now to proceed with the removal.