### PR TITLE
WIP: k8s: Set mininum timeout for tests and other improvements

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -15,7 +15,6 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 export kata_repo="github.com/kata-containers/kata-containers"
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
 export kata_default_branch="${kata_default_branch:-main}"
-export timeout="90s"
 
 
 # Name of systemd service for the throttler

--- a/integration/kubernetes/k8s-attach-handlers.bats
+++ b/integration/kubernetes/k8s-attach-handlers.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	nginx_version=$(get_test_version "docker_images.nginx.version")

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -15,8 +15,6 @@ setup() {
 	pod_name="pod-block-pv"
 	volume_name="block-loop-pv"
 	volume_claim="block-loop-pvc"
-	wait_time=90
-	sleep_time=3
 	ctr_dev_path="/dev/xda"
 	vol_capacity="500M"
 

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -15,8 +15,8 @@ setup() {
 	pod_name="pod-block-pv"
 	volume_name="block-loop-pv"
 	volume_claim="block-loop-pvc"
-	wait_time=10
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 	ctr_dev_path="/dev/xda"
 	vol_capacity="500M"
 
@@ -49,7 +49,7 @@ setup() {
 	tmp_pod_yaml=$(mktemp --tmpdir pod-pv.XXXXX.yaml)
 	sed -e "s|DEVICE_PATH|${ctr_dev_path}|" "${pod_config_dir}/${pod_name}.yaml" > "$tmp_pod_yaml"
 	kubectl create -f "$tmp_pod_yaml"
-	kubectl wait --for condition=ready "pod/${pod_name}"
+	kubectl wait --timeout=$timeout --for condition=ready "pod/${pod_name}"
 
 	# Verify persistent volume claim is bound
 	kubectl get "pvc/${volume_claim}" | grep "Bound"

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -27,7 +27,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Check env
 	cmd="env"

--- a/integration/kubernetes/k8s-configmap.bats
+++ b/integration/kubernetes/k8s-configmap.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-copy-file.bats
+++ b/integration/kubernetes/k8s-copy-file.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {

--- a/integration/kubernetes/k8s-custom-dns.bats
+++ b/integration/kubernetes/k8s-custom-dns.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -22,8 +22,8 @@ setup() {
 	pod_name="sharevol-kata"
 	get_pod_config_dir
 	pod_logs_file=""
-	wait_time=20
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 }
 
 @test "Empty dir volumes" {

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 assert_equal() {
 	local expected=$1

--- a/integration/kubernetes/k8s-empty-dirs.bats
+++ b/integration/kubernetes/k8s-empty-dirs.bats
@@ -22,8 +22,6 @@ setup() {
 	pod_name="sharevol-kata"
 	get_pod_config_dir
 	pod_logs_file=""
-	wait_time=90
-	sleep_time=3
 }
 
 @test "Empty dir volumes" {

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -19,7 +19,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"

--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-exec.bats
+++ b/integration/kubernetes/k8s-exec.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -25,8 +25,6 @@ setup() {
 }
 
 @test "Expose IP Address" {
-	wait_time=90
-	sleep_time=3
 
 	# Create deployment
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -25,8 +25,8 @@ setup() {
 }
 
 @test "Expose IP Address" {
-	wait_time=20
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 
 	# Create deployment
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
@@ -34,7 +34,7 @@ setup() {
 		kubectl create -f -
 
 	# Check deployment creation
-	cmd="kubectl wait --for=condition=Available deployment/${deployment}"
+	cmd="kubectl wait --timeout=$timeout --for=condition=Available deployment/${deployment}"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check pods are running

--- a/integration/kubernetes/k8s-expose-ip.bats
+++ b/integration/kubernetes/k8s-expose-ip.bats
@@ -12,7 +12,7 @@
 # See detailed info in PR#2157(https://github.com/kata-containers/tests/pull/2157)
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-footloose.bats
+++ b/integration/kubernetes/k8s-footloose.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 issue="https://github.com/kata-containers/runtime/issues/1674"
 

--- a/integration/kubernetes/k8s-footloose.bats
+++ b/integration/kubernetes/k8s-footloose.bats
@@ -43,7 +43,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-footloose.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Get pod ip
 	pod_ip=$(kubectl get pod $pod_name --template={{.status.podIP}})

--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -5,7 +5,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 issue="https://github.com/kata-containers/runtime/issues/2172"
 
 setup() {

--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"
@@ -43,7 +43,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"

--- a/integration/kubernetes/k8s-job.bats
+++ b/integration/kubernetes/k8s-job.bats
@@ -18,8 +18,8 @@ setup() {
 @test "Run a job to completion" {
 	skip "test not working see: ${issue}"
 	job_name="job-pi-test"
-	wait_time=60
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 
 	# Create job
 	kubectl apply -f "${pod_config_dir}/job.yaml"

--- a/integration/kubernetes/k8s-job.bats
+++ b/integration/kubernetes/k8s-job.bats
@@ -18,8 +18,6 @@ setup() {
 @test "Run a job to completion" {
 	skip "test not working see: ${issue}"
 	job_name="job-pi-test"
-	wait_time=90
-	sleep_time=3
 
 	# Create job
 	kubectl apply -f "${pod_config_dir}/job.yaml"

--- a/integration/kubernetes/k8s-job.bats
+++ b/integration/kubernetes/k8s-job.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 issue="https://github.com/kata-containers/tests/issues/1746"
 
 setup() {

--- a/integration/kubernetes/k8s-limit-range.bats
+++ b/integration/kubernetes/k8s-limit-range.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-cpu-defaults.yaml" --namespace=${namespace_name}
 
 	# Get pod specification
-	kubectl wait --for=condition=Ready pod "$pod_name" --namespace="$namespace_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name" --namespace="$namespace_name"
 
 	# Check limits
 	# Find the 500 millicpus specified at the yaml

--- a/integration/kubernetes/k8s-limit-range.bats
+++ b/integration/kubernetes/k8s-limit-range.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-liveness-probes.bats
+++ b/integration/kubernetes/k8s-liveness-probes.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -15,8 +15,6 @@ setup() {
 }
 
 @test "Test OOM events for pods" {
-	wait_time=90
-	sleep_time=3
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-oom.yaml"

--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -15,14 +15,14 @@ setup() {
 }
 
 @test "Test OOM events for pods" {
-	wait_time=60
-	sleep_time=5
+	wait_time=90
+	sleep_time=3
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-oom.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Check if OOMKilled
 	cmd="kubectl get pods "$pod_name" -o yaml | yq r - 'status.containerStatuses[0].state.terminated.reason' | grep OOMKilled"

--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-parallel.bats
+++ b/integration/kubernetes/k8s-parallel.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-pid-ns.bats
+++ b/integration/kubernetes/k8s-pid-ns.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -5,7 +5,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-pod-quota.bats
+++ b/integration/kubernetes/k8s-pod-quota.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
 
 	# View deployment
-	kubectl wait --for=condition=Available --timeout=60s deployment/${deployment_name}
+	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment_name}
 }
 
 teardown() {

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
 issue="https://github.com/kata-containers/runtime/issues/1834"

--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -24,12 +24,12 @@ setup() {
 	kubectl apply -f "${pod_config_dir}/redis-master-deployment.yaml"
 
 	# Check deployment
-	kubectl wait --for=condition=Available deployment/"$deployment_name"
+	kubectl wait --timeout=$timeout --for=condition=Available deployment/"$deployment_name"
 	kubectl expose deployment/"$deployment_name"
 
 	# Get pod name
 	pod_name=$(kubectl get pods --output=jsonpath={.items..metadata.name})
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# View replicaset
 	kubectl get rs

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
 memory_issue="https://github.com/kata-containers/runtime/issues/1249"

--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Guaranteed"
@@ -41,7 +41,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-burstable.yam"l
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Burstable"
@@ -55,7 +55,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-besteffort.yam"l
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --timeout=$timeout --for=condition=Ready pod "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: BestEffort"

--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -19,8 +19,6 @@ setup() {
 @test "Replication controller" {
 	replication_name="replicationtest"
 	number_of_replicas="1"
-	wait_time=90
-	sleep_time=3
 
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \

--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -19,8 +19,8 @@ setup() {
 @test "Replication controller" {
 	replication_name="replicationtest"
 	number_of_replicas="1"
-	wait_time=20
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
@@ -34,7 +34,7 @@ setup() {
 
 	# Check pod creation
 	pod_name=$(kubectl get pods --output=jsonpath={.items..metadata.name})
-	cmd="kubectl wait --for=condition=Ready pod $pod_name"
+	cmd="kubectl wait --timeout=$timeout --for=condition=Ready pod $pod_name"
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Check number of pods created for the

--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	nginx_version=$(get_test_version "docker_images.nginx.version")

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -19,8 +19,6 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
-	wait_time=90
-	sleep_time=3
 
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -19,14 +19,14 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
-	wait_time=30
+	wait_time=90
 	sleep_time=3
 
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 
 	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
-	kubectl wait --for=condition=Available --timeout=60s deployment/${deployment}
+	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
 	kubectl expose deployment/${deployment}
 	kubectl scale deployment/${deployment} --replicas=${replicas}
 	cmd="kubectl get deployment/${deployment} -o yaml | grep 'availableReplicas: ${replicas}'"

--- a/integration/kubernetes/k8s-scale-nginx.bats
+++ b/integration/kubernetes/k8s-scale-nginx.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	nginx_version=$(get_test_version "docker_images.nginx.version")

--- a/integration/kubernetes/k8s-security-context.bats
+++ b/integration/kubernetes/k8s-security-context.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-shared-volume.bats
+++ b/integration/kubernetes/k8s-shared-volume.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"

--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 issue="https://github.com/kata-containers/tests/issues/3472"
 
 setup() {

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -31,8 +31,6 @@ setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
-	wait_time=90
-	sleep_time=3
 	volume_name="pv-volume"
 	volume_claim="pv-claim"
 

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -31,8 +31,8 @@ setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 
-	wait_time=10
-	sleep_time=2
+	wait_time=90
+	sleep_time=3
 	volume_name="pv-volume"
 	volume_claim="pv-claim"
 

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -22,7 +22,7 @@ setup() {
 }
 
 @test "Verify nginx connectivity between pods" {
-	wait_time=30
+	wait_time=90
 	sleep_time=3
 
 	# Create test .yaml
@@ -30,7 +30,7 @@ setup() {
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 
 	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
-	kubectl wait --for=condition=Available --timeout=60s deployment/${deployment}
+	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
 	kubectl expose deployment/${deployment}
 
 	busybox_pod="test-nginx"

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -6,7 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
-load "${BATS_TEST_DIRNAME}/../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	nginx_version=$(get_test_version "docker_images.nginx.version")

--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -22,8 +22,6 @@ setup() {
 }
 
 @test "Verify nginx connectivity between pods" {
-	wait_time=90
-	sleep_time=3
 
 	# Create test .yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \

--- a/integration/kubernetes/tests_common.sh
+++ b/integration/kubernetes/tests_common.sh
@@ -9,6 +9,11 @@
 #
 # This contains variables and functions common to all e2e tests.
 
+# Timeout options, mainly for use with waitForProcess(). Use them unless the
+# operation needs to wait longer.
+wait_time=90
+sleep_time=3
+
 get_pod_config_dir() {
 	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	info "k8s configured to use runtimeclass"

--- a/integration/kubernetes/tests_common.sh
+++ b/integration/kubernetes/tests_common.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is evoked within an OpenShift Build to product the binary image,
+# which will contain the Kata Containers installation into a given destination
+# directory.
+#
+# This contains variables and functions common to all e2e tests.
+
+get_pod_config_dir() {
+	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
+	info "k8s configured to use runtimeclass"
+}
+
+# Uses crictl to pull a container image passed in $1.
+# If crictl is not found then it just prints a warning.
+crictl_pull() {
+	local img="${1:-}"
+	local cmd="crictl"
+	if ! command -v "$cmd" &>/dev/null; then
+		warn "$cmd not found. Cannot pull image $img"
+	else
+		sudo -E "$cmd" pull "$img"
+	fi
+}

--- a/integration/kubernetes/tests_common.sh
+++ b/integration/kubernetes/tests_common.sh
@@ -14,6 +14,10 @@
 wait_time=90
 sleep_time=3
 
+# Timeout for use with `kubectl wait`, unless it needs to wait longer.
+# Note: try to keep timeout and wait_time equal.
+timeout=90s
+
 get_pod_config_dir() {
 	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	info "k8s configured to use runtimeclass"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -180,20 +180,3 @@ clean_env_ctr()
 		sudo ctr c rm $(sudo ctr c list -q)
 	fi
 }
-
-get_pod_config_dir() {
-	pod_config_dir="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
-	info "k8s configured to use runtimeclass"
-}
-
-# Uses crictl to pull a container image passed in $1.
-# If crictl is not found then it just prints a warning.
-crictl_pull() {
-	local img="${1:-}"
-	local cmd="crictl"
-	if ! command -v "$cmd" &>/dev/null; then
-		warn "$cmd not found. Cannot pull image $img"
-	else
-		sudo -E "$cmd" pull "$img"
-	fi
-}


### PR DESCRIPTION
The test mentioned in https://github.com/kata-containers/tests/issues/3496 seems to be failing because same times 30s (default of `kubectl wait`) is not enough for the test pod to be ready. My initial thought was to just increase its timeout but then I realized that each test sets its own timeout (some just leave the default) and maybe we could have a minimum baseline for all tests.

I am also sending other improvements, more like code re-organization, so that variables and functions live closer to the tests using them.