### PR TITLE
ci: enable govet

### DIFF
--- a/.ci/.golangci.yml
+++ b/.ci/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - gocyclo
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - misspell
     - staticcheck
@@ -32,3 +33,6 @@ linters-settings:
     min_complexity: 15
   unused:
     check-exported: true
+  govet:
+    enable:
+      - fieldalignment


### PR DESCRIPTION
structures in kata-containers repo have been aligned correctly
let's enable govet again.

Depends-on: github.com/kata-containers/kata-containers#2237

fixes #3726