### PR TITLE
ci: Fix RHEL CI when building CRI-O

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -89,7 +89,7 @@ fi
 pushd "${GOPATH}/src/${crio_repo}"
 echo "Installing CRI-O"
 make clean
-make BUILDTAGS='exclude_graphdriver_devicemapper libdm_no_deferred_remove'
+make BUILDTAGS='exclude_graphdriver_btrfs exclude_graphdriver_devicemapper libdm_no_deferred_remove'
 make test-binaries
 sudo -E PATH=$PATH sh -c "make install"
 sudo -E PATH=$PATH sh -c "crio config --default > crio.conf"


### PR DESCRIPTION
This PR excludes the  btrfs-tools or btrfs-progs-devel package that
seems to be needed to build CRI-O or containerd in RHEL CI.

Fixes #3445

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>