### PR TITLE
ci: remove existing k8s+crio config before seting up new config

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -93,6 +93,9 @@ install_extra_tools() {
 	echo "Install CNI plugins"
 	bash -f "${cidir}/install_cni_plugins.sh"
 
+	# Remove K8s + CRIO conf that may remain from a previous run
+	rm -f /etc/systemd/system/kubelet.service.d/0-crio.conf
+
 	[ "${CRIO}" = "yes" ] &&
 		echo "Install CRI-O" &&
 		bash -f "${cidir}/install_crio.sh" &&


### PR DESCRIPTION
Removes existing k8s+crio config during setup to ensure k8s will not use crio when running a containerd test.

Fixes #3480

Signed-off-by: MatthieuSarter matthieu.sarter@ibm.com