### PR TITLE
kata-webhook: Use env var to change runtimeclass name

### DIFF
--- a/kata-webhook/README.md
+++ b/kata-webhook/README.md
@@ -5,13 +5,16 @@ Kata runtime class.
 
 ## How to build the admission controller
 
+> **Note:**
+> Only run this step if you are modifying the current webhook or don't
+> want to use the webhook available in docker hub.
+
 First build the admission controller image and the associated
 Kubernetes YAML files required to instantiate the admission
 controller.
 
 ```bash
 $ docker build -t katadocker/kata-webhook-example:latest .
-$ ./create_certs.sh
 ```
 
 > **Note:**
@@ -25,9 +28,18 @@ Today in `crio.conf` `runc` is the default runtime when a user does not specify
 `runtimeClass` in the pod spec. If you want to run a cluster where Kata is used
 by default, except for workloads we know for sure will not work with Kata, use
 the [admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks)
-and sample admission controller we created by running
+and sample admission controller we created by running the commands below:
+
+> **Note:**
+> By default, the `runtimeClass` name used in this webhook is `kata`. If your
+> cluster is configured with another `runtimeClass`, you'll need to change the
+> value of the `RUNTIME_CLASS` environment variable defined in the
+> [webhook file](deploy/webhook.yaml). You can manually edit the file or use
+> the `yq` tool. E.g:
+> `~/go/bin/yq w -i webhook.yaml spec.template.spec.containers[0].env[0].value "kata-clh"`
 
 ```bash
+$ ./create_certs.sh
 $ kubectl apply -f deploy/
 ```
 

--- a/kata-webhook/create-certs.sh
+++ b/kata-webhook/create-certs.sh
@@ -9,6 +9,7 @@ WEBHOOK_NAME=${2:-"pod-annotate"}
 WEBHOOK_SVC="${WEBHOOK_NAME}-webhook"
 
 # Create certs for our webhook
+touch $HOME/.rnd
 openssl genrsa -out webhookCA.key 2048
 openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.svc" -out ./webhookCA.csr 
 openssl x509 -req -days 365 -in webhookCA.csr -signkey webhookCA.key -out webhook.crt

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -20,8 +20,11 @@ spec:
     spec:
       containers:
         - name: pod-annotate-webhook
-          image: fuentess/kata-webhook:20200707
+          image: katadocker/kata-webhook-example:latest
           imagePullPolicy: Always
+          env:
+            - name: RUNTIME_CLASS
+              value: kata
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-key-file=/etc/webhook/certs/key.pem

--- a/kata-webhook/main.go
+++ b/kata-webhook/main.go
@@ -21,6 +21,13 @@ import (
 	mutatingwh "github.com/slok/kubewebhook/pkg/webhook/mutating"
 )
 
+func getRuntimeClass(runtimeClassKey, defaultRuntimeClass string) string {
+	if runtimeClass, ok := os.LookupEnv(runtimeClassKey); ok {
+		return runtimeClass
+	}
+	return defaultRuntimeClass
+}
+
 func annotatePodMutator(ctx context.Context, obj metav1.Object) (bool, error) {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
@@ -70,7 +77,8 @@ func annotatePodMutator(ctx context.Context, obj metav1.Object) (bool, error) {
 	// Mutate the pod
 	fmt.Println("setting runtime to kata: ", pod.GetNamespace(), pod.GetName())
 
-	kataRuntimeClassName := "kata"
+	runtimeClassEnvKey := "RUNTIME_CLASS"
+	kataRuntimeClassName := getRuntimeClass(runtimeClassEnvKey, "kata")
 	pod.Spec.RuntimeClassName = &kataRuntimeClassName
 
 	return false, nil


### PR DESCRIPTION
kata-webhook currently works with hardcoded RuntimeClass name kata.
If the k8s cluster is configured with other RuntimeClasses, such as
kata-clh or kata-qemu, the webhook will not work.

With this change, the webhook will be able to get the name of the
RuntimeClass from an environment variable so that you can specify
other values.

Updated documentation for this new change.

Fixes: #3415.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>