### PR TITLE
 Disable virtio-fs for KSM

### DIFF
--- a/.ci/set_kata_config.sh
+++ b/.ci/set_kata_config.sh
@@ -21,9 +21,9 @@ declare -A sections
 declare -A valid_requests
 declare -A json_keys
 
-readonly sections=([sandbox_cgroup_only]=runtime)
-readonly valid_requests=([sandbox_cgroup_only]="true false")
-readonly json_keys=([sandbox_cgroup_only]=.Runtime.SandboxCgroupOnly)
+readonly sections=([sandbox_cgroup_only]=runtime [shared_fs]=hypervisor.qemu)
+readonly valid_requests=([sandbox_cgroup_only]="true false" [shared_fs]="virtio-fs virtio-9p")
+readonly json_keys=([sandbox_cgroup_only]=.Runtime.SandboxCgroupOnly [shared_fs]=.Hypervisor.SharedFS)
 
 option=${1:-}
 request=${2:-}

--- a/.ci/set_kata_config.sh
+++ b/.ci/set_kata_config.sh
@@ -17,36 +17,61 @@ source "${script_dir}/../lib/common.bash"
 # shellcheck source=./lib.sh
 source "${script_dir}/lib.sh"
 
-option="sandbox_cgroup_only"
-request=${1:-}
+declare -A sections
+declare -A valid_requests
+declare -A json_keys
+
+readonly sections=([sandbox_cgroup_only]=runtime)
+readonly valid_requests=([sandbox_cgroup_only]="true false")
+readonly json_keys=([sandbox_cgroup_only]=.Runtime.SandboxCgroupOnly)
+
+option=${1:-}
+request=${2:-}
 
 usage(){
 	cat <<EOT
 Usage:
-${script_name} <true|false|clean>"
+${script_name} <option> <request>
 
-false: Disable ${option}
-true:  Enable ${option}
+Valid options and requests:
+$(for opt in "${!valid_requests[@]}"
+do
+	echo "${opt}": "${valid_requests["$opt"]}"
+done)
 
 The configuration changes are applied in kata user config:
 ${KATA_ETC_CONFIG_PATH}
 
 Remove it if you want to use the stateless options.
 EOT
+	exit 1
 }
 
-case ${request} in
-	true)
-		;;
-	false)
-		;;
-	*)
-		usage
-		exit 1
-		;;
-esac
+# need explicit handling of both cases because all errors are trapped
+valid=$([[ -n "${option}" ]] && echo $? || echo $?)
+# trailing space to match whole words
+if [[ "${valid}" == 0 && ! "${!valid_requests[*]} " =~ "${option} " ]]
+then
+	echo >&2 "ERROR: unknown option: '${option}'"
+	valid=1
+fi
+[[ "${valid}" == 0 ]] || usage
 
-current_value=$(kata-runtime kata-env --json | jq ".Runtime.SandboxCgroupOnly")
+valid=$([[ -n "${request}" ]] && echo $? || echo $?)
+if [[ "${valid}" == 0 && ! "${valid_requests["${option}"]} " =~ "${request} " ]]
+then
+	echo >&2 "ERROR: unknown request: '${request}'"
+	valid=1
+fi
+[[ "${valid}" == 0 ]] || usage
+
+# quote non-boolean request
+[[ "$request" =~ ^(true|false)$ ]] || request="\"${request}\""
+
+readonly section="${sections["${option}"]}"
+readonly json_key="${json_keys["${option}"]}"
+
+current_value=$(kata-runtime kata-env --json | jq "${json_key}")
 if [ "$current_value" == "${request}" ]; then
 	info "already ${request}"
 	exit 0
@@ -73,10 +98,10 @@ if [ "${KATA_ETC_CONFIG_PATH}" != "${kata_config_path}" ]; then
 fi
 
 info "modifying config file : ${KATA_ETC_CONFIG_PATH}"
-sudo crudini --set "${KATA_ETC_CONFIG_PATH}" "runtime" "${option}" "${request}"
+sudo crudini --set "${KATA_ETC_CONFIG_PATH}" "${section}" "${option}" "${request}"
 
 info "Validate option is ${request}"
-current_value=$(kata-runtime kata-env --json | jq ".Runtime.SandboxCgroupOnly")
+current_value=$(kata-runtime kata-env --json | jq "${json_key}")
 
 [ "$current_value" == "${request}" ] || die "The option was not updated"
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-kata-metric3.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-kata-metric3.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 107138.0
+midval = 47667.0
 minpercent = 5.0
 maxpercent = 5.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 107698.8
+midval = 47667.0
 minpercent = 5.0
 maxpercent = 5.0
 

--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -19,12 +19,6 @@ KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-yes}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
 WAIT_TIME="60"
-arch=$("${dir_path}"/../../.ci/kata-arch.sh -d)
-
-if [ "$arch" == "aarch64" ]; then
-	echo "Skip KSM test: $arch does not support it"
-	exit 0
-fi
 
 function setup() {
 	sudo systemctl restart containerd

--- a/integration/sandbox_cgroup/sandbox_cgroup_test.sh
+++ b/integration/sandbox_cgroup/sandbox_cgroup_test.sh
@@ -34,9 +34,9 @@ function setup() {
 
 function test_stability() {
 	pushd "${GOPATH}/src/${tests_repo}"
-	".ci/toggle_sandbox_cgroup_only.sh" true
+	".ci/set_kata_config.sh" sandbox_cgroup_only true
 	sudo -E PATH="$PATH" bash -c "make stability"
-	".ci/toggle_sandbox_cgroup_only.sh" false
+	".ci/set_kata_config.sh" sandbox_cgroup_only false
 	popd
 }
 

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -286,6 +286,13 @@ wait_ksm_settle(){
 
 	oldscan=$(cat /sys/kernel/mm/ksm/full_scans)
 
+	# Wait some time for KSM to kick in to avoid early dismissal
+	for ((t=0; t<5; t++)); do
+		pages=$(cat "${KSM_PAGES_SHARED}")
+		[[ "$pages" -ne 0 ]] && echo "Discovered KSM activity" && break
+		sleep 1
+	done
+
 	# Go around the loop until either we see a small % change
 	# between two full_scans, or we timeout
 	for ((t=0; t<$1; t++)); do


### PR DESCRIPTION
Due to virtio-fs using file-backed memory, KSM (Kernel Samepage Merging) is unstable or, depending on architecture, might not work at all.

- Generalize `.ci/toggle_sandbox_cgroup_only.sh` to `.ci/set_kata_config.sh` so it can be used for other keys.
- Disable virtio-fs for KSM test. Keep virtio-9p if it was enabled.
- Give KSM a little time to kick in (just because there are no shared pages *immediately* after starting container doesn't mean it isn't working).
- Re-enable KSM test on ARM. **I'm assuming this will fix ARM, but I don't have the means to test it. Test before merging.**

Fixes: #3531