### PR TITLE
stable-2.1 | The last round of backports before releasing 2.1.0

### DIFF
--- a/.ci/ci_cache_components.sh
+++ b/.ci/ci_cache_components.sh
@@ -119,6 +119,13 @@ create_cache_asset() {
 		path=$(readlink -f "${image_path}")
 		echo $(basename "${path}") > "latest-${image_name}"
 		sudo cp "${path}" "${kata_dir}/osbuilder-${image_name}.yaml"  .
+	elif [ ! -z "${check_qemu}" ]; then
+		# The latest file is compounded of the QEMU version and SHA-256
+		# calculated from all files and scripts used to its build.
+		qemu_sha=$(calc_qemu_files_sha256sum)
+		[ -n "$qemu_sha" ] || \
+			die "Failed to calculate a SHA-256 for QEMU"
+		echo "${component_version} ${qemu_sha}" > "latest"
 	else
 		echo "${component_version}" >  "latest"
 	fi

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -31,6 +31,14 @@ qemu_latest_build_url="${jenkins_url}/job/qemu-nightly-$(uname -m)/${cached_arti
 # option "--shallow-submodules" was introduced in git v2.9.0
 GIT_SHADOW_VERSION="2.9.0"
 
+# We need to move the tar file to a specific location so we
+# can know where it is and then we can perform the build cache
+# operations
+update_cache() {
+	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
+	sudo mv ${QEMU_TAR} ${KATA_TESTS_CACHEDIR}
+}
+
 build_static_qemu() {
 	info "building static QEMU"
 	# only x86_64 is supported for building static QEMU
@@ -40,11 +48,7 @@ build_static_qemu() {
 	cd "${PACKAGING_DIR}/static-build/qemu"
 	prefix="${KATA_QEMU_DESTDIR}" make
 
-	# We need to move the tar file to a specific location so we
-	# can know where it is and then we can perform the build cache
-	# operations
-	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
-	sudo mv ${QEMU_TAR} ${KATA_TESTS_CACHEDIR}
+	update_cache
 	)
 }
 
@@ -69,6 +73,7 @@ install_cached_qemu() {
 
 	sha256sum -c "sha256sum-${QEMU_TAR}" || return 1
 	uncompress_static_qemu "${QEMU_TAR}"
+	update_cache
 }
 
 clone_qemu_repo() {

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -416,3 +416,52 @@ get_pr_changed_file_details()
 {
 	get_pr_changed_file_details_full | grep -v "vendor/"
 }
+
+
+# Gets a list of files and/or directories to build a SHA-256 from their contents.
+# Returns the SHA-256 hash if succeeded, otherwise an empty string.
+sha256sum_from_files() {
+	local files_in=${1:-}
+	local files=""
+	local shasum=""
+
+	# Process the input files:
+	#  - discard the files/directories that don't exist.
+	#  - find the files if it is a directory
+	for f in $files_in; do
+		if [ -d "$f" ]; then
+			files+=" $(find $f -type f)"
+		elif [ -f "$f" ]; then
+			files+=" $f"
+		fi
+	done
+	# Return in case there is none input files.
+	[ -n "$files" ] || return 0
+
+	# Alphabetically sorting the files.
+	files="$(echo $files | tr ' ' '\n' | LC_ALL=C sort -u)"
+	# Concate the files and calculate a hash.
+	shasum="$(cat $files | sha256sum -b)" || true
+	if [ -n "$shasum" ];then
+		# Return only the SHA field.
+		echo $(awk '{ print $1 }' <<< $shasum)
+	fi
+}
+
+# Calculate a SHA-256 from all the files used to build QEMU.
+# Use this function to detect changes on build scripts which should force a
+# local build of QEMU.
+#
+# Note: bear in mind it is not used a comprehensive list of files but only
+# those that seems sufficient to detect changes. For example, this script is
+# sourced by many others but it is not considered.
+calc_qemu_files_sha256sum() {
+	local pkg_dir="${kata_repo_dir}/tools/packaging"
+	local files="${pkg_dir}/qemu \
+		${pkg_dir}/static-build/qemu \
+		${pkg_dir}/static-build/qemu.blacklist \
+		${pkg_dir}/static-build/scripts \
+		${pkg_dir}/scripts"
+
+	sha256sum_from_files $files
+}

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -93,6 +93,9 @@ install_extra_tools() {
 	echo "Install CNI plugins"
 	bash -f "${cidir}/install_cni_plugins.sh"
 
+	# Remove K8s + CRIO conf that may remain from a previous run
+	rm -f /etc/systemd/system/kubelet.service.d/0-crio.conf
+
 	[ "${CRIO}" = "yes" ] &&
 		echo "Install CRI-O" &&
 		bash -f "${cidir}/install_crio.sh" &&

--- a/integration/kubernetes/k8s-sysctls.bats
+++ b/integration/kubernetes/k8s-sysctls.bats
@@ -7,23 +7,14 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-issue="https://github.com/kata-containers/tests/issues/3472"
 
 setup() {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 	pod_name="sysctl-test"
 	get_pod_config_dir
 }
 
 @test "Setting sysctl" {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	# Create pod
 	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
 
@@ -37,10 +28,6 @@ setup() {
 }
 
 teardown() {
-        if [ "$CI_JOB" == "CRIO_K8S" ]; then
-                skip "test not working on CRI-O, see: ${issue}"
-        fi
-
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 


### PR DESCRIPTION
Folks, this is the last round of backports before getting 2.1.0 out, and it includes:

* One backport related to removing cri-o configuration for kubelet, in case of running a baremetal CI that would have to deal with both cri-o and containerd
d390f57955fc74f74c74e5b8ae5b778f5e1c33a8 ci: Removes existing k8s+crio config during setup

* Start using cached QEMU, which saves a brutal time when running the CI
d5a91e26e1fd13440aa5da4e00a7fa4f1c629147 ci/install_qemu: Always copy the tarball to the cache directory
2e4c14af3f374c0f4331f8ffa9259bd9f815cbd8 ci/install_qemu: Use cached QEMU

* Re-enable a previously disabled Kubernetes test, as the fix is getting in for the agent
3722c8cfad58d42c3b732282eeeb2702f2b26028 kubernetes: Reenable "Setting sysctl" test with CRI-O"
Depends-on: github.com/kata-containers/kata-containers#1853

Please, let me know if you think some of those should not be here.
