### PR TITLE
tests: Set --default-toolchain when installing rustup

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -19,13 +19,19 @@ if [ -z "${version}" ]; then
 	version=$(get_version "languages.rust.meta.newest-version")
 fi
 
+echo "Install rust ${version}"
+
 if ! command -v rustup > /dev/null; then
-	curl https://sh.rustup.rs -sSf | sh -s -- -y
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${version}
 fi
 
 export PATH="${PATH}:${HOME}/.cargo/bin"
 
-echo "Install rust"
+## Still try to install the target version of toolchain,
+## in case that the rustup has been installed but
+## with a different version toolchain.
+## Even though the target version toolchain has been installed,
+## this command will not take too long to run.
 rustup toolchain install ${version}
 rustup default ${version}
 if [ "${rustarch}" == "powerpc64le" ] || [ "${rustarch}" == "s390x" ] ; then


### PR DESCRIPTION
Set `--default-toolchain` option can install the desired version
of rust and avoid installing two versions of rust toolchain.

Fixes: #3672

Signed-off-by: bin liu <bin@hyper.sh>