### PR TITLE
1.x | ci: Fix broken CRI-O CI due to empty crio.conf

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -92,6 +92,7 @@ make clean
 make BUILDTAGS='exclude_graphdriver_devicemapper libdm_no_deferred_remove'
 make test-binaries
 sudo -E PATH=$PATH sh -c "make install"
+sudo -E PATH=$PATH sh -c "crio config --default > crio.conf"
 sudo -E PATH=$PATH sh -c "make install.config"
 
 containers_config_path="/etc/containers"


### PR DESCRIPTION
Since https://github.com/cri-o/cri-o/issues/4506 got merged, CRI-O
default config file is empty, unless use explicitly generate it with
`crio config --default`.

Fixes: #3423

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>