### PR TITLE
CI: Use cached QEMU

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -119,6 +119,13 @@ create_cache_asset() {
 		path=$(readlink -f "${image_path}")
 		echo $(basename "${path}") > "latest-${image_name}"
 		sudo cp "${path}" "${kata_dir}/osbuilder-${image_name}.yaml"  .
+	elif [ ! -z "${check_qemu}" ]; then
+		# The latest file is compounded of the QEMU version and SHA-256
+		# calculated from all files and scripts used to its build.
+		qemu_sha=$(calc_qemu_files_sha256sum)
+		[ -n "$qemu_sha" ] || \
+			die "Failed to calculate a SHA-256 for QEMU"
+		echo "${component_version} ${qemu_sha}" > "latest"
 	else
 		echo "${component_version}" >  "latest"
 	fi

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -31,6 +31,14 @@ qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_arti
 # option "--shallow-submodules" was introduced in git v2.9.0
 GIT_SHADOW_VERSION="2.9.0"
 
+# We need to move the tar file to a specific location so we
+# can know where it is and then we can perform the build cache
+# operations
+update_cache() {
+	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
+	sudo mv ${QEMU_TAR} ${KATA_TESTS_CACHEDIR}
+}
+
 build_static_qemu() {
 	info "building static QEMU"
 	# only x86_64 is supported for building static QEMU
@@ -40,11 +48,7 @@ build_static_qemu() {
 	cd "${PACKAGING_DIR}/static-build/qemu"
 	prefix="${KATA_QEMU_DESTDIR}" make
 
-	# We need to move the tar file to a specific location so we
-	# can know where it is and then we can perform the build cache
-	# operations
-	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
-	sudo mv ${QEMU_TAR} ${KATA_TESTS_CACHEDIR}
+	update_cache
 	)
 }
 
@@ -69,6 +73,7 @@ install_cached_qemu() {
 
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_static_qemu "${QEMU_TAR}"
+	update_cache
 }
 
 clone_qemu_repo() {


### PR DESCRIPTION
his changed the installer script to fetch and install a built QEMU
if a suitable version is found on the project's Jenkins.

To detect changes that would flag a cache mismatch it is employed
a simple algorithm to generate a SHA-256 from the files and scripts
used to build QEMU. The cached and current sha-256 is compared to
determine whether or not use the cached asset.

Fixes #3119
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>