### PR TITLE
ci: Add libbtrfs-dev as a containerd dependency in Ubuntu

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -44,6 +44,10 @@ declare -A packages=( \
 	[redis]="redis-server" \
 )
 
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == "1" ]; then
+	packages[cri_containerd_dependencies]+=" libbtrfs-dev"
+fi
+
 if [ "$(uname -m)" == "x86_64" ] && [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 18.04" | bc -q)" == "1" ]; then
 	packages[qemu_dependencies]+=" libpmem-dev"
 fi


### PR DESCRIPTION
This PR adds libbtrfs-dev as a containerd dependency as it is also
needed to build properly containerd in Ubuntu 20.04

Fixes #3461

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>