### PR TITLE
ci: s/containerd.io/containerd/ in cleanup

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -314,8 +314,8 @@ gen_clean_arch() {
 	info "Remove installed kubernetes packages and configuration"
 	if [ "$ID" == ubuntu ]; then
 		sudo rm -rf /etc/systemd/system/kubelet.service.d
-		sudo apt-get remove kubeadm kubelet kubectl docker.io docker-ce containerd.io docker-ce-cli -y
-		sudo apt autoremove -y
+		sudo apt-get autoremove -y kubeadm kubelet kubectl \
+			$(dpkg -l | awk '{print $2}' | grep -E '^(containerd(.\io)?|docker(\.io|-ce(-cli)?))$')
 	fi
 	# Remove existing CNI configurations and binaries.
 	sudo sh -c 'rm -rf /opt/cni/bin/*'


### PR DESCRIPTION
Clean up scripts uninstall `containerd.io` on Ubuntu when the package is
called `containerd`. This can lead to Docker failing to start because
containerd was not fully removed and systemd still remembers the
custom-installed unit file which points to `/usr/local`, as seen e.g. in
http://jenkins.katacontainers.io/job/kata-containers-2.0-ubuntu-s390x-PR/83
(although I can also reproduce this on x86?).

Fixes: #3705
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>