### PR TITLE
test: Skip KSM tests on ARM CI

### DIFF
--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -19,6 +19,12 @@ KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-yes}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
 WAIT_TIME="60"
+arch=$("${dir_path}"/../../.ci/kata-arch.sh -d)
+
+if [ "$arch" == "aarch64" ]; then
+	echo "Skip KSM test: $arch does not support it"
+	exit 0
+fi
 
 function setup() {
 	sudo systemctl restart containerd


### PR DESCRIPTION
This PR skips KSM tests on ARM CI as it seems that is not
working properly.

Fixes #3438

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>