### PR TITLE
Revert "kubernetes: Skip "Setting sysctl" test with CRI-O"

### DIFF
--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -7,23 +7,15 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-issue="https://github.com/kata-containers/tests/issues/3472"
+issue="https://github.com/kata-containers/tests/issues/2574"
 
 setup() {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	pod_name="sysctl-test"
 	get_pod_config_dir
 }
 
 @test "Setting sysctl" {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	# Create pod
 	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
 
@@ -37,10 +29,6 @@ setup() {
 }
 
 teardown() {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 


### PR DESCRIPTION
This reverts commit 1e89be5d9f1b25395dd9b4e5c227f8a089abf6d0.

Depends-on: https://github.com/kata-containers/kata-containers/pull/1844

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>