### PR TITLE
kubernetes: remove memory limitation for flannel on ppc64le

### DIFF
--- a/.ci/ppc64le/kubernetes/init.sh
+++ b/.ci/ppc64le/kubernetes/init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+network_plugin_config_file="${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/kube-flannel.yml"
+
+curl -fsL $flannel_url -o $network_plugin_config_file
+
+memory_resource="spec.template.spec.containers[*].resources.*.memory"
+# install yq if not exist
+${SCRIPT_PATH}/../../.ci/install_yq.sh
+# Default flannel config has limitation and request for memory, and it may cause OOM on ppc64le.
+# Though here, we delete memory limitation for all archs, this modified-configuration
+# file will only be applied on ppc64le.
+sudo -E ${GOPATH}/bin/yq d -i -d'*' $network_plugin_config_file $memory_resource  > /dev/null
+
+network_plugin_config="$network_plugin_config_file"


### PR DESCRIPTION
The pod gets often OOM killed with default limitation.

Fixes #3590

Signed-off-by: MatthieuSarter <matthieu.sarter@ibm.com>