### PR TITLE
ci: Skip memory-related tests on s390x

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -3,20 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-test:
-  - functional
-  - docker
-  - network
-  - ramdisk
-  - docker-stability
-  - entropy
-
-docker:
-  Describe:
-    - CPUs and CPU set
-    - Hotplug memory
-    - memory constraints
-  Context:
-    - remove bind-mount source before container exits
-    - run container exceeding memory constraints
-  It:
+kubernetes:
+  - k8s-oom
+  - k8s-memory


### PR DESCRIPTION
to pave the way for a basic s390x CI. They depend on
- https://github.com/kata-containers/kata-containers/issues/1412
- Replacing docker.io/containerstack/alpine-stress with an image that is
  also built for s390x -- probably need local build, which requires
  Podman for CRI-O, which isn't enabled yet.

Also remove obsolete skippings

Fixes: #3626

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>