### PR TITLE
readme: Remove reference to cri-o unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ and with different container managers.
 
 1. Integration tests to ensure compatibility with:
    - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [CRI-O](https://github.com/kata-containers/tests/tree/main/integration/cri-o)
    - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
 2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
 3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)


### PR DESCRIPTION
As we still didn't get CRI-O unit tests to run against shimv2, we
removed those from our tree as part 816aee4. However, we left some
documentation behind and that will break the static check.

Fixes: #3505

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>