### PR TITLE
docs: Fix footprint data documentation

### DIFF
--- a/metrics/density/footprint_data.md
+++ b/metrics/density/footprint_data.md
@@ -1,7 +1,7 @@
 # Footprint data script details
 
 The `footprint_data.sh` script runs a number of identical containers sequentially
-via the docker engine and takes a number of memory related measurements after each
+via ctr and takes a number of memory related measurements after each
 launch. The script is generally not used in a CI type environment, but is intended
 to be run and analyzed manually.
 
@@ -17,21 +17,20 @@ Some variables affect how the payload is executed. The `RUNTIME` and `PAYLOAD`
 arguments directly affect the payload execution with the following line in
 the script:
 
-`$ docker run -tid --runtime=$RUNTIME $PAYLOAD_RUNTIME_ARGS $PAYLOAD $PAYLOAD_ARGS`
+`$ ctr run --memory-limit $PAYLOAD_RUNTIME_ARGS --rm --runtime=$CONTAINERD_RUNTIME $PAYLOAD $NAME sh -c $PAYLOAD_ARGS`
 
 Other settings affect how memory footprint is measured and the test termination
 conditions.
 
 | Variable | Function
 | -------- | --------
-| `PAYLOAD` | The docker image to run
-| `PAYLOAD_ARGS` | Any arguments passed into the docker image
-| `PAYLOAD_RUNTIME_ARGS` | Any extra arguments passed into the docker `run` command
+| `PAYLOAD` | The `ctr` image to run
+| `PAYLOAD_ARGS` | Any arguments passed into the `ctr` image
+| `PAYLOAD_RUNTIME_ARGS` | Any extra arguments passed into the `ctr run` command
 | `PAYLOAD_SLEEP` | Seconds to sleep between launch and measurement, to allow settling
 | `MAX_NUM_CONTAINERS` | The maximum number of containers to run before terminating
 | `MAX_MEMORY_CONSUMED` | The maximum amount of memory to be consumed before terminating
 | `MIN_MEMORY_FREE` | The minimum amount of memory allowed to be free before terminating
-| `DOCKERD_PATH` | The path to the Docker `dockerd` binary (for `smem` measurements)
 | `DUMP_CACHES` | A flag to note if the system caches should be dumped before capturing stats
 | `DATAFILE` | Can be set to over-ride the default JSON results filename
 
@@ -48,7 +47,6 @@ The test measures, calculates, and stores a number of data items:
 | `uss` | USS for all the VM runtime components
 | `pss` | PSS for all the VM runtime components
 | `all_pss` | PSS of all of userspace - to monitor if we had other impact on the system
-| `dockerd` | PSS of the `dockerd` process
 | `user_smem` | `smem` "userspace" consumption value
 | `avail` | "available" memory from `free`
 | `avail_decr` | "available" memory decrease since start of test
@@ -70,39 +68,20 @@ invoke the test script to run a number of different container tests.
 set -e
 set -x
 
-export MAX_NUM_CONTAINERS=40
-export MAX_MEMORY_CONSUMED=56*1024*1024*1024
+export MAX_NUM_CONTAINERS=10
+export MAX_MEMORY_CONSUMED=6*1024*1024*1024
 
 function run() {
 	###
 	# Define what we will be running (app under test)
 	#  Default is we run busybox, as a 'small' workload
-	export PAYLOAD="busybox"
+	export PAYLOAD="quay.io/prometheus/busybox:latest"
 	export PAYLOAD_ARGS="tail -f /dev/null"
 	export PAYLOAD_SLEEP=10
-	export PAYLOAD_RUNTIME_ARGS="-m 2G"
-	sudo -E bash $(pwd)/density/footprint_data.sh
-
-	#  mysql is a more medium sized workload
-	export PAYLOAD="mysql"
-	# Unset aio, as for some runtimes the host kernel will run out of handles
-	# after ~24 containers or so
-	export PAYLOAD_ARGS="--innodb_use_native_aio=0 --disable-log-bin"
-	export PAYLOAD_SLEEP=10
-	export PAYLOAD_RUNTIME_ARGS="-m 4G -e MYSQL_ALLOW_EMPTY_PASSWORD=1"
-	sudo -E bash $(pwd)/density/footprint_data.sh
-
-	#  elasticsearch is a large workload
-	export PAYLOAD="elasticsearch"
-	# This is a 'hack' - if we do not set the PAYLOAD_ARGS to non-NULL, then we will
-	# inherit the default ones set in the script, and they are not what we want
-	# for this container
-	export PAYLOAD_ARGS=" "
-	export PAYLOAD_SLEEP=10
-	export PAYLOAD_RUNTIME_ARGS="-m 8G"
+	export PAYLOAD_RUNTIME_ARGS="5120"
 	sudo -E bash $(pwd)/density/footprint_data.sh
 }
 
-export RUNTIME=kata-runtime
+export CONTAINERD_RUNTIME=io.containerd.kata.v2
 run
 ```


### PR DESCRIPTION
This PR fixes the footprint data documentation. This replaces docker
to what we are using which is using ctr as well as it is updating
the changes that we did in the footprint script.

Fixes #3583

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>