### PR TITLE
tests: do retry for running wget command in pod

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -52,7 +52,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-security-context.bats" \
 	"k8s-shared-volume.bats" \
 	"k8s-volume.bats" \
-	"nginx.bats" \
+	"k8s-nginx-connectivity.bats" \
 	"k8s-hugepages.bats")
 
 # we may need to skip a few test cases when running on non-x86_64 arch


### PR DESCRIPTION
Only run wget once may fail without retries.
The wget command in busybox image doesn't support
many options that used to control the retry, so here a
while-loop of shell is used.

And this commit also rename nginx.bats
to k8s-nginx-connectivity.bats to follow the naming rule
with other files under the same directory.

Fixes: #3714

Signed-off-by: bin <bin@hyper.sh>