### PR TITLE
Use Podman on Fedora-likes for ppc64le & s390x

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -40,8 +40,11 @@ build_rust_image() {
 	case "$build_method" in
 		"distro")
 			distro="${osbuilder_distro:-ubuntu}"
-			use_docker="${osbuild_docker:-1}"
-			sudo -E USE_DOCKER="${use_docker}" DISTRO="${distro}" \
+			if [[ ! "${osbuild_docker:-}" =~ ^(0|false|no)$ ]]; then
+				use_docker="${osbuild_docker:-}"
+				[[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
+			fi
+			sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" \
 				make -e "${target_image}"
 			;;
 		"dracut")

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -52,6 +52,14 @@ install_docker() {
 		return
 	fi
 
+	if ([ "$arch" == "ppc64le" ] || [ "$arch" == "s390x" ]) && ([ "$ID" == "fedora" ] || [[ "${ID_LIKE:-}" =~ "fedora" ]]); then
+		# download.docker.com does not package for ppc64le and s390x and on
+		# Fedora-likes, it's not packaged by the distro either. Use Podman.
+		sudo dnf install -y podman runc
+		export USE_PODMAN=1
+		return
+	fi
+
 	if ! command -v docker >/dev/null; then
 		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
 	fi


### PR DESCRIPTION
Docker is unavailable on Fedora/RHEL for ppc64le & s390x.

- ci: Enable running osbuilder with Podman & without a container engine, neither of which are currently supported
- ci/ppc64le,s390x: Install and use Podman on Fedora

Fixes: #3598

@Amulyam24, @bpradipt, or @clnperez: PTAL