### PR TITLE
metrics: Update memory value for virtiofs metrics CI

### DIFF
--- a/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_slaves/checkmetrics-json-virtiofs-baremetal-kata-metric3.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 136691.59
+midval = 156694.51
 minpercent = 5.0
 maxpercent = 5.0
 


### PR DESCRIPTION
This PR updates the memory value for virtiofs metrics CI as currently
is failing. It seems that this update is related with issue
github.com/kata-containers/tests/issues#3404.

Fixes #3429

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>