### PR TITLE
k8s: Use libpod instead of footloose

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -7,7 +7,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: my-container
-      image: quay.io/footloose/ubuntu18.04
+      image: quay.io/libpod/ubuntu:latest
       command: ["tail", "-f", "/dev/null"]
       volumeDevices:
         - devicePath: DEVICE_PATH


### PR DESCRIPTION
In pod-block-pv k8s test, use libpod latest (has no 18.04 tag) instead
of footloose 18.04 for quay.io registry organization, because footloose
has no s390x image.

Fixes: #3606

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>