### PR TITLE
integration/k8s: Build custom stress image

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -61,6 +61,20 @@ jenkins_url="http://jenkins.katacontainers.io"
 # Path where cached artifacts are found.
 cached_artifacts_path="lastSuccessfulBuild/artifact/artifacts"
 
+# Info for running local registry
+registry_port="${REGISTRY_PORT:-5000}"
+registry_name="kata-registry"
+container_engine="${USE_PODMAN:+podman}"
+container_engine="${container_engine:-docker}"
+# We cannot use Podman's and Kubernetes' CNI at the same time, but Podman uses k8s' namespace
+if [ "${container_engine}" == "podman" ]; then
+	stress_image="localhost/stress-kata:latest"
+	stress_image_pull_policy="Never"
+else
+	stress_image="localhost:${registry_port}/stress-kata:latest"
+	stress_image_pull_policy="Always"
+fi
+
 # Clone repo only if $kata_repo_dir is empty
 # Otherwise, we assume $kata_repo is cloned and in correct branch, e.g. a PR or local change
 clone_kata_repo() {

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -7,6 +7,7 @@
 # This script is used to reset the kubernetes cluster
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
 cri_runtime="${CRI_RUNTIME:-crio}"
@@ -38,6 +39,8 @@ BAREMETAL="${BAREMETAL:-false}"
 if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
 	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 fi
+
+sudo -E "${container_engine}" rm -f "${registry_name}" || true
 
 # Check no kata processes are left behind after reseting kubernetes
 check_processes

--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -14,14 +14,21 @@ setup() {
 	get_pod_config_dir
 }
 
+setup_yaml() {
+	sed \
+		-e "s/\${memory_size}/${memory_limit_size}/" \
+		-e "s/\${memory_allocated}/${allocated_size}/" \
+		-e "s|\${stress_image}|${stress_image}|" \
+		-e "s/\${stress_image_pull_policy}/${stress_image_pull_policy}/" \
+		"${pod_config_dir}/pod-memory-limit.yaml"
+}
+
+
 @test "Exceeding memory constraints" {
 	memory_limit_size="50Mi"
 	allocated_size="250M"
 	# Create test .yaml
-        sed \
-            -e "s/\${memory_size}/${memory_limit_size}/" \
-            -e "s/\${memory_allocated}/${allocated_size}/" \
-            "${pod_config_dir}/pod-memory-limit.yaml" > "${pod_config_dir}/test_exceed_memory.yaml"
+	setup_yaml > "${pod_config_dir}/test_exceed_memory.yaml"
 
 	# Create the pod exceeding memory constraints
 	run kubectl create -f "${pod_config_dir}/test_exceed_memory.yaml"
@@ -34,10 +41,7 @@ setup() {
 	memory_limit_size="600Mi"
 	allocated_size="150M"
 	# Create test .yaml
-        sed \
-            -e "s/\${memory_size}/${memory_limit_size}/" \
-            -e "s/\${memory_allocated}/${allocated_size}/" \
-            "${pod_config_dir}/pod-memory-limit.yaml" > "${pod_config_dir}/test_within_memory.yaml"
+	setup_yaml > "${pod_config_dir}/test_within_memory.yaml"
 
 	# Create the pod within memory constraints
 	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"

--- a/integration/kubernetes/k8s-oom.bats
+++ b/integration/kubernetes/k8s-oom.bats
@@ -16,8 +16,14 @@ setup() {
 
 @test "Test OOM events for pods" {
 
+	# Create test .yaml
+	sed \
+		-e "s|\${stress_image}|${stress_image}|" \
+		-e "s/\${stress_image_pull_policy}/${stress_image_pull_policy}/" \
+		"${pod_config_dir}/pod-oom.yaml" > "${pod_config_dir}/test_pod_oom.yaml"
+
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-oom.yaml"
+	kubectl create -f "${pod_config_dir}/test_pod_oom.yaml"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -26,6 +32,8 @@ setup() {
 	cmd="kubectl get pods "$pod_name" -o yaml | yq r - 'status.containerStatuses[0].state.terminated.reason' | grep OOMKilled"
 
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+	rm -f "${pod_config_dir}/test_pod_oom.yaml"
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -12,7 +12,8 @@ spec:
   runtimeClassName: kata
   containers:
   - name: memory-test-ctr
-    image: containerstack/alpine-stress:latest
+    image: ${stress_image}
+    imagePullPolicy: ${stress_image_pull_policy}
     resources:
       limits:
         memory: "${memory_size}"

--- a/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
@@ -13,8 +13,8 @@ spec:
   runtimeClassName: kata
   restartPolicy: Never
   containers:
-    - image: containerstack/alpine-stress:latest
-      imagePullPolicy: Always
+    - image: ${stress_image}
+      imagePullPolicy: ${stress_image_pull_policy}
       name: oom-test
       command: ["/bin/sh"]
       args: ["-c", "sleep 2; stress --vm 2 --vm-bytes 400M --timeout 30s"]

--- a/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
+++ b/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2021 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM quay.io/libpod/ubuntu
+RUN apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get -y install stress


### PR DESCRIPTION
containerstack/alpine-stress is only built for x86_64 and I cannot find
a substitute. Let's build the image ourselves to have a `stress`
container available on all architectures.

Fixes: #3678
Depends-on: github.com/kata-containers/tests#3636
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>