### PR TITLE
k8s: New case for empty dir when FSGroup is set test

### DIFF
--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -47,13 +47,15 @@ setup() {
 	waitForProcess "${wait_time}" "${sleep_time}" "${cmd}"
 
 	pod_logs_file="$(mktemp)"
-	kubectl logs "$pod_name" > "$pod_logs_file"
-	# Check owner UID of file
-	uid=$(cat $pod_logs_file | grep 'owner UID of' | sed 's/.*:\s//')
-	assert_equal "1001" "$uid"
-	# Check owner GID of file
-	gid=$(cat $pod_logs_file | grep 'owner GID of' | sed 's/.*:\s//')
-	assert_equal "123" "$gid"
+	for container in mounttest-container mounttest-container-2; do
+		kubectl logs "$pod_name" "$container" > "$pod_logs_file"
+		# Check owner UID of file
+		uid=$(cat $pod_logs_file | grep 'owner UID of' | sed 's/.*:\s//')
+		assert_equal "1001" "$uid"
+		# Check owner GID of file
+		gid=$(cat $pod_logs_file | grep 'owner GID of' | sed 's/.*:\s//')
+		assert_equal "123" "$gid"
+	done
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
@@ -25,6 +25,20 @@ spec:
     volumeMounts:
       - name: emptydir-volume
         mountPath: /test-volume
+  - name: mounttest-container-2
+    image: "k8s.gcr.io/e2e-test-images/agnhost:2.21"
+    args:
+      - mounttest
+      - --fs_type=/test-volume-2
+      - --new_file_0660=/test-volume-2/test-file
+      - --file_perm=/test-volume-2/test-file
+      - --file_owner=/test-volume-2/test-file
+    volumeMounts:
+      - name: mem-emptydir-volume
+        mountPath: /test-volume-2
   volumes:
   - name: emptydir-volume
     emptyDir: {}
+  - name: mem-emptydir-volume
+    emptyDir:
+      medium: Memory


### PR DESCRIPTION
This adds the test case where the emptyDir volume is stored on memory;
likewise the mounted point and any created files should be owned
by the GID specified on the security context fsGroup.

Fixes #3409
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>