### PR TITLE
CI: remove codecov execution

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -350,9 +350,6 @@ elif [ "${METRICS_CI}" == "false" ]; then
 	#
 	# Note: this will run all classes of tests for ${tests_repo}.
 	"${ci_dir_name}/run.sh"
-
-	# Code coverage
-	bash <(curl -s https://codecov.io/bash)
 else
 	echo "Running the metrics tests:"
 	"${ci_dir_name}/run.sh"


### PR DESCRIPTION
Codecov is currently not configured for 2.x branches, and we are
currently discussing which tools we want to use fore code coverage.
In the meantime, it doesn't make sense to run this script.

Fixes: #3435.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>