### PR TITLE
ci: Remove X86 pc machine related tests

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -17,7 +17,7 @@ source /etc/os-release || source /usr/lib/os-release
 KATA_REPO="github.com/kata-containers/kata-containers"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
-MACHINETYPE="${MACHINETYPE:-pc}"
+MACHINETYPE="${MACHINETYPE:-q35}"
 METRICS_CI="${METRICS_CI:-}"
 PREFIX="${PREFIX:-/usr}"
 DESTDIR="${DESTDIR:-/}"

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,6 @@ vfio:
 #	Skip: Issue: https://github.com/kata-containers/kata-containers/issues/1488
 #	bash -f functional/vfio/run.sh -s false -p clh -i image
 #	bash -f functional/vfio/run.sh -s true -p clh -i image
-	bash -f functional/vfio/run.sh -s false -p qemu -m pc -i image
-	bash -f functional/vfio/run.sh -s true -p qemu -m pc -i image
 	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i image
 	bash -f functional/vfio/run.sh -s true -p qemu -m q35 -i image
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.57
+midval = 0.53
 minpercent = 5.0
 maxpercent = 5.0
 

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -196,14 +196,10 @@ main() {
 	# run_test initrd "" cloud-hypervisor false
 	# run_test initrd "q35" qemu false
 	# run_test initrd "q35" qemu true
-	# run_test initrd "pc" qemu false
-	# run_test initrd "pc" qemu true
 	run_test image "" cloud-hypervisor false
 	run_test image "" cloud-hypervisor true
 	run_test image "q35" qemu false
 	run_test image "q35" qemu true
-	run_test image "pc" qemu false
-	run_test image "pc" qemu true
 }
 
 main $@


### PR DESCRIPTION
Issue: https://github.com/kata-containers/kata-containers/issues/1953
aims to remove the support for the legacy X86 machine (PC), remove
the related tests.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>