### PR TITLE
integration/cri-o: do not edit ctr.bats

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -68,10 +68,10 @@ IFS=''
 
 # Skip CRI-O tests that currently are not working
 pushd "${crio_repository_path}/test/"
-cp $GOPATH/src/${crio_repository}/test/ctr.bats $GOPATH/src/${crio_repository}/test/ctr_kata_integration_tests.bats
+cp ctr.bats ctr_kata_integration_tests.bats
 for i in "${skipCRIOTests[@]}"
 do
-	sed -i '/'${i}'/a skip \"This is not working\"' "$GOPATH/src/${crio_repository}/test/ctr_kata_integration_tests.bats"
+	sed -i '/'${i}'/a skip \"This is not working\"' "ctr_kata_integration_tests.bats"
 done
 
 IFS=$OLD_IFS

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -68,9 +68,10 @@ IFS=''
 
 # Skip CRI-O tests that currently are not working
 pushd "${crio_repository_path}/test/"
+cp $GOPATH/src/${crio_repository}/test/ctr.bats $GOPATH/src/${crio_repository}/test/ctr_kata_integration_tests.bats
 for i in "${skipCRIOTests[@]}"
 do
-	sed -i '/'${i}'/a skip \"This is not working\"' "$GOPATH/src/${crio_repository}/test/ctr.bats"
+	sed -i '/'${i}'/a skip \"This is not working\"' "$GOPATH/src/${crio_repository}/test/ctr_kata_integration_tests.bats"
 done
 
 IFS=$OLD_IFS
@@ -86,6 +87,7 @@ if systemctl is-active --quiet docker; then
 fi
 
 echo "Running cri-o tests with runtime: $CONTAINER_RUNTIME"
-./test_runner.sh ctr.bats
+./test_runner.sh ctr_kata_integration_tests.bats
+rm ctr_kata_integration_tests.bats
 
 popd


### PR DESCRIPTION
Make a copy of ctr.bats before editing it.
This prevents multiple lines from being added to the file in cri-o sources.
It also makes it possible to change the list of skipped tests and take the
change into account.

Fixes: #3622

Signed-off-by: Julien Ropé <jrope@redhat.com>