### PR TITLE
docs: Include missing tittle in table of contents README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         * [Requirements to run Kata Containers tests](#requirements-to-run-kata-containers-tests)
         * [Prepare an environment](#prepare-an-environment)
         * [Run the tests](#run-the-tests)
+        * [Running subsets of tests](#running-subsets-of-tests)
     * [Metrics tests](#metrics-tests)
     * [Kata Admission controller webhook](#kata-admission-controller-webhook)
 


### PR DESCRIPTION
This PR includes a missing title in the table of contents of README.

Fixes #3578

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>