### PR TITLE
integration: Fix off-by-one in KSM comparison

### DIFF
--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -66,7 +66,7 @@ function run_with_ksm() {
 
 	# Compared the pages merged between the containers
 	echo "Comparing merged pages between containers"
-	[ "$second_pages_merged" -gt "$first_pages_merged" ] || die "The merged pages on the second container is less than the first container"
+	[ "$second_pages_merged" -ge "$first_pages_merged" ] || die "The merged pages on the second container is less than the first container"
 
 }
 


### PR DESCRIPTION
Fails when pages merged on second container is equal to first, which
should still be a pass

Fixes: #3631

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>