### PR TITLE
k8s: Use the same agnhost image version

### DIFF
--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -41,12 +41,14 @@ setup() {
 @test "Empty dir volume when FSGroup is specified with non-root container" {
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
-	image=$(grep 'image:' ${pod_file} | head -1 | sed 's/.*\s//')
+	agnhost_name=$(get_test_version "container_images.agnhost.name")
+	agnhost_version=$(get_test_version "container_images.agnhost.version")
+	image="${agnhost_name}:${agnhost_version}"
 
 	# Try to avoid timeout by prefetching the image.
 	crictl_pull "$image"
-	kubectl create -f "$pod_file"
-
+	sed -e "s#\${agnhost_image}#${image}#" "$pod_file" |\
+		kubectl create -f -
 	cmd="kubectl get pods ${pod_name} | grep Completed"
 	waitForProcess "${wait_time}" "${sleep_time}" "${cmd}"
 

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -18,6 +18,9 @@ setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	deployment="hello-world"
 	service="my-service"
+	agnhost_name=$(get_test_version "container_images.agnhost.name")
+	agnhost_version=$(get_test_version "container_images.agnhost.version")
+
 	get_pod_config_dir
 }
 
@@ -26,7 +29,9 @@ setup() {
 	sleep_time=2
 
 	# Create deployment
-	kubectl create -f "${pod_config_dir}/deployment-expose-ip.yaml"
+	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
+		"${pod_config_dir}/deployment-expose-ip.yaml" |\
+		kubectl create -f -
 
 	# Check deployment creation
 	cmd="kubectl wait --for=condition=Available deployment/${deployment}"

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -11,6 +11,8 @@ load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	sleep_liveness=20
+	agnhost_name=$(get_test_version "container_images.agnhost.name")
+	agnhost_version=$(get_test_version "container_images.agnhost.version")
 
 	get_pod_config_dir
 }
@@ -36,7 +38,9 @@ setup() {
 	pod_name="liveness-http"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-http-liveness.yaml"
+	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
+		"${pod_config_dir}/pod-http-liveness.yaml" |\
+		kubectl create -f -
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -54,7 +58,9 @@ setup() {
 	pod_name="tcptest"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-tcp-liveness.yaml"
+	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
+		"${pod_config_dir}/pod-tcp-liveness.yaml" |\
+		kubectl create -f -
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/deployment-expose-ip.yaml
@@ -22,7 +22,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: hello-world
-        image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
+        image: ${agnhost_image}
         args:
         - netexec
         ports:

--- a/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-empty-dir-fsgroup.yaml
@@ -15,7 +15,7 @@ spec:
     fsGroup: 123
   containers:
   - name: mounttest-container
-    image: k8s.gcr.io/e2e-test-images/agnhost:2.21
+    image: ${agnhost_image}
     args:
       - mounttest
       - --fs_type=/test-volume
@@ -26,7 +26,7 @@ spec:
       - name: emptydir-volume
         mountPath: /test-volume
   - name: mounttest-container-2
-    image: k8s.gcr.io/e2e-test-images/agnhost:2.21
+    image: ${agnhost_image}
     args:
       - mounttest
       - --fs_type=/test-volume-2

--- a/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -14,7 +14,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: liveness
-    image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
+    image: ${agnhost_image}
     args:
     - liveness
     livenessProbe:

--- a/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -14,7 +14,7 @@ spec:
   runtimeClassName: kata
   containers:
   - name: tcp-liveness
-    image: gcr.io/kubernetes-e2e-test-images/agnhost:2.2
+    image: ${agnhost_image}
     args:
     - liveness
     ports:

--- a/versions.yaml
+++ b/versions.yaml
@@ -35,6 +35,15 @@ docker_images:
     url: "https://hub.docker.com/_/nginx/"
     version: "1.15-alpine"
 
+container_images:
+  description: "Images used for testing but not hosted on Docker hub"
+
+  agnhost:
+    description: "Kubernetes host OS agnostic test image"
+    name: "k8s.gcr.io/e2e-test-images/agnhost"
+    # Keep this updated with the Kubernetes version used for testing.
+    version: "2.21"
+
 externals:
   description: "Third-party projects used specifically for testing"
 


### PR DESCRIPTION
This is a refactor on some kubernetes integration tests to ensure they
rely on the same version of the agnhost image. It was added a new
entry on versions.yaml to record the exact image's name and version.

Fixes #3455
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>