### PR TITLE
[forward-port] ci: Upgrade to yq 3.4.1

### DIFF
--- a/.ci/install_yq.sh
+++ b/.ci/install_yq.sh
@@ -25,7 +25,7 @@ function install_yq() {
 
 	# Stick to a specific version. Same used in
 	# runtime and osbuilder repos.
-	local yq_version=3.1.0
+	local yq_version=3.4.1
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"


### PR DESCRIPTION
In more recent versions of `yq`, the binary is no longer broken on
s390x. This is an upgrade to the latest v3 version of yq (v4 has new
syntax). This is a forward-port of https://github.com/kata-containers/tests/pull/3158.

Fixes: #3418

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>