### PR TITLE
ci: Add support for forked repo in ci scripts

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -12,7 +12,7 @@ set -o errtrace
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
-rust_agent_repo="github.com/kata-containers/kata-containers"
+rust_agent_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 arch=$("${cidir}"/kata-arch.sh -d)
 PREFIX="${PREFIX:-/usr}"
 DESTDIR="${DESTDIR:-/}"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -14,7 +14,7 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
-KATA_REPO="github.com/kata-containers/kata-containers"
+KATA_REPO=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
 MACHINETYPE="${MACHINETYPE:-q35}"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -12,7 +12,7 @@ export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
-export kata_repo="github.com/kata-containers/kata-containers"
+export kata_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
 export kata_default_branch="${kata_default_branch:-main}"
 


### PR DESCRIPTION
Update kata-containers repo constants so they can be set as shell
variables if required.

Fixes #3648

Signed-off-by: stevenhorsman <steven@uk.ibm.com>