### PR TITLE
ci: Refer to stable-2.1 branch on stable-2.1 branch

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -14,7 +14,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo="github.com/kata-containers/kata-containers"
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
-export kata_default_branch="${kata_default_branch:-main}"
+export kata_default_branch="${kata_default_branch:-stable-2.1}"
 export timeout="90s"
 
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -35,7 +35,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-main}
+branch=${branch:-stable-2.1}
 
 # Which static check functions to consider.
 handle_funcs="all"
@@ -232,7 +232,7 @@ static_check_commits()
 	# for master branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
 	# for main branch
-	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'stable-2.1' && git fetch -v)
 
 	# Check the commits in the branch
 	{
@@ -242,7 +242,7 @@ static_check_commits()
 			--ignore-fixes-for-subsystem "release" \
 			--verbose \
 			HEAD \
-			main; \
+			stable-2.1; \
 			rc="$?";
 	} || true
 
@@ -1202,7 +1202,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "main" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "stable-2.1" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
-3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/stable-2.1/integration/kubernetes)
+   - [Containerd](https://github.com/kata-containers/tests/tree/stable-2.1/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/stable-2.1/integration/stability)
+3. [Metrics](https://github.com/kata-containers/tests/tree/stable-2.1/metrics)
 
 ## CI Content
 
@@ -159,7 +159,7 @@ You need to install the following to run Kata Containers tests:
 - [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
-  [versions database](https://github.com/kata-containers/kata-containers/blob/main/versions.yaml).
+  [versions database](https://github.com/kata-containers/kata-containers/blob/stable-2.1/versions.yaml).
 
 - `make`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ and with different container managers.
 
 1. Integration tests to ensure compatibility with:
    - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/main/integration/cri-o)
    - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
 2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
 3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -110,7 +110,7 @@ categories:
   - name: related
     description: |
       Related project. Base set can be generated from
-      https://github.com/kata-containers/kata-containers/blob/main/versions.yaml.
+      https://github.com/kata-containers/kata-containers/blob/stable-2.1/versions.yaml.
 
   - name: release
     description: Related to production of new versions.

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -50,7 +50,7 @@ create_file() {
 	local block_size=4096
 	local data_offset=$((1024*1024*2))
 	local dax_alignment=$((1024*1024*2))
-	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/osbuilder/image-builder/nsdax.gpl.c"
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/stable-2.1/tools/osbuilder/image-builder/nsdax.gpl.c"
 
 	truncate -s "${SIZE}" "${FILE}"
 	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,7 +10,7 @@ description: |
   This file contains test specific version details.
   For other version details, see the main database:
 
-  https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
+  https://github.com/kata-containers/kata-containers/blob/stable-2.1/versions.yaml
 
 docker_images:
   description: "Docker hub images used for testing"


### PR DESCRIPTION
This commit forces all the checks and references to point to stable-2.1
branch rather than pointing to `main`.  This will guarantee that changes
done on `main` won't affect the testing of this specific branch.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>