### PR TITLE
ci: Ensure the configuration is not duplicated on a 2nd run

### DIFF
--- a/.ci/configure_crio_for_kata.sh
+++ b/.ci/configure_crio_for_kata.sh
@@ -15,7 +15,7 @@ crio_config_dir="/etc/crio/crio.conf.d"
 
 echo "Configure runtimes map for RuntimeClass feature with drop-in configs"
 
-sudo tee -a "$crio_config_dir/99-runtimes" > /dev/null <<EOF
+sudo tee "$crio_config_dir/99-runtimes" > /dev/null <<EOF
 [crio.runtime.runtimes.kata]
 runtime_path = "/usr/local/bin/containerd-shim-kata-v2"
 runtime_root = "/run/vc"


### PR DESCRIPTION
When using `tee -a ...` we ended up appending content to the
configuration file, while what we wanted was to simply override the
file's content, if the file existed.

Knowing this, let's drop the `-a` from the command line.

Fixes: #3563

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>