### PR TITLE
containerd: disable memory update test on s390x

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -268,7 +268,7 @@ TestKilledVmmCleanup() {
 }
 
 TestContainerMemoryUpdate() {
-	if [[ "${KATA_HYPERVISOR}" != "qemu" ]] || [[ "${ARCH}" == "ppc64le" ]]; then
+	if [[ "${KATA_HYPERVISOR}" != "qemu" ]] || [[ "${ARCH}" == "ppc64le" ]] || [[ "${ARCH}" == "s390x" ]]; then
 		return
 	fi
 


### PR DESCRIPTION
As discussed in
https://github.com/kata-containers/kata-containers/issues/1412, memory
hotplugging is not possible on s390x (until virtio-mem lands).
Therefore, disable the memory update test, as on ppc64le.

Fixes: #3674
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>