### PR TITLE
containerd: enable memory update test on arm64

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -263,13 +263,16 @@ TestKilledVmmCleanup() {
 }
 
 TestContainerMemoryUpdate() {
-	if [[ "${KATA_HYPERVISOR}" != "qemu" ]] || [[ "$ARCH" != "x86_64" ]]; then
+	if [[ "${KATA_HYPERVISOR}" != "qemu" ]]; then
 		return
 	fi
 
 	test_virtio_mem=$1
 
 	if [ $test_virtio_mem -eq 1 ]; then
+		if [[ "$ARCH" != "x86_64" ]]; then
+			return
+		fi
 		info "Test container memory update with virtio-mem"
 
 		sudo sed -i -e 's/^#enable_virtio_mem.*$/enable_virtio_mem = true/g' "${kata_config}"


### PR DESCRIPTION
As memory hotplug has enabled for now on arm64, let memory update test run.

Fixes: #3533
Depends-on: github.com/kata-containers/kata-containers#1888

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>