### PR TITLE
vfio: Delete test cases for machine type of pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,6 @@ vfio:
 #	Skip: Issue: https://github.com/kata-containers/kata-containers/issues/1488
 #	bash -f functional/vfio/run.sh -s false -p clh -i image
 #	bash -f functional/vfio/run.sh -s true -p clh -i image
-	bash -f functional/vfio/run.sh -s false -p qemu -m pc -i image
-	bash -f functional/vfio/run.sh -s true -p qemu -m pc -i image
 	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i image
 	bash -f functional/vfio/run.sh -s true -p qemu -m q35 -i image
 


### PR DESCRIPTION
The machine type of pc has been deleted, so delete test cases
for pc machine type for vfio

Fixes: #3640

Signed-off-by: bin liub <bin@hyper.sh>