### PR TITLE
metrics: Remove iperf3 due to issues with kubernetes

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -56,9 +56,6 @@ run() {
 
 		# Run the time tests
 		bash time/launch_times.sh -i registry.fedoraproject.org/fedora:latest -n 20
-
-		# Run iperf3 bandwidth test
-		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b
 	fi
 
 	# Run storage tests

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -71,16 +71,3 @@ checktype = "mean"
 midval = 48055.25
 minpercent = 10.0
 maxpercent = 10.0
-
-[[metric]]
-name = "network-iperf3-bandwidth"
-type = "json"
-description = "measure container bandwidth using iperf3"
-# Min and Max values to set a 'range' that
-# the median of the CSV Results data must fall
-# within (inclusive)
-checkvar = ".\"network-iperf3-bandwidth\".Results | .[] | .bandwidth.Result"
-checktype = "mean"
-midval = 30811123135.60
-minpercent = 10.0
-maxpercent = 10.0


### PR DESCRIPTION
This PR removes iperf3 metrics as it seems that kubernetes is not
cleaning properly the environment.

Fixes #3475

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>