### PR TITLE
CI: Show HTTP error code in static check script

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -559,7 +559,7 @@ check_url()
 
 		if ! echo "$status" | grep -qE "^(1[0-9][0-9]|2[0-9][0-9]|3[0-9][0-9]|405)"; then
 			echo "$url" >> "$invalid_file"
-			die "found HTTP error status codes for URL $url"
+			die "found HTTP error status codes for URL $url ($status)"
 		fi
 	done
 }


### PR DESCRIPTION
Display the HTTP error code if the static check script fails to verify a URL.

Fixes: #3624.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>