### PR TITLE
ci: Enable AGENT_INIT if TEST_INITRD == yes

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -19,7 +19,7 @@ DESTDIR="${DESTDIR:-/}"
 image_path="${DESTDIR}${image_path:-${PREFIX}/share/kata-containers}"
 image_name="${image_name:-kata-containers.img}"
 initrd_name="${initrd_name:-kata-containers-initrd.img}"
-AGENT_INIT="${AGENT_INIT:-no}"
+AGENT_INIT="${AGENT_INIT:-${TEST_INITRD:-no}}"
 TEST_INITRD="${TEST_INITRD:-no}"
 build_method="${BUILD_METHOD:-distro}"
 
@@ -33,6 +33,9 @@ build_rust_image() {
 	target_image="image"
 	file_to_install="${osbuilder_path}/${image_name}"
 	if [ "${TEST_INITRD}" == "yes" ]; then
+		if [ "${AGENT_INIT}" != "yes" ]; then
+			die "TEST_INITRD=yes without AGENT_INIT=yes is unsupported"
+		fi
 		target_image="initrd"
 		file_to_install="${osbuilder_path}/${initrd_name}"
 	fi


### PR DESCRIPTION
initrd only works with agent as init, so enable it, unless AGENT_INIT is
already set. Die when someone still tries to use INITRD=yes without
AGENT_INIT=yes.

Fixes: #3604

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>