### PR TITLE
stable 2.1 | Backports

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -29,4 +29,6 @@ cat << EOT | sudo tee /etc/containerd/config.toml
         [plugins.cri.containerd.runtimes.kata]
            runtime_type = "io.containerd.kata.v2"
            privileged_without_host_devices = true
+    [plugins.cri.registry.mirrors."localhost:5000"]
+      endpoint = ["http://localhost:5000"]
 EOT

--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -3,20 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-test:
-  - functional
-  - docker
-  - network
-  - ramdisk
-  - docker-stability
-  - entropy
-
-docker:
-  Describe:
-    - CPUs and CPU set
-    - Hotplug memory
-    - memory constraints
-  Context:
-    - remove bind-mount source before container exits
-    - run container exceeding memory constraints
-  It:
+kubernetes:
+  - k8s-oom
+  - k8s-memory

--- a/Unit-Test-Advice.md
+++ b/Unit-Test-Advice.md
@@ -273,7 +273,7 @@ mod tests {
 
 ## User running the test
 
-[Unit tests are run *twice*](https://github.com/kata-containers/tests/blob/master/.ci/go-test.sh):
+[Unit tests are run *twice*](https://github.com/kata-containers/tests/blob/main/.ci/go-test.sh):
 
 - as the current user
 - as the `root` user (if different to the current user)
@@ -291,7 +291,7 @@ Some repositories already provide utility functions to skip a test:
 
 The runtime repository has the most comprehensive set of skip abilities. See:
 
-- https://github.com/kata-containers/runtime/tree/master/pkg/katatestutils
+- https://github.com/kata-containers/kata-containers/tree/main/src/runtime/pkg/katatestutils
 
 ### running rust tests as different users
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -263,7 +263,7 @@ TestKilledVmmCleanup() {
 }
 
 TestContainerMemoryUpdate() {
-	if [[ "${KATA_HYPERVISOR}" != "qemu" ]]; then
+	if [[ "${KATA_HYPERVISOR}" != "qemu" ]] || [[ "${ARCH}" == "ppc64le" ]] || [[ "${ARCH}" == "s390x" ]]; then
 		return
 	fi
 

--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -72,7 +72,7 @@ function run_with_ksm() {
 
 	# Compared the pages merged between the containers
 	echo "Comparing merged pages between containers"
-	[ "$second_pages_merged" -gt "$first_pages_merged" ] || die "The merged pages on the second container is less than the first container"
+	[ "$second_pages_merged" -ge "$first_pages_merged" ] || die "The merged pages on the second container is less than the first container"
 
 }
 

--- a/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
+++ b/integration/kubernetes/e2e_conformance/skipped_tests_e2e.yaml
@@ -9,6 +9,8 @@
 containerd:
   - \[sig-api-machinery\] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
   - Daemon set \[Serial\] should rollback without unnecessary restarts
+  - \[sig-scheduling\] SchedulerPreemption \[Serial\] \[It\] validates lower priority pod preemption by critical pod \[Conformance\]
+  - \[sig-scheduling\] SchedulerPreemption \[Serial\] \[It\] validates basic preemption works \[Conformance\]
 
 crio:
   - Daemon set \[Serial\] should rollback without unnecessary restarts
@@ -17,4 +19,6 @@ hypervisor:
   cloud-hypervisor:
     - \[sig-apps]\ Daemon set \[Serial\] should rollback without unnecessary restarts \[Conformance\]
     - \[sig-api-machinery\] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator \[Conformance\]
+    - \[sig-scheduling\] SchedulerPreemption \[Serial\] \[It\] validates lower priority pod preemption by critical pod \[Conformance\]
+    - \[sig-scheduling\] SchedulerPreemption \[Serial\] \[It\] validates basic preemption works \[Conformance\]  
     - \[k8s.io\] Security Context When creating a pod with privileged should run the container as unprivileged when false \[LinuxOnly\] \[NodeConformance\]


### PR DESCRIPTION
eef0c6d91fb6cb40e1e29f4a62e2fbb4406af70a containerd: disable memory update test on s390x
2972ff149b55fe334a643030bd73bacb1872e7ed tests: Add more tests to skip in k8s e2e conformance for clh+containerd
231d4632182b67e8073f542d0682ec117ec1ccbb docs: Fix URLs in unit test doc
a2268f44178611059758857d7649f436fc2185ed integration: pmem: fix test
912087fa7e13c3b705ad5250cb10f3407dd16f3a integration: Fix off-by-one in KSM comparison
ebd42776e97a8d2de94bd4474bb38a3ca277c7b3 ci: Skip memory-related tests on s390x 