### PR TITLE
ci: Ensure we install rust whenever we're installing kata

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -84,6 +84,9 @@ enable_nested_virtualization() {
 
 install_kata() {
 	if [ "${INSTALL_KATA}" == "yes" ]; then
+		echo "Ensure rust is installed"
+		command -v rustup || bash -f ${cidir}/install_rust.sh
+
 		echo "Install Kata sources"
 		bash -f ${cidir}/install_kata.sh
 	fi


### PR DESCRIPTION
Let's ensure we will **always** install rust whenever kata-containers
will be installed.

I know, this is theoretically done on the osbuilder side, but we, as
part of the CI, should ensure this environment is ready from our side.

Fixes: #3515

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>