### PR TITLE
openshift-ci: Fix job is broken due symlink on installation and improvements

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -77,3 +77,13 @@ unset VERSION
 "${cidir}/install_kata_image.sh"
 
 "${cidir}/install_runtime.sh"
+
+# The resulting kata installation will be merged in rhcos filesystem, and
+# symlinks are troublesome. So instead let's convert them to in-place files.
+for ltarget in $(find ${DESTDIR} -type l); do
+	lsource=$(readlink -f "${ltarget}")
+	if [ -e "${lsource}" ]; then
+		unlink "${ltarget}"
+		cp -fr "${lsource}" "${ltarget}"
+	fi
+done


### PR DESCRIPTION
This PR fixes the issue #3544 related with installation of kata containers now has symlinks to the kernel and image.

I am also sending a improvement that will help on future to spot problems on CI.