### PR TITLE
docs: Include vfio tests in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ and with different container managers.
    - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
 2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
 3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
+4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
 
 ## CI Content
 


### PR DESCRIPTION
This PR adds vfio tests as part of the current tests that we support
in kata 2.x.

Fixes #3561

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>