### PR TITLE
ci: workaround to fix arm ci failure on behalf of containerd and k8s test

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -21,6 +21,9 @@ kubernetes_version=$(get_version "externals.kubernetes.version")
 ARCH=$("${cidir}"/kata-arch.sh -d)
 
 if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
+	if [ "$(command -v kubelet)" != "" ]; then
+		apt purge kubelet -y
+	fi
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
@@ -30,6 +33,9 @@ EOF"
 	chronic sudo -E apt update
 	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
+	if [ "$(command -v kubelet)" != "" ]; then
+		yum autoremove kubelet -y
+	fi
 	url="https://packages.cloud.google.com/yum/repos/kubernetes-el7-${ARCH}"
 	echo "Install ${url} for ${ARCH}"
 	sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -159,9 +159,37 @@ err_report() {
 
 trap err_report ERR
 
+restart_docker() {
+	info "restart docker service"
+
+	back_file=$(mktemp)
+
+	#avoid the "Start request repeated too quickly" error
+        if [ -f "/lib/systemd/system/docker.service" ]; then
+		cp /lib/systemd/system/docker.service ${back_file}
+                sed -i 's/StartLimitBurst.*$/StartLimitBurst=0/g' /lib/systemd/system/docker.service
+        elif [ -f "/usr/lib/systemd/system/docker.service" ]; then
+		cp /usr/lib/systemd/system/docker.service ${back_file}
+                sed -i 's/StartLimitBurst.*$/StartLimitBurst=0/g' /usr/lib/systemd/system/docker.service
+        fi
+        sudo systemctl daemon-reload
+        sudo systemctl restart docker
+
+	#recover docker service file
+	if [ -f "/lib/systemd/system/docker.service" ]; then
+		mv ${back_file} /lib/systemd/system/docker.service
+	elif [ -f "/usr/lib/systemd/system/docker.service" ]; then
+		mv ${back_file} /usr/lib/systemd/system/docker.service
+	fi
+        sudo systemctl daemon-reload
+}
+
 check_daemon_setup() {
 	info "containerd(cri): Check daemon works with runc"
 	create_containerd_config "runc"
+
+	#restart docker service as TestImageLoad depends on it
+	restart_docker
 
 	sudo -E PATH="${PATH}:/usr/local/bin" \
 		REPORT_DIR="${REPORT_DIR}" \

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -70,7 +70,7 @@ esac
 check_processes
 
 # Remove existing CNI configurations:
-cni_config_dir="/etc/cni/net.d"
+cni_config_dir="/etc/cni"
 cni_interface="cni0"
 sudo rm -rf /var/lib/cni/networks/*
 sudo rm -rf "${cni_config_dir}"/*
@@ -109,6 +109,13 @@ trap 'sudo -E sh -c "rm -r "${kubeadm_config_file}""' EXIT
 if [ "${BAREMETAL}" == true ] && [[ $(wc -l /proc/swaps | awk '{print $1}') -gt 1 ]]; then
 	sudo swapoff -a || true
 fi
+
+#reinstall kubelet to do deep cleanup
+if [ "$(command -v kubelet)" != "" ]; then
+	info "reinstall kubeadm, kubelet before initialize k8s"
+	bash -f "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
+fi
+
 sudo -E kubeadm init --config "${kubeadm_config_file}"
 
 mkdir -p "$HOME/.kube"


### PR DESCRIPTION
Currently, before containerd integration test, containerd service is
stopped., which will disable docker service. Then, the TestImageLoad
will fail for it depends on docker service.

Here, we restart docker before containerd test to avoid that failure.

But these tests have been working well for years. I can't tell why it
is.

Fixes: #3478
Signed-off-by: Jianyong.wu <jianyong.wu@arm.com>