### PR TITLE
test: Allow more time to check pod-quota deployment

### DIFF
--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
 
 	# View deployment
-	kubectl wait --for=condition=Available deployment/${deployment_name}
+	kubectl wait --for=condition=Available --timeout=60s deployment/${deployment_name}
 }
 
 teardown() {


### PR DESCRIPTION
This PR allows more time to check the pod-quota k8s deployment
as we have seen random failures in checking if the deployment
is ready.

Fixes #3452

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>