### PR TITLE
tests: Remove 0-crio.conf using sudo.

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -94,7 +94,7 @@ install_extra_tools() {
 	bash -f "${cidir}/install_cni_plugins.sh"
 
 	# Remove K8s + CRIO conf that may remain from a previous run
-	rm -f /etc/systemd/system/kubelet.service.d/0-crio.conf
+	sudo rm -f /etc/systemd/system/kubelet.service.d/0-crio.conf
 
 	[ "${CRIO}" = "yes" ] &&
 		echo "Install CRI-O" &&


### PR DESCRIPTION
On Fedora, we get:

```
Install CNI binaries
~/go/src/github.com/kata-containers/tests
Configure CNI
rm: cannot remove '/etc/systemd/system/kubelet.service.d/0-crio.conf':
Permission denied
```

The file cannot be removed by a regular user. Add `sudo` to fix that.

Fixes: #3553

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>