### PR TITLE
integration: fix containerd service fail to stop randomly issue

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -318,13 +318,21 @@ TestContainerMemoryUpdate() {
 	testContainerStop
 }
 
+# k8s may restart docker which will impact on containerd stop
+stop_containerd() {
+	local tmp=$(pgrep kubelet || true)
+	[ -n "$tmp" ] && sudo kubeadm reset -f
+
+	sudo systemctl stop containerd
+}
+
 main() {
 
 	info "Stop crio service"
 	systemctl is-active --quiet crio && sudo systemctl stop crio
 
 	info "Stop containerd service"
-	systemctl is-active --quiet containerd && sudo systemctl stop containerd
+	systemctl is-active --quiet containerd && stop_containerd
 
 	# Configure enviroment if running in CI
 	ci_config


### PR DESCRIPTION
k8s impact on containerd stop

containerd may fail to stop when k8s is running, as k8s may restart
docker or containerd meanwhile containerd stop. To fix is, k8s should be
killed before containerd stop.

Fixes: #3644
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>