### PR TITLE
k8s: enable cri runtime service rather than start it

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -80,7 +80,7 @@ if ip a show "$cni_interface"; then
 fi
 
 echo "Start ${cri_runtime} service"
-sudo systemctl start ${cri_runtime}
+sudo systemctl enable --now ${cri_runtime}
 max_cri_socket_check=5
 wait_time_cri_socket_check=5
 


### PR DESCRIPTION
While using the init.sh script to setup a local dev environment, I've found
that the cri runtime service was not enabled, and I had to re-start it on
reboots.
Enabling it makes sure it is always available.

Fixes #3519

Signed-off-by: Julien Ropé <jrope@redhat.com>