### PR TITLE
ubuntu: Install btrfs-progs as containerd dependency

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -36,7 +36,7 @@ declare -A packages=( \
 	[build_tools]="build-essential python pkg-config zlib1g-dev" \
 	[crio_dependencies_for_ubuntu]="libdevmapper-dev util-linux" \
 	[metrics_dependencies]="smem jq" \
-	[cri-containerd_dependencies]="libseccomp-dev libapparmor-dev make gcc pkg-config" \
+	[cri-containerd_dependencies]="btrfs-progs libseccomp-dev libapparmor-dev make gcc pkg-config" \
 	[crudini]="crudini" \
 	[procenv]="procenv" \
 	[haveged]="haveged" \
@@ -46,10 +46,6 @@ declare -A packages=( \
 
 if [ "$(uname -m)" == "x86_64" ] && [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 18.04" | bc -q)" == "1" ]; then
 	packages[qemu_dependencies]+=" libpmem-dev"
-fi
-
-if [ "$(echo "${VERSION_ID} <= 18.04" | bc -q)" == "1" ]; then
-	packages[crio_dependencies_for_ubuntu]+=" btrfs-tools"
 fi
 
 rust_agent_pkgs=()


### PR DESCRIPTION
To be fair, this is also a CRI-O dependency and later on we should
explore using buildtags based on installed packages (rather than
explicitly defining those).

Fixes: #3456

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>