### PR TITLE
fio-k8s: Lower the go dependency to 1.15

### DIFF
--- a/metrics/storage/fio-k8s/cmd/fiotest/go.mod
+++ b/metrics/storage/fio-k8s/cmd/fiotest/go.mod
@@ -1,6 +1,6 @@
 module github.com/tests/metrics/storage/fio-k8s
 
-go 1.16
+go 1.15
 
 require (
 	github.com/kata-containers/tests/metrics/env v0.0.0-00010101000000-000000000000

--- a/metrics/storage/fio-k8s/pkg/k8s/go.mod
+++ b/metrics/storage/fio-k8s/pkg/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/kata-containers/tests/metrics/k8s
 
-go 1.16
+go 1.15
 
 replace github.com/kata-containers/tests/metrics/exec => ../exec
 


### PR DESCRIPTION
Fixes: #3619 

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>