### PR TITLE
DEBUG: integration/stability: Ignore running hypervisor processes + metrics: Update metrics ksm value

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 47667.0
+midval = 52305.0
 minpercent = 5.0
 maxpercent = 5.0
 

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -39,8 +39,8 @@ if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
 fi
 
-# Check no kata processes are left behind after reseting kubernetes
-check_processes
-
 # Checks that pods were not left
 check_pods
+
+# Check no kata processes are left behind after reseting kubernetes
+check_processes


### PR DESCRIPTION
This PR has https://github.com/kata-containers/tests/pull/3668 and https://github.com/kata-containers/tests/pull/3660 together, rebased atop of the current main.

This should help to unblock the CI.