### PR TITLE
ci: Add C++ compiler to build gperf

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -63,6 +63,7 @@ declare -A packages=( \
 	[qemu_dependencies]="libcap-devel libcap-ng-devel libattr-devel libcap-ng-devel librbd1-devel flex libfdt-devel libpmem-devel ninja-build" \
 	[kernel_dependencies]="elfutils-libelf-devel flex pkgconfig patch" \
 	[crio_dependencies]="glibc-static libseccomp-devel libassuan-devel libgpg-error-devel util-linux libselinux-devel" \
+	[gperf_dependencies]="gcc-c++" \
 	[bison_binary]="bison" \
 	[libgudev1-dev]="libgudev1-devel" \
 	[general_dependencies]="gpgme-devel glib2-devel glibc-devel bzip2 m4 gettext-devel automake autoconf pixman-devel coreutils" \

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -25,6 +25,7 @@ declare -A packages=( \
 	[qemu_dependencies]="libcap-devel libattr-devel libcap-ng-devel zlib-devel pixman-devel librbd-devel ninja-build" \
 	[kernel_dependencies]="elfutils-libelf-devel flex" \
 	[crio_dependencies]="btrfs-progs-devel device-mapper-devel glib2-devel glibc-devel glibc-static gpgme-devel libassuan-devel libseccomp-devel libselinux-devel" \
+	[gperf_dependencies]="gcc-c++" \
 	[bison_binary]="bison" \
 	[os_tree]="ostree-devel" \
 	[metrics_dependencies]="jq" \


### PR DESCRIPTION
This adds C++ compiler (`gcc-c++`) to centos and fedora in order to build gperf. 
The kata-agent will support seccomp, so libseccomp library is required and the gperf needed to build the library requires C++ compiler.

Fixes: #3669

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>