### PR TITLE
kubernetes: Use a timeout for "OOM events for pods" test

### DIFF
--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -22,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-oom.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check if OOMKilled
 	cmd="kubectl get pods "$pod_name" -o yaml | yq r - 'status.containerStatuses[0].state.terminated.reason' | grep OOMKilled"


### PR DESCRIPTION
The default timeout has been increased recently and adjusted for some
tests that were failing.

This is a try-and-error kind of process and we'll keep adjusting such
timeouts accordingly to the errors we see coming from the tests.

Fixes: #2864

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>