### PR TITLE
stable-2.0 | Backport fixes for ARM & PPC

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -18,6 +18,7 @@ echo "Install Kubernetes components"
 cidir=$(dirname "$0")
 source /etc/os-release || source /usr/lib/os-release
 kubernetes_version=$(get_version "externals.kubernetes.version")
+ARCH=$("${cidir}"/kata-arch.sh -d)
 
 if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 	die "Kubernetes will not work with $KATA_HYPERVISOR"
@@ -33,10 +34,12 @@ EOF"
 	chronic sudo -E apt update
 	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
+	url="https://packages.cloud.google.com/yum/repos/kubernetes-el7-${ARCH}"
+	echo "Install ${url} for ${ARCH}"
 	sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 	[kubernetes]
 	name=Kubernetes
-	baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+	baseurl=${url}
 	enabled=1
 	gpgcheck=1
 	repo_gpgcheck=1

--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -25,6 +25,9 @@ if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
 fi
 
 if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
+	if [ "$(command -v kubelet)" != "" ]; then
+		apt purge kubelet -y
+	fi
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
 EOF"
@@ -34,6 +37,9 @@ EOF"
 	chronic sudo -E apt update
 	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 elif [ "$ID" == "centos" ] || [ "$ID" == "fedora" ]; then
+	if [ "$(command -v kubelet)" != "" ]; then
+		yum autoremove kubelet -y
+	fi
 	url="https://packages.cloud.google.com/yum/repos/kubernetes-el7-${ARCH}"
 	echo "Install ${url} for ${ARCH}"
 	sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo

--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -71,5 +71,9 @@ build_and_install_qemu() {
         sudo -E make install
 
         sudo ln -sf $(command -v ${BUILT_QEMU}) "/usr/bin/qemu-system-${QEMU_ARCH}"
+
+        echo "Link virtiofsd to /usr/libexec/kata-qemu/virtiofsd"
+        sudo mkdir -p /usr/libexec/kata-qemu/
+        sudo ln -sf $(pwd)/virtiofsd /usr/libexec/kata-qemu/virtiofsd
         popd
 }

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -68,7 +68,7 @@ esac
 check_processes
 
 # Remove existing CNI configurations:
-cni_config_dir="/etc/cni/net.d"
+cni_config_dir="/etc/cni"
 cni_interface="cni0"
 sudo rm -rf /var/lib/cni/networks/*
 sudo rm -rf "${cni_config_dir}"/*
@@ -106,6 +106,13 @@ trap 'sudo -E sh -c "rm -r "${kubeadm_config_file}""' EXIT
 if [ "${BAREMETAL}" == true ] && [[ $(wc -l /proc/swaps | awk '{print $1}') -gt 1 ]]; then
 	sudo swapoff -a || true
 fi
+
+#reinstall kubelet to do deep cleanup
+if [ "$(command -v kubelet)" != "" ]; then
+	info "reinstall kubeadm, kubelet before initialize k8s"
+	bash -f "${SCRIPT_PATH}/../../.ci/install_kubernetes.sh"
+fi
+
 sudo -E kubeadm init --config "${kubeadm_config_file}"
 
 mkdir -p "$HOME/.kube"


### PR DESCRIPTION
This contains two backports:
**ci: updates to kata setup scripts for ppc64le**

    - kubenetes package installation for ppc64le
    - virtiofsd installation

    Fixes: #3185

Signed-off-by: Jing Wang <jing.wang4@ibm.com>
(cherry picked from commit 0febfe00f8c8bbfc45ce27ec852320a698aef1ad)

**ci: workaround to fix arm ci failure.**

Currently, before containerd integration test, containerd service is
stopped., which will disable docker service. Then, the TestImageLoad
will fail for it depends on docker service.

Here, we restart docker before containerd test to avoid that failure.

But these tests have been working well for years. I can't tell why it
is.

Also do cleanup before k8s initialization to avoid lots of bizarre
issues.
for example:
1. [ERROR Port-10250]: Port 10250 is in use
2. Unfortunately, an error has occurred:
                timed out waiting for the condition

Fixes: #3478
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
(cherry picked from commit d7ca6409275b88ef12fad30ec7c8c188e8766f47)
