### PR TITLE
ci/setup_env_centos: enable CentOS Stream support

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -29,7 +29,8 @@ sudo -E dnf -y install epel-release
 # Enable priority to CentOS Base repo in order to
 # avoid perl updating issues
 for repo_file_path in /etc/yum.repos.d/CentOS-Base.repo \
-	/etc/yum.repos.d/CentOS-Linux-BaseOS.repo; do
+	/etc/yum.repos.d/CentOS-Linux-BaseOS.repo \
+	/etc/yum.repos.d/CentOS-Stream-BaseOS.repo; do
 	if [ -f "$repo_file_path" ]; then
 		repo_file="$repo_file_path"
 		break


### PR DESCRIPTION
The CentOS Stream base repository file name is different from the one
shipped with CentOS. This causes the script to fail.
Just add it. Nothing more needed to be CentOS Stream ready.

Fixes #3695

Signed-off-by: Francesco Giudici <fgiudici@redhat.com>