### PR TITLE
backport fixes for stable 2.0

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -347,7 +347,7 @@ static_check_rust_arch_specific()
 		return
 	fi
 
-	{ find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check > /dev/null 2>&1; ret=$?; } || true
+	{ find . -type f -name "*.rs"  | egrep -v "target/|grpc-rs/|protocols/" | xargs rustfmt --check; ret=$?; } || true
 
 	[ $ret -eq 0 ] || die "crate not formatted by rustfmt."
 }

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -35,7 +35,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-master}
+branch=${branch:-main}
 
 # Which static check functions to consider.
 handle_funcs="all"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -484,6 +484,9 @@ static_check_license_headers()
 			--exclude="*.patch" \
 			--exclude="*.diff" \
 			--exclude="tools/packaging/static-build/qemu.blacklist" \
+			--exclude="tools/packaging/qemu/default-configs/*" \
+			--exclude="src/agent/protocols/protos/gogo/*" \
+			--exclude="src/agent/protocols/protos/google/*" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
ebffde7e static: rustfmt check output the details on the files
15afd386 static-checks: Do not inspect default-configs of QEMU
e345ac61 static-check: Change branch to main for kata 2.0