### PR TITLE
ci: skips k8s tests on ppc64le

### DIFF
--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -29,3 +29,8 @@ docker:
   Context:
     - run container exceeding memory constraints
   It:
+
+kubernetes:
+  - k8s-block-volume
+  - k8s-oom
+  - k8s-memory


### PR DESCRIPTION
Currently these tests are failing on ppc64le,
skip them for now.

Fixes: #3608

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>