### PR TITLE
docs: Update README to include Jenkins and github actions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     * [CI Content](#ci-content)
         * [Centralised scripts](#centralised-scripts)
         * [CI setup](#ci-setup)
+        * [Controlling the CI](#controlling-the-ci)
         * [Detecting a CI system](#detecting-a-ci-system)
         * [Breaking Compatibility](#breaking-compatibility)
     * [CLI tools](#cli-tools)
@@ -76,6 +77,21 @@ Use `make list-install-targets` to retrieve all the available install targets.
 > The CI scripts perform a lot of setup before running content under a
 > CI. Some of this setup runs as the `root` user and **could break your developer's
 > system**. See [Developer Mode](#developer-mode).
+
+### Controlling the CI
+
+#### GitHub Actions
+
+Kata Containers uses GitHub Actions in the [Kata Containers](https://github.com/kata-containers/kata-containers) repos.
+All those actions, apart from the one to test `kata-deploy`, are automatically triggered when
+a pull request is submitted. The trigger phrase for testing kata-deploy is `/test_kata_deploy`.
+
+#### Jenkins
+
+The Jenkins configuration and most documentation is kept in the [CI repository](https://github.com/kata-containers/ci).
+Jenkins is setup to trigger a CI run on all the slaves/nodes when a `/test` comment is added to a pull request. However,
+there are some specific comments that are defined for specific CI slaves/nodes which are defined in the Jenkins
+`config.xml` files in the `<triggerPhase>` XML element in the [CI repository](https://github.com/kata-containers/ci).
 
 ### Detecting a CI system
 

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -22,6 +22,7 @@ crypto		# Cryptography
 DaemonSet/AB
 deliverable/AB
 devicemapper/B
+deploy
 dialer
 dialog/A
 distro/AB
@@ -45,6 +46,7 @@ implementor/A
 iodepth/A
 ioengine/A
 iptables
+kata
 Kat/AB		# "Kat Herding Team" :)
 keypair/A
 lifecycle/A


### PR DESCRIPTION
This PR updates the README to start including more information about
Jenkins jobs and github actions that are being used in kata repositories.

Fixes #3565

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>