### PR TITLE
stable-2.1: First round of backports

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -17,7 +17,7 @@ source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
 latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-vanilla-$(uname -m)-nightly/${cached_artifacts_path}"
-experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
+experimental_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-experimental-$(uname -m)-nightly/${cached_artifacts_path}"
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
@@ -39,11 +39,10 @@ trap exit_handler EXIT
 get_current_kernel_version() {
 	if [ "$experimental_kernel" == "true" ]; then
 		kernel_version=$(get_version "assets.kernel-experimental.tag")
-		echo "${kernel_version}"
 	else
 		kernel_version=$(get_version "assets.kernel.version")
-		echo "${kernel_version/v/}"
 	fi
+	echo "${kernel_version/v/}"
 }
 
 get_kata_config_version() {
@@ -130,6 +129,7 @@ main() {
 	if [ "${experimental_kernel}" == "false" ]; then
 		cached_kernel_version=$(curl -sfL "${latest_build_url}/latest") || cached_kernel_version="none"
 	else
+		current_kernel_version+="-experimental"
 		cached_kernel_version=$(curl -sfL "${experimental_latest_build_url}/latest") || cached_kernel_version="none"
 	fi
 	info "current kernel : ${current_kernel_version}"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -21,9 +21,7 @@ experimental_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-exp
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
-kata_repo="github.com/kata-containers/kata-containers"
-export GOPATH=${GOPATH:-${HOME}/go}
-kernel_repo_dir="${GOPATH}/src/${kata_repo}/tools/packaging"
+kernel_repo_dir="${kata_repo_dir}/tools/packaging"
 kernel_arch="$(arch)"
 readonly tmp_dir="$(mktemp -d -t install-kata-XXXXXXXXXXX)"
 packaged_kernel="kata-linux-container"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -16,7 +16,7 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-latest_build_url="${jenkins_url}/job/kernel-nightly-$(uname -m)/${cached_artifacts_path}"
+latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-vanilla-$(uname -m)-nightly/${cached_artifacts_path}"
 experimental_latest_build_url="${jenkins_url}/job/kernel-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"

--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -55,7 +55,7 @@ run() {
 		bash density/memory_usage_inside_container.sh
 
 		# Run the time tests
-		bash time/launch_times.sh -i registry.fedoraproject.org/fedora:latest -n 20
+		bash time/launch_times.sh -i mirror.gcr.io/library/ubuntu:latest -n 20
 	fi
 
 	# Run storage tests

--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -55,7 +55,7 @@ run() {
 		bash density/memory_usage_inside_container.sh
 
 		# Run the time tests
-		bash time/launch_times.sh -i mirror.gcr.io/library/ubuntu:latest -n 20
+		bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 	fi
 
 	# Run storage tests

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -16,9 +16,9 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.575
-minpercent = 10.0
-maxpercent = 10.0
+midval = 0.62
+minpercent = 5.0
+maxpercent = 5.0
 
 [[metric]]
 name = "memory-footprint"

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -33,7 +33,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# List the files
 	cmd="ls /tmp/secret-volume"
@@ -44,7 +44,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-secret-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$second_pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$second_pod_name"
 
 	# Display environment variables
 	second_cmd="printenv"

--- a/integration/kubernetes/k8s-exec.bats
+++ b/integration/kubernetes/k8s-exec.bats
@@ -21,7 +21,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
 	# Get pod specification
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Run commands in Pod
 	## Cases for -it options

--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -21,7 +21,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	retries="10"
 	max_number_cpus="3"

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -54,7 +54,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pv-pod.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	cmd="cat /mnt/index.html"
 	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"

--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -80,7 +80,7 @@ run_workload() {
 
 	# Run the image and command and capture the results into an array...
 	declare workload_result
-	readarray -n 0 workload_result < <(ctr run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test /bin/bash -c "$DATECMD $DMESGCMD")
+	readarray -n 0 workload_result < <(ctr run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test bash -c "$DATECMD $DMESGCMD")
 
 	end_time=$($DATECMD)
 
@@ -166,7 +166,7 @@ EOF
 	# between each of our 'test' containers. The aim being to see if our launch times
 	# are linear with the number of running containers or not
 	if [ -n "$SCALING" ]; then
-		ctr run --runtime=${CTR_RUNTIME} -d ${IMAGE} test /bin/bash -c "tail -f /dev/null"
+		ctr run --runtime=${CTR_RUNTIME} -d ${IMAGE} test bash -c "tail -f /dev/null"
 	fi
 }
 


### PR DESCRIPTION
This PR contains the first round of backports we need for the stable-2.1 branch and that would be really beneficial to have those merged before the 2.1.0 release.

Those are:
https://github.com/kata-containers/tests/pulls?q=is%3Apr+is%3Aclosed+label%3Amissing-backport-to-stable-2.1.0