### PR TITLE
ci: Install k8s containerd config if required

### DIFF
--- a/.ci/configure_containerd_for_kubernetes.sh
+++ b/.ci/configure_containerd_for_kubernetes.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Add kubelet containerd configuration"
+kubelet_service_dir="/etc/systemd/system/kubelet.service.d/"
+sudo mkdir -p "${kubelet_service_dir}"
+
+sudo rm -f "${kubelet_service_dir}/0-crio.conf"
+cat << EOF | sudo tee "${kubelet_service_dir}/0-containerd.conf"
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+EOF
+
+echo "Reload systemd services"
+sudo systemctl daemon-reload

--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -162,6 +162,7 @@ kubelet_service_dir="${service_path}/kubelet.service.d/"
 
 sudo mkdir -p "${kubelet_service_dir}"
 
+sudo rm -f "${kubelet_service_dir}/0-containerd.conf"
 cat <<EOF| sudo tee "${kubelet_service_dir}/0-crio.conf"
 [Service]
 Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -130,6 +130,8 @@ install_extra_tools() {
 	if [ "${KUBERNETES}" == "yes" ]; then
 		echo "Install Kubernetes" &&
 		bash -f "${cidir}/install_kubernetes.sh" &&
+		[ "${CRI_CONTAINERD}" = "yes" ] &&
+		bash -f "${cidir}/configure_containerd_for_kubernetes.sh" ||
 		echo "Kubernetes installed" ||
 		die "Kubernetes not installed"
 	fi


### PR DESCRIPTION
An entry for CRI-O is created in /etc/systemd/system/kubelet.service.d
when using CRI-O. Do the same when using Kubernetes and containerd.
Remove the other configuration respectively.

Fixes: #3602

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>