### PR TITLE
ci: Use cached kernels

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -17,7 +17,7 @@ source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
 latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-vanilla-$(uname -m)-nightly/${cached_artifacts_path}"
-experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
+experimental_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-experimental-$(uname -m)-nightly/${cached_artifacts_path}"
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
@@ -39,11 +39,10 @@ trap exit_handler EXIT
 get_current_kernel_version() {
 	if [ "$experimental_kernel" == "true" ]; then
 		kernel_version=$(get_version "assets.kernel-experimental.tag")
-		echo "${kernel_version}"
 	else
 		kernel_version=$(get_version "assets.kernel.version")
-		echo "${kernel_version/v/}"
 	fi
+	echo "${kernel_version/v/}"
 }
 
 get_kata_config_version() {
@@ -130,6 +129,7 @@ main() {
 	if [ "${experimental_kernel}" == "false" ]; then
 		cached_kernel_version=$(curl -sfL "${latest_build_url}/latest") || cached_kernel_version="none"
 	else
+		current_kernel_version+="-experimental"
 		cached_kernel_version=$(curl -sfL "${experimental_latest_build_url}/latest") || cached_kernel_version="none"
 	fi
 	info "current kernel : ${current_kernel_version}"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -21,9 +21,7 @@ experimental_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-exp
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
-kata_repo="github.com/kata-containers/kata-containers"
-export GOPATH=${GOPATH:-${HOME}/go}
-kernel_repo_dir="${GOPATH}/src/${kata_repo}/tools/packaging"
+kernel_repo_dir="${kata_repo_dir}/tools/packaging"
 kernel_arch="$(arch)"
 readonly tmp_dir="$(mktemp -d -t install-kata-XXXXXXXXXXX)"
 packaged_kernel="kata-linux-container"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -16,7 +16,7 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
+latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-vanilla-$(uname -m)-nightly/${cached_artifacts_path}"
 experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"


### PR DESCRIPTION
Today I created two jobs on CI to nightly build either vanilla and experimental kernels:

  http://jenkins.katacontainers.io/job/kata-containers-2.0-kernel-experimental-x86_64-nightly
  http://jenkins.katacontainers.io/job/kata-containers-2.0-kernel-vanilla-x86_64-nightly

It is using the same mechanism and scripts as used with kata 1.x. So basically on this PR I am only adjusting urls. 