### PR TITLE
ci: pmem: containerd: allow image pulling from localhost registry

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -29,4 +29,6 @@ cat << EOT | sudo tee /etc/containerd/config.toml
         [plugins.cri.containerd.runtimes.kata]
            runtime_type = "io.containerd.kata.v2"
            privileged_without_host_devices = true
+    [plugins.cri.registry.mirrors."localhost:5000"]
+      endpoint = ["http://localhost:5000"]
 EOT


### PR DESCRIPTION
pmem test requires image pulling from localhost:5000.
Configures containerd correctly to allow image pulling from a local
registry.

fixes #3680

Signed-off-by: Julio Montes <julio.montes@intel.com>