### PR TITLE
ci: Minor script fixes

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -45,7 +45,7 @@ install_from_source() {
 		cd "${GOPATH}/src/${cri_repository}" >>/dev/null
 		git fetch
 		git checkout "${cri_containerd_version}"
-		make BUILDTAGS="${BUILD_TAGS:-}" release
+		make BUILD_TAGS="${BUILDTAGS:-}" release
 		local commit
 		commit=$(git rev-parse --short HEAD)
 		tarball_name="cri-containerd-${commit}.${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -60,7 +60,7 @@ declare -A minimal_packages=( \
 
 declare -A packages=( \
 	[kata_containers_dependencies]="libtool libtool-ltdl-devel device-mapper-persistent-data lvm2 libtool-ltdl" \
-	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel libpmem-devel" \
+	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel libpmem-devel ninja-build" \
 	[kernel_dependencies]="elfutils-libelf-devel flex pkgconfig patch" \
 	[crio_dependencies]="glibc-static libseccomp-devel libassuan-devel libgpg-error-devel util-linux libselinux-devel" \
 	[bison_binary]="bison" \

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -46,7 +46,7 @@ if [ "$(uname -m)" == "ppc64le" ] || [ "$(uname -m)" == "s390x" ]; then
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
-	packages[kernel_dependencies]+=" openssl-devel"
+	packages[kernel_dependencies]+=" openssl openssl-devel"
 fi
 
 main()

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -56,7 +56,7 @@ if [ "$(uname -m)" == "ppc64le" ] || [ "$(uname -m)" == "s390x" ]; then
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
-	packages[kernel_dependencies]+=" openssl-devel"
+	packages[kernel_dependencies]+=" openssl openssl-devel"
 fi
 
 main()

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -27,7 +27,7 @@ declare -A minimal_packages=( \
 )
 
 declare -A packages=( \
-	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils" \
+	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils curl" \
 	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev ninja-build" \
 	[kernel_dependencies]="libelf-dev flex" \
 	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev thin-provisioning-tools" \
@@ -45,7 +45,7 @@ declare -A packages=( \
 )
 
 if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == "1" ]; then
-	packages[cri_containerd_dependencies]+=" libbtrfs-dev"
+	packages[cri-containerd_dependencies]+=" libbtrfs-dev"
 fi
 
 if [ "$(uname -m)" == "x86_64" ] && [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 18.04" | bc -q)" == "1" ]; then
@@ -53,7 +53,7 @@ if [ "$(uname -m)" == "x86_64" ] && [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VE
 fi
 
 if [ "$(uname -m)" == "s390x" ]; then
-	packages[kernel_depencencies]+=" libssl-dev"
+	packages[kernel_dependencies]+=" libssl-dev"
 fi
 
 rust_agent_pkgs=()


### PR DESCRIPTION
- CRI-containerd installation needs our $BUILDTAGS for its $BUILD_TAGS
  env -- not the other way around...
- Install ninja-build for QEMU on CentOS
- Install openssl non-`-devel` on s390x Fedora-likes for generating
  X.509 certificates during kernel build
- Install curl as general dependency on Ubuntu (used for checking
  versions)
- Fix non-fatal dependency typos in Ubuntu setup

Fixes: #3633

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>