### PR TITLE
tests: get deploy/pod details for debugging

### DIFF
--- a/integration/kubernetes/nginx.bats
+++ b/integration/kubernetes/nginx.bats
@@ -43,6 +43,8 @@ setup() {
 teardown() {
 	# Debugging information
 	kubectl describe "pod/$busybox_pod"
+	kubectl get "pod/$busybox_pod" -o yaml
+	kubectl get deployment/${deployment} -o yaml
 
 	rm -f "${pod_config_dir}/test-${deployment}.yaml"
 	kubectl delete deployment "$deployment"


### PR DESCRIPTION
For nginx connectivity test, get deploy/pod
detail info at the end for debugging.

Fixes: #3689

Signed-off-by: bin <bin@hyper.sh>