### PR TITLE
ci: metrics: change image used to test boot time

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -55,7 +55,7 @@ run() {
 		bash density/memory_usage_inside_container.sh
 
 		# Run the time tests
-		bash time/launch_times.sh -i mirror.gcr.io/library/ubuntu:latest -n 20
+		bash time/launch_times.sh -i registry.fedoraproject.org/fedora:latest -n 20
 
 		# Run iperf3 bandwidth test
 		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -80,7 +80,7 @@ run_workload() {
 
 	# Run the image and command and capture the results into an array...
 	declare workload_result
-	readarray -n 0 workload_result < <(ctr run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test bash -c "$DATECMD $DMESGCMD")
+	readarray -n 0 workload_result < <(ctr run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test /bin/bash -c "$DATECMD $DMESGCMD")
 
 	end_time=$($DATECMD)
 
@@ -166,7 +166,7 @@ EOF
 	# between each of our 'test' containers. The aim being to see if our launch times
 	# are linear with the number of running containers or not
 	if [ -n "$SCALING" ]; then
-		ctr run --runtime=${CTR_RUNTIME} -d ${IMAGE} test bash -c "tail -f /dev/null"
+		ctr run --runtime=${CTR_RUNTIME} -d ${IMAGE} test /bin/bash -c "tail -f /dev/null"
 	fi
 }
 


### PR DESCRIPTION
ubuntu image was removed from `mirror.gcr.io` registry,
change to fedora image and pull it from its official registry.

fixes #3443

Signed-off-by: Julio Montes <julio.montes@intel.com>