### PR TITLE
metrics: Update memory-footprint-ksm midval

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 53985.0
+midval = 44380.0
 minpercent = 10.0
 maxpercent = 10.0
 


### PR DESCRIPTION
Seems that using golang 1.16 has some impact in the memory-footprint-ksm
metrics.

Depends-on: github.com/kata-containers/kata-containers#2102

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>