### PR TITLE
containerd: fix the issue of getting cri version

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -80,6 +80,9 @@ if ip a show "$cni_interface"; then
 fi
 
 echo "Start ${cri_runtime} service"
+# stop containerd first and then restart it
+info "Stop containerd service"
+systemctl is-active --quiet containerd && sudo systemctl stop containerd
 sudo systemctl enable --now ${cri_runtime}
 max_cri_socket_check=5
 wait_time_cri_socket_check=5


### PR DESCRIPTION
Since 1.5.0, containerd had embedded cri and there's no
need to get the cri version.

Depends-on: github.com/kata-containers/kata-containers#2040

Fixes:#3630

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>