### PR TITLE
ci: Build the rootfs accordingly to the used distro

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -19,7 +19,7 @@ TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 echo "Install Kata Containers Image"
 echo "rust image is default for Kata 2.0"
-"${cidir}/install_kata_image.sh" "${tag}"
+osbuilder_distro="$ID" "${cidir}/install_kata_image.sh" "${tag}"
 
 echo "Install Kata Containers Kernel"
 "${cidir}/install_kata_kernel.sh" "${tag}"


### PR DESCRIPTION
Instead of always using "ubuntu" as rootfs, let's start building the
rootfs matching the distro being used in the CI.

This is a very first step in order to improve coverage on the what we
ship, and it'll increase the coverage from only ubuntu to ubuntu,
debian, centos, and fedora.

Related: #3657

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>