### PR TITLE
static-checks: Friendly messages when required commands aren't found

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -164,6 +164,8 @@ Parameters:
 Notes:
 
 - If no options are specified, all non-skipped tests will be run.
+- Some required tools may be installed in \$GOPATH/bin, so you should ensure
+  that it is in your \$PATH.
 
 Examples:
 
@@ -239,6 +241,9 @@ static_check_commits()
 	# for main branch
 	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
 
+	command -v checkcommits &>/dev/null || \
+		die 'checkcommits command not found. Ensure that "$GOPATH/bin" is in your $PATH.'
+
 	# Check the commits in the branch
 	{
 		checkcommits \
@@ -310,6 +315,8 @@ static_check_go_arch_specific()
 
 		info "Forcing ${linter} version ${linter_version}"
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "${linter_version}"
+		command -v $linter &>/dev/null || \
+			die "$linter command not found. Ensure that \"\$GOPATH/bin\" is in your \$PATH."
 	fi
 
 	local linter_args="run -c ${cidir}/.golangci.yml"
@@ -583,6 +590,9 @@ static_check_docs()
 
 		# xurls is very fussy about how it's built.
 		GO111MODULE=on go get "${url}@${version}"
+
+		command -v xurls &>/dev/null ||
+			die 'xurls not found. Ensure that "$GOPATH/bin" is in your $PATH'
 	fi
 
 	info "Checking documentation"
@@ -649,6 +659,9 @@ static_check_docs()
 	md_docs_to_check="$all_docs"
 
 	(cd "${tests_repo_dir}" && make check-markdown)
+
+	command -v kata-check-markdown &>/dev/null || \
+		die 'kata-check-markdown command not found. Ensure that "$GOPATH/bin" is in your $PATH.'
 
 	for doc in $md_docs_to_check
 	do

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -232,6 +232,16 @@ pkg_to_path()
 	go list -f '{{.Dir}}' "$pkg"
 }
 
+# Check that chronic is installed, otherwise die.
+need_chronic() {
+	local first_word
+	[ -z "$chronic" ] && return
+	first_word="${chronic%% *}"
+	command -v chronic &>/dev/null || \
+		die "chronic command not found. You must have it installed to run this check." \
+		"Usually it is distributed with the 'moreutils' package of your Linux distribution."
+}
+
 static_check_commits()
 {
 	# Since this script is called from another repositories directory,
@@ -964,6 +974,8 @@ static_check_xml()
 	local all_xml
 	local files
 
+	need_chronic
+
 	all_xml=$(git ls-files "*.xml" | grep -Ev "/(vendor|grpc-rs|target)/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
@@ -1016,6 +1028,8 @@ static_check_shell()
 	local all_scripts
 	local scripts
 
+	need_chronic
+
 	all_scripts=$(git ls-files "*.sh" "*.bash" | grep -Ev "/(vendor|grpc-rs|target)/" | sort || true)
 
 	if [ "$specific_branch" = "true" ]
@@ -1052,6 +1066,8 @@ static_check_json()
 {
 	local all_json
 	local json_files
+
+	need_chronic
 
 	all_json=$(git ls-files "*.json" | grep -Ev "/(vendor|grpc-rs|target)/" | sort || true)
 

--- a/cmd/github-labels/github-labels.sh
+++ b/cmd/github-labels/github-labels.sh
@@ -28,6 +28,14 @@ typeset -r master_labels_template="${self_dir}/${labels_template}"
 # default to a white background.
 typeset -r default_color="ffffff"
 
+need_yq() {
+	# install yq if not exist
+	${cidir}/install_yq.sh
+
+	command -v yq &>/dev/null || \
+		die 'yq command not found. Ensure "$GOPATH/bin" is in your $PATH.'
+}
+
 merge_yaml()
 {
 	local -r file1="$1"
@@ -38,9 +46,7 @@ merge_yaml()
 	[ -n "$file2" ] || die "need 2nd file"
 	[ -n "$out" ] || die "need output file"
 
-	# install yq if not exist
-	${cidir}/install_yq.sh
-
+	need_yq
 	yq merge "$file1" --append "$file2" > "$out"
 }
 
@@ -50,6 +56,7 @@ check_yaml()
 
 	[ -n "$file" ] || die "need file to check"
 
+	need_yq
 	yq read "$file" >/dev/null
 
 	[ -z "$(command -v yamllint)" ] && die "need yamllint installed"


### PR DESCRIPTION
The `.ci/static-checks.sh` script relies on external tools provided by the distro (e.g. `chronic` and `pandoc`) as well as on in-house ones which are built and installed under `$GOPATH/bin`. For a first comer to ensure that those tools are installed and searchable may not be obvious. So on this PR I tried to make the script more friendly by pointing out where those tools live (what they eat? :) and how to install some of them.   