### PR TITLE
integration/cri-o: add integration tests kata 2.x ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ else
 	bash sanity/check_sanity.sh
 endif
 
+crio:
+	bash .ci/install_bats.sh
+	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
+
 docker-stability:
 	systemctl is-active --quiet docker || sudo systemctl start docker
 	cd integration/stability && \
@@ -178,6 +182,7 @@ help:
 .PHONY: \
 	check \
 	checkcommits \
+	crio \
 	docker \
 	docker-stability \
 	filesystem \

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 
 crio:
 	bash .ci/install_bats.sh
-	RUNTIME=${RUNTIME} ./integration/cri-o/cri-o.sh
+	./integration/cri-o/cri-o.sh
 
 docker-stability:
 	systemctl is-active --quiet docker || sudo systemctl start docker

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -14,7 +14,10 @@ source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
 export JOBS="${JOBS:-$(nproc)}"
-export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-containerd-shim-kata-v2}"
+export CONTAINER_DEFAULT_RUNTIME="${CONTAINER_DEFAULT_RUNTIME:-$CONTAINER_RUNTIME}"
+export RUNTIME_ROOT="${RUNTIME_ROOT:-/run/vc}"
+export RUNTIME_TYPE="${RUNTIME_TYPE:-vm}"
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -67,7 +67,7 @@ IFS=''
 pushd "${crio_repository_path}/test/"
 for i in "${skipCRIOTests[@]}"
 do
-	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/tests/issues/714)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
+	sed -i '/'${i}'/a skip \"This is not working\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
 done
 
 IFS=$OLD_IFS

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
+source "${SCRIPT_PATH}/crio_skip_tests.sh"
+source "${SCRIPT_PATH}/../../metrics/lib/common.bash"
+source /etc/os-release || source /usr/lib/os-release
+
+export JOBS="${JOBS:-$(nproc)}"
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$RUNTIME}"
+
+# Skip the cri-o tests if TEST_CRIO is not true
+# and we are on a CI job.
+# For non CI execution, run the cri-o tests always.
+if [ "$CI" = true ] && [ "$TEST_CRIO" != true ]
+then
+	echo "Skipping cri-o tests as TEST_CRIO is not true"
+	exit
+fi
+
+crio_repository="github.com/cri-o/cri-o"
+crio_repository_path="$GOPATH/src/${crio_repository}"
+
+img_file=""
+loop_device=""
+cleanup() {
+	[ -n "${loop_device}" ] && sudo losetup -d "${loop_device}"
+	[ -n "${img_file}" ] && rm -f "${img_file}"
+}
+
+# Check no processes are left behind
+check_processes
+
+# overlay storage options
+OVERLAY_STORAGE_OPTIONS="--storage-driver overlay"
+
+# Clone CRI-O repo if it is not already present.
+if [ ! -d "${crio_repository_path}" ]; then
+	go get -d "${crio_repository}" || true
+fi
+
+# If the change we are testing does not come from CRI-O repository,
+# then checkout to the version from versions.yaml in the runtime repository.
+if [ "$ghprbGhRepository" != "${crio_repository/github.com\/}" ];then
+	pushd "${crio_repository_path}"
+	if [ "$ID" == "fedora" ]; then
+		crio_version=$(get_version "externals.crio.meta.openshift")
+	else
+		crio_version=$(get_version "externals.crio.version")
+	fi
+	git fetch
+	git checkout "${crio_version}"
+	popd
+fi
+
+OLD_IFS=$IFS
+IFS=''
+
+# Skip CRI-O tests that currently are not working
+pushd "${crio_repository_path}/test/"
+for i in "${skipCRIOTests[@]}"
+do
+	sed -i '/'${i}'/a skip \"This is not working (Issue https://github.com/kata-containers/tests/issues/714)\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
+done
+
+IFS=$OLD_IFS
+
+# On other distros or on ZUUL, use overlay.
+# This will allow us to run tests with at least 2 different
+# storage drivers.
+export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
+
+echo "Ensure crio service is stopped before running the tests"
+if systemctl is-active --quiet crio; then
+	sudo systemctl stop crio
+fi
+
+echo "Ensure docker service is stopped before running the tests"
+if systemctl is-active --quiet docker; then
+	sudo systemctl stop docker
+fi
+
+echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
+./test_runner.sh ctr.bats
+
+popd

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -50,11 +50,7 @@ fi
 # then checkout to the version from versions.yaml in the runtime repository.
 if [ "$ghprbGhRepository" != "${crio_repository/github.com\/}" ];then
 	pushd "${crio_repository_path}"
-	if [ "$ID" == "fedora" ]; then
-		crio_version=$(get_version "externals.crio.meta.openshift")
-	else
-		crio_version=$(get_version "externals.crio.version")
-	fi
+	crio_version=$(get_version "externals.crio.branch")
 	git fetch
 	git checkout "${crio_version}"
 	popd

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -18,6 +18,7 @@ export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-containerd-shim-kata-v2}"
 export CONTAINER_DEFAULT_RUNTIME="${CONTAINER_DEFAULT_RUNTIME:-$CONTAINER_RUNTIME}"
 export RUNTIME_ROOT="${RUNTIME_ROOT:-/run/vc}"
 export RUNTIME_TYPE="${RUNTIME_TYPE:-vm}"
+export STORAGE_OPTIONS="--storage-driver overlay"
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.
@@ -40,9 +41,6 @@ cleanup() {
 
 # Check no processes are left behind
 check_processes
-
-# overlay storage options
-OVERLAY_STORAGE_OPTIONS="--storage-driver overlay"
 
 # Clone CRI-O repo if it is not already present.
 if [ ! -d "${crio_repository_path}" ]; then
@@ -76,11 +74,6 @@ do
 done
 
 IFS=$OLD_IFS
-
-# On other distros or on ZUUL, use overlay.
-# This will allow us to run tests with at least 2 different
-# storage drivers.
-export STORAGE_OPTIONS="$OVERLAY_STORAGE_OPTIONS"
 
 echo "Ensure crio service is stopped before running the tests"
 if systemctl is-active --quiet crio; then

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -59,6 +59,12 @@ if [ "$ghprbGhRepository" != "${crio_repository/github.com\/}" ];then
 	popd
 fi
 
+# Ensure the correct version of the CRI-O binary is built and ready
+pushd "${crio_repository_path}"
+CONTAINER_DEFAULT_RUNTIME="" make
+make test-binaries
+popd
+
 OLD_IFS=$IFS
 IFS=''
 

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Currently these are the CRI-O tests that are not working
+
+declare -a skipCRIOTests=(
+'test "ctr oom"'
+'test "ctr stats output"'
+'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
+'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
+'test "additional devices permissions"'
+);
+
+if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then
+	# This is a limitation in firecracker, the maximum number
+	# of block devices supported is 8, but this test tries to attach
+	# more than 10
+	skipCRIOTests+=(
+		'test "privileged ctr device add"'
+	)
+fi

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -8,18 +8,27 @@
 # Currently these are the CRI-O tests that are not working
 
 declare -a skipCRIOTests=(
+'test "ctr lifecycle"'
+'test "ctr logging"'
+'test "ctr journald logging"'
+'test "ctr log max"'
+'test "ctr log max with minimum value"'
+'test "ctr partial line logging"'
+'test "ctr execsync"'
+'test "ctr execsync should not overwrite initial spec args"'
+'test "privileged ctr device add"'
+'test "ctr execsync std{out,err}"'
 'test "ctr oom"'
-'test "ctr stats output"'
-'test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine"'
-'test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine"'
-'test "additional devices permissions"'
+'test "ctr \/etc\/resolv.conf rw\/ro mode"'
+'test "ctr create with non-existent command"'
+'test "ctr create with non-existent command \[tty\]"'
+'test "ctr update resources"'
+'test "ctr resources"'
+'test "ctr with non-root user has no effective capabilities"'
+'test "ctr with low memory configured should not be created"'
+'test "privileged ctr -- check for rw mounts"'
+'test "annotations passed through"'
+'test "ctr with default_env set in configuration"'
+'test "ctr with absent mount that should be rejected"'
 );
 
-if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then
-	# This is a limitation in firecracker, the maximum number
-	# of block devices supported is 8, but this test tries to attach
-	# more than 10
-	skipCRIOTests+=(
-		'test "privileged ctr device add"'
-	)
-fi


### PR DESCRIPTION
Add back integration tests with CRI-O but 2.x ready as per issue https://github.com/kata-containers/tests/issues/3592.
Once kata is installed on the system, "make crio" should allow the tests to be run.