### PR TITLE
tests: fix wrong runtime name

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -9,7 +9,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly kata_runtime_path=$(command -v kata-runtime)
 readonly runc_path=$(command -v runc)
 
 sudo mkdir -p /etc/containerd/

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-export KATA_RUNTIME=${KATA_RUNTIME:-kata-runtime}
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
@@ -114,24 +113,6 @@ function build() {
 	version="${3:-"HEAD"}"
 
 	build_version "${github_project}" "${make_target}" "${version}"
-}
-
-function build_and_install() {
-	github_project="$1"
-	make_target="$2"
-	test_not_gopath_set="$3"
-	tag="$4"
-
-	build "${github_project}" "${make_target}" "${tag}"
-	pushd "${GOPATH}/src/${github_project}"
-	if [ "$test_not_gopath_set" = "true" ]; then
-		info "Installing ${github_project} in No GO command or GOPATH not set mode"
-		sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
-		[ $? -ne 0 ] && die "Fail to install ${github_project} in No GO command or GOPATH not set mode"
-	fi
-	info "Installing ${github_project}"
-	sudo -E PATH="$PATH" KATA_RUNTIME="${KATA_RUNTIME}" make install
-	popd
 }
 
 function get_dep_from_yaml_db(){

--- a/integration/stability/agent_stability_test.sh
+++ b/integration/stability/agent_stability_test.sh
@@ -30,7 +30,6 @@ end_time=$((start_time+timeout))
 function setup {
 	sudo systemctl restart containerd
 	clean_env_ctr
-	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	sudo ctr image pull $IMAGE
 	sudo ctr run --runtime=$CONTAINERD_RUNTIME -d $IMAGE $CONTAINER_NAME sh -c $PAYLOAD_ARGS
 }

--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -23,7 +23,6 @@ setup()  {
 	extract_kata_env
 	clean_env_ctr
 	HYPERVISOR_NAME=$(basename ${HYPERVISOR_PATH})
-	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	sudo ctr image pull $IMAGE
 	[ $? != 0 ] && die "Unable to get image $IMAGE"
 

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -57,16 +57,11 @@ trap 'handle_error $LINENO' ERR
 # want in reality, but this function knows the names of the default
 # and recommended Kata docker runtime install names.
 is_a_kata_runtime(){
-	case "$1" in
-	"kata-runtime") ;&	# fallthrough
-	"kata-qemu") ;&		# fallthrough
-	"kata-fc")
+	if [ "$1" = "containerd-shim-kata-v2" ]; then
 		echo "1"
-		return
-		;;
-	esac
-
-	echo "0"
+	else
+		echo "0"
+	fi
 }
 
 
@@ -97,7 +92,6 @@ extract_kata_env(){
 	VIRTIOFSD_PATH=$(kata-runtime kata-env --json | jq -r .Hypervisor.VirtioFSDaemon)
 
 	INITRD_PATH=$(kata-runtime kata-env --json | jq -r .Initrd.Path)
-	NETMON_PATH=$(kata-runtime kata-env --json | jq -r .Netmon.Path)
 }
 
 # Checks that processes are not running

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -16,7 +16,9 @@ source /etc/os-release || source /usr/lib/os-release
 CTR_EXE="${CTR_EXE:-ctr}"
 DOCKER_EXE="${DOCKER_EXE:-docker}"
 CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.run.kata.v2}"
-RUNTIME="${RUNTIME:-kata-runtime}"
+RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
+KATA_RUNTIME_NAME="containerd-shim-kata-v2"
+CONTAINERD_RUNTIME="io.containerd.kata.v2"
 
 KSM_BASE="/sys/kernel/mm/ksm"
 KSM_ENABLE_FILE="${KSM_BASE}/run"
@@ -187,7 +189,7 @@ show_system_ctr_state() {
 	echo " --Check tasks--"
 	sudo ctr task list
 
-	local processes="containerd-shim-kata-v2 kata-runtime"
+	local processes="containerd-shim-kata-v2"
 
 	for p in ${processes}; do
 		echo " --pgrep ${p}--"


### PR DESCRIPTION
Some code in tests is using kata-runtime as the
runtime (process) name, which leads to some tests
have been skipped.

And netmon test should be deleted too.

Fixes: #3691

Signed-off-by: bin <bin@hyper.sh>