### PR TITLE
tests: Strengthen the vcpus integration tests

### DIFF
--- a/integration/vcpus/default_vcpus_test.sh
+++ b/integration/vcpus/default_vcpus_test.sh
@@ -41,13 +41,13 @@ function test_ctr_with_vcpus() {
 	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	sudo ctr image pull "${IMAGE}"
 	[ $? != 0 ] && die "Unable to get image $IMAGE"
-	sudo ctr run --runtime="${CONTAINERD_RUNTIME}" -d "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
+	sudo ctr run --runtime="${CONTAINERD_RUNTIME}" -d "${IMAGE}" \
+		"${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}" || die "Test failed"
 }
 
 function teardown() {
+	echo "Running teardown"
 	sudo sed -i "s/${name} = 4/${name} = 1/g" "${RUNTIME_CONFIG_PATH}"
-	sudo ctr tasks rm -f $(sudo ctr task list -q)
-	sudo ctr c rm $(sudo ctr c list -q)
 	clean_env_ctr
 	check_processes
 }


### PR DESCRIPTION
Improved the vcpus integration tests:

 * The clean_env_ctr() is going to clean up all tasks and containers
   so it doesn't need to try the same on teardown();
 * More verbose. Print if the test failed and when entered teardown();

Fixes #3283

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>