### PR TITLE
ci: Temporarily disable govet checks

### DIFF
--- a/.ci/.golangci.yml
+++ b/.ci/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - gocyclo
     - gofmt
     - gosimple
-    - govet
     - ineffassign
     - misspell
     - staticcheck
@@ -33,6 +32,3 @@ linters-settings:
     min_complexity: 15
   unused:
     check-exported: true
-  govet:
-    enable:
-      - fieldalignment


### PR DESCRIPTION
Let's hammer this issue down by temporarily disabling govet checks, as
it does affect a whole lot of code that's already part of our codebase
and, for some reason, it just started being opinionated now.

The proposal here is, disable it ... and do a somewhat taskforce to
re-enable this, skipping the checks wherever it makes sense to be
skipped (our tests, for instance).

Fixes: https://github.com/kata-containers/tests/issues/3694

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>


Note:
The kind of issues govet will expose are all related to field alignment
in structs, which we could do better indeed.

Here's one example of the exposed issues:
```
INFO: Running golangci-lint on /home/runner/work/kata-containers/kata-containers/src/github.com/kata-containers/kata-containers/src/runtime/cli
kata-env.go:74:18: fieldalignment: struct with 128 pointer bytes could be 112 (govet)
type RuntimeInfo struct {
^
kata-env.go:86:18: fieldalignment: struct with 48 pointer bytes could be 24 (govet)
type VersionInfo struct {
^
kata-env.go:117:16: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type AgentInfo struct {
^
```