### PR TITLE
metrics: Fix boot times metrics baseline

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -16,9 +16,9 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.62
-minpercent = 5.0
-maxpercent = 5.0
+midval = 0.575
+minpercent = 10.0
+maxpercent = 10.0
 
 [[metric]]
 name = "memory-footprint"


### PR DESCRIPTION
This PR fixes the boot time baseline as it seems that we are getting
less boot time as we changed the test image.

Fixes #3459

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>