### PR TITLE
k8s: Prefetch image on emptyDir test

### DIFF
--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -41,6 +41,10 @@ setup() {
 @test "Empty dir volume when FSGroup is specified with non-root container" {
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
+	image=$(grep 'image:' ${pod_file} | head -1 | sed 's/.*\s//')
+
+	# Try to avoid timeout by prefetching the image.
+	crictl_pull "$image"
 	kubectl create -f "$pod_file"
 
 	cmd="kubectl get pods ${pod_name} | grep Completed"

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -14,7 +14,7 @@ setup() {
 	replicas="3"
 	deployment="nginx-deployment"
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-	sudo -E crictl pull "$nginx_image"
+	crictl_pull "$nginx_image"
 	get_pod_config_dir
 }
 

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -15,8 +15,8 @@ setup() {
 	deployment="nginx-deployment"
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	# Pull the images before launching workload.
-	sudo -E crictl pull "$busybox_image"
-	sudo -E crictl pull "$nginx_image"
+	crictl_pull "$busybox_image"
+	crictl_pull "$nginx_image"
 
 	get_pod_config_dir
 }

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
@@ -15,7 +15,7 @@ spec:
     fsGroup: 123
   containers:
   - name: mounttest-container
-    image: "k8s.gcr.io/e2e-test-images/agnhost:2.21"
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.21
     args:
       - mounttest
       - --fs_type=/test-volume
@@ -26,7 +26,7 @@ spec:
       - name: emptydir-volume
         mountPath: /test-volume
   - name: mounttest-container-2
-    image: "k8s.gcr.io/e2e-test-images/agnhost:2.21"
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.21
     args:
       - mounttest
       - --fs_type=/test-volume-2

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -185,3 +185,15 @@ get_pod_config_dir() {
 	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	info "k8s configured to use runtimeclass"
 }
+
+# Uses crictl to pull a container image passed in $1.
+# If crictl is not found then it just prints a warning.
+crictl_pull() {
+	local img="${1:-}"
+	local cmd="crictl"
+	if ! command -v "$cmd" &>/dev/null; then
+		warn "$cmd not found. Cannot pull image $img"
+	else
+		sudo -E "$cmd" pull "$img"
+	fi
+}


### PR DESCRIPTION
The "Empty dir volume when FSGroup is specified with non-root" test
has randomically failed. Let's prefetch the agnhost image to try
to avoid timeout waiting for the pod to come up.

Fixes #3449
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>