### PR TITLE
tests: Skip k8s tests that are failing randomly

### DIFF
--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -7,8 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+issue="https://github.com/kata-containers/tests/issues/3453"
+arch=$("${BATS_TEST_DIRNAME}"/../../.ci/kata-arch.sh -d)
 
 setup() {
+	[ "${arch}" == "aarch64" ] && skip "test not working see: ${issue}"
 	nginx_version=$(get_test_version "docker_images.nginx.version")
 	nginx_image="nginx:$nginx_version"
 
@@ -19,6 +22,7 @@ setup() {
 }
 
 @test "Running with postStart and preStop handlers" {
+	[ "${arch}" == "aarch64" ] && skip "test not working see: ${issue}"
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/lifecycle-events.yaml" > "${pod_config_dir}/test-lifecycle-events.yaml"
@@ -35,6 +39,7 @@ setup() {
 }
 
 teardown(){
+	[ "${arch}" == "aarch64" ] && skip "test not working see: ${issue}"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -7,8 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
+issue="https://github.com/kata-containers/tests/issues/3464"
 
 assert_equal() {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	local expected=$1
 	local actual=$2
 	if [[ "$expected" != "$actual" ]]; then
@@ -18,6 +21,7 @@ assert_equal() {
 }
 
 setup() {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	pod_name="sharevol-kata"
 	get_pod_config_dir
@@ -27,6 +31,7 @@ setup() {
 }
 
 @test "Empty dir volumes" {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
 
@@ -39,6 +44,7 @@ setup() {
 }
 
 @test "Empty dir volume when FSGroup is specified with non-root container" {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
 	agnhost_name=$(get_test_version "container_images.agnhost.name")
@@ -65,6 +71,7 @@ setup() {
 }
 
 teardown() {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -7,8 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
+issue="https://github.com/kata-containers/tests/issues/3464"
 
 setup() {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	pod_name="busybox"
 	first_container_name="first-test-container"
@@ -18,6 +21,7 @@ setup() {
 }
 
 @test "Check PID namespaces" {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
@@ -42,6 +46,7 @@ setup() {
 }
 
 teardown() {
+	[ "${ID}" == "centos" ] && skip "test not working see ${issue}"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -8,8 +8,11 @@
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"
+source /etc/os-release || source /usr/lib/os-release
+issue="https://github.com/kata-containers/tests/issues/3463"
 
 setup() {
+	[ "${ID}" == "fedora" ] && skip "test not working see ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
@@ -17,6 +20,7 @@ setup() {
 }
 
 @test "Projected volume" {
+	[ "${ID}" == "fedora" ] && skip "test not working see ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
 	password="1f2d1e2e67df"
@@ -54,6 +58,7 @@ setup() {
 }
 
 teardown() {
+	[ "${ID}" == "fedora" ] && skip "test not working see ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
 	# Debugging information


### PR DESCRIPTION
This PR skips k8s tests that are failing randomly which is making
unstable the CI. The issues for these failures have been raised and
further investigation of this needs to be done.

Fixes #3465

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>