### PR TITLE
ci: Use Podman on Fedora-likes

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -10,7 +10,9 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+cidir=$(dirname "$0")
 source "/etc/os-release" || source "/usr/lib/os-release"
+source "${cidir}/lib.sh"
 
 CI_JOB=${CI_JOB:-}
 ghprbPullId=${ghprbPullId:-}

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -49,6 +49,7 @@ if [ "$(uname -m)" == "s390x" ] && grep -Eq "\<(fedora|suse)\>" /etc/os-release 
 	export CC=gcc
 fi
 
+grep -Eq "\<fedora\>" /etc/os-release 2> /dev/null && export USE_PODMAN=true
 
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
@@ -303,8 +304,10 @@ gen_clean_arch() {
 
 	info "kill stale process"
 	kill_stale_process
-	info "delete stale docker resource under ${stale_docker_dir_union[@]}"
-	delete_stale_docker_resource
+	if [ -z "${USE_PODMAN}" ]; then
+		info "delete stale docker resource under ${stale_docker_dir_union[@]}"
+		delete_stale_docker_resource
+	fi
 	info "delete stale kata resource under ${stale_kata_dir_union[@]}"
 	delete_stale_kata_resource
 	info "Remove installed kata packages"

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -41,7 +41,7 @@ echo "priority=1" | sudo tee -a "$repo_file"
 sudo -E dnf -y clean all
 
 echo "Update repositories"
-sudo -E dnf -y update
+sudo -E dnf -y --nobest update
 
 echo "Enable PowerTools repository"
 sudo -E dnf install -y 'dnf-command(config-manager)'

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.53
+midval = 0.62
 minpercent = 5.0
 maxpercent = 5.0
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -164,7 +164,7 @@ check_daemon_setup() {
 	create_containerd_config "runc"
 
 	#restart docker service as TestImageLoad depends on it
-	restart_docker_service
+	[ -z "${USE_PODMAN:-}" ] && restart_docker_service
 
 	sudo -E PATH="${PATH}:/usr/local/bin" \
 		REPORT_DIR="${REPORT_DIR}" \

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -19,10 +19,6 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 # Using trap to ensure the cleanup occurs when the script exists.
 trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 
-# Docker is required to initialize kubeadm, even if we are
-# using cri-o as the runtime.
-systemctl is-active --quiet docker || sudo systemctl start docker
-
 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-block-volume.bats" \
 	"k8s-configmap.bats" \


### PR DESCRIPTION
since it's more aligned with CRI-O, e.g. for importing images.

- A comment in the CRI tests claims that their TestImageLoad test
  depends on it, but my experiments don't confirm this.
- Likewise, kubeadm depends on Docker according to a comment, but I
  can't reproduce that.

Fixes: #3635
Depended-on: github.com/kata-containers/kata-containers#2068
I-once-thought-it-depended-on: github.com/kata-containers/tests#3658
But-it-really-Depends-on: github.com/kata-containers/kata-containers#2150

Do you think that any of these are a blocker?

- ~Podman is incompatible with osbuilder Ubuntu in that it can't be debootstrapped, apt errors about setting up packages.~ fixed with an Ubuntu 20.04 guest
- The metrics tests use Docker a lot, but those are configured to CRI-containerd and we don't run them on Fedora-likes anyways.
- The packaging scripts also use Docker.

~Starting out as draft~ adding do-not-merge
because there are some open questions.