### PR TITLE
Update SUSE support, especially for s390x

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -42,7 +42,7 @@ install_from_source() {
 		cd "${GOPATH}/src/${cri_containerd_repo}" >>/dev/null
 		git fetch
 		git checkout "${cri_containerd_tarball_version}"
-		make BUILDTAGS="${BUILD_TAGS:-}" cri-cni-release
+		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
 		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
 		sudo tar -xvf "./releases/${tarball_name}" -C /
 	)

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -31,8 +31,8 @@ cri_containerd_repo=$(get_version "externals.cri-containerd.url")
 cri_containerd_version=${cri_containerd_tarball_version#v}
 
 echo "Set up environment"
-if [ "$ID" == centos ] || [ "$ID" == rhel ]; then
-	# CentOS/RHEL: remove seccomp from runc build, no btrfs
+if [ "$ID" == centos ] || [ "$ID" == rhel ] || [ "$ID" == sles ]; then
+	# CentOS/RHEL/SLES: remove seccomp from runc build, no btrfs
 	export BUILDTAGS=${BUILDTAGS:-apparmor no_btrfs}
 fi
 

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -234,13 +234,13 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	;;
-"CRI_CONTAINERD_K8S")
+"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="yes"
+	[ "${CI_JOB}" == "CRI_CONTAINERD_K8S" ] && export KUBERNETES="yes"
 	;;
 "CRI_CONTAINERD_K8S_INITRD")
 	# This job tests initrd image + containerd + k8s

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -37,6 +37,12 @@ else
 	export GOPATH="${GOPATH:-$HOME/go}"
 fi
 
+if [ "$(uname -m)" == "s390x" ] && grep -Eq "\<(fedora|suse)\>" /etc/os-release 2> /dev/null; then
+	# see https://github.com/kata-containers/osbuilder/issues/217
+	export CC=gcc
+fi
+
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -21,12 +21,13 @@ case "${CI_JOB}" in
 		echo "INFO: Running pmem integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		;;
-	"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_INITRD")
+	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_INITRD")
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
+		[ "${CI_JOB}" != "CRI_CONTAINERD" ] && \
+			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		echo "INFO: Running vcpus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vcpus"
 		echo "INFO: Skipping pmem test: Issue: https://github.com/kata-containers/tests/issues/3223"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -152,11 +152,6 @@ main() {
 
 	[ "$setup_type" = "minimal" ] && info "finished minimal setup" && exit 0
 
-	if [ "$arch" == "s390x" ] && ([ "$ID" == "fedora" ] || [[ "${ID_LIKE:-}" =~ "fedora" ]]); then
-		# see https://github.com/kata-containers/osbuilder/issues/217
-		export CC=gcc
-	fi
-
 	install_docker
 	enable_nested_virtualization
 	install_kata

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -12,33 +12,26 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
 arch=$("${cidir}"/kata-arch.sh -d)
 
-echo "Add repo for perl-IPC-Run"
-perl_repo="https://download.opensuse.org/repositories/devel:languages:perl/SLE_${VERSION//-/_}/devel:languages:perl.repo"
-sudo -E zypper addrepo --no-gpgcheck ${perl_repo}
-sudo -E zypper refresh
+# Use at least openSUSE 15.3 on s390x because that is the first release
+major="${VERSION_ID%.*}"
+minor="${VERSION_ID#*.}"
+[ "${arch}" == "s390x" ] && ([[ "${major}" -le 12 ]] || ([ "${major}" == "15" ] && [ "${minor}" -le 2 ])) && \
+	VERSION_ID="15.3"
 
-echo "Add repo for myspell"
-leap_repo="http://download.opensuse.org/update/leap/15.0/oss/"
+leap_repo="http://download.opensuse.org/distribution/leap/${VERSION_ID}/repo/oss/"
 leap_repo_name="leap-oss"
+sudo -E zypper removerepo ${leap_repo} || true
 sudo -E zypper addrepo --no-gpgcheck ${leap_repo} ${leap_repo_name}
 sudo -E zypper refresh  ${leap_repo_name}
 
 echo "Install perl-IPC-Run"
 sudo -E zypper -n install perl-IPC-Run
 
-echo "Add repo for moreutils"
-moreutils_repo="https://download.opensuse.org/repositories/utilities/SLE_${VERSION//-/_}/utilities.repo"
-sudo -E zypper addrepo --no-gpgcheck ${moreutils_repo}
-sudo -E zypper refresh
-
-echo "Add repo for hunspell and pandoc packages"
-sudo -E SUSEConnect -p PackageHub/${VERSION_ID}/${arch}
-
 echo "Install chronic"
 sudo -E zypper -n install moreutils
 
 declare -A minimal_packages=( \
-	[spell-check]="hunspell myspell-en_GB myspell-en_US pandoc" \
+	[spell-check]="hunspell myspell-en_GB myspell-en_US" \
 	[xml_validator]="libxml2-tools" \
 	[yaml_validator_dependencies]="python-setuptools" \
 )
@@ -46,7 +39,7 @@ declare -A minimal_packages=( \
 declare -A packages=( \
 	[general_dependencies]="curl git patch"
 	[kata_containers_dependencies]="libtool automake autoconf bc libpixman-1-0-devel coreutils" \
-	[qemu_dependencies]="libcap-devel libattr1 libcap-ng-devel librbd-devel libpmem-devel" \
+	[qemu_dependencies]="libcap-devel libattr1 libcap-ng-devel librbd-devel ninja" \
 	[kernel_dependencies]="libelf-devel flex" \
 	[crio_dependencies]="libglib-2_0-0 libseccomp-devel libapparmor-devel libgpg-error-devel glibc-devel-static libgpgme-devel libassuan-devel glib2-devel glibc-devel util-linux" \
 	[bison_binary]="bison" \
@@ -57,6 +50,18 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 )
+
+if [ "${arch}" == "x86_64" ] || [ "${arch}" == "ppc64le" ]; then
+	packages[qemu_dependencies]+=" libpmem-devel"
+fi
+
+if [ "$(uname -m)" == "ppc64le" ] || [ "$(uname -m)" == "s390x" ]; then
+	packages[kata_containers_dependencies]+=" protobuf-devel"
+fi
+
+if [ "$(uname -m)" == "s390x" ]; then
+	packages[kernel_dependencies]+=" libopenssl-devel"
+fi
 
 main()
 {
@@ -80,23 +85,21 @@ main()
 
 	chronic sudo -E zypper -n install $pkgs_to_install
 
+	# Pandoc currently unavailable in openSUSE s390x repos
+	# Allow install failure, is not required for mainstream CI workflow
+	echo "Try to install pandoc"
+	sudo -E zypper -n install pandoc || true
+
 	echo "Install YAML validator"
 	chronic sudo -E easy_install pip
 	chronic sudo -E pip install yamllint
 
-	echo "Add redis repo and install redis"
-	redis_repo="https://download.opensuse.org/repositories/server:database/SLE_${VERSION//-/_}/server:database.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${redis_repo}
-	chronic sudo -E zypper refresh
+	echo "Install redis"
 	chronic sudo -E zypper -n install redis
 
 	[ "$setup_type" = "minimal" ] && exit 0
 
-	echo "Add crudini repo"
-	VERSIONID="12_SP1"
-	crudini_repo="https://download.opensuse.org/repositories/Cloud:OpenStack:Liberty/SLE_${VERSIONID}/Cloud:OpenStack:Liberty.repo"
-	chronic sudo -E zypper addrepo --no-gpgcheck ${crudini_repo}
-	chronic sudo -E zypper refresh
+	echo "Install crudini"
 	chronic sudo -E zypper -n install crudini
 }
 

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -186,6 +186,7 @@ install_docker_s390x(){
 	log_message "Installing docker"
 	case "$ID" in
 		ubuntu) sudo apt-get install -y docker.io ;;
+		sles|opensuse*) sudo zypper install -y docker ;;
 		*) die "Unsupported distribution: $ID" ;;
 	esac
 }

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -62,12 +62,13 @@ die() {
 }
 
 ci_config() {
+	sudo mkdir -p $(dirname "${kata_config}")
+	sudo cp "${default_kata_config}" "${kata_config}"
+
 	source /etc/os-release || source /usr/lib/os-release
 	ID=${ID:-""}
 	if [ "$ID" == ubuntu ] &&  [ -n "${CI}" ] ;then
 		# https://github.com/kata-containers/tests/issues/352
-		sudo mkdir -p $(dirname "${kata_config}")
-		sudo cp "${default_kata_config}" "${kata_config}"
 		if [ -n "${FACTORY_TEST}" ]; then
 			sudo sed -i -e 's/^#enable_template.*$/enable_template = true/g' "${kata_config}"
 			echo "init vm template"
@@ -84,7 +85,7 @@ ci_config() {
 	fi
 
 	echo "enable debug for kata-runtime"
-	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${kata_config} 
+	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${kata_config}
 	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${default_kata_config}
 }
 


### PR DESCRIPTION
- ci: Apply fixes from CentOS/RHEL to SLE
  - no seccomp & btrfs
  - CC=gcc on s390x
- ci: Re-apply $BUILD_TAGS fix
  - PR #3634 fixed use of the $BUILD_TAGS variable, which was later overwritten in #3629. Re-apply this fix.
- ci: Add a non-k8s CRI_CONTAINERD job
  - Kubernetes is really hard to set up on SUSE (I failed to set it up even on x86). The "blessed" way to run k8s on SUSE is Kubic, but that is e.g. not built for s390x. Add a job for cri-containerd without k8s.
- integration: Copy configuration.toml
  - Copy `/usr/share/defaults/kata-containers/configuration.toml` to `/etc/kata-containers` (previously only done on Ubuntu). Also fix trailing space.
- ci: Fix SLE package install
  - Skip all the individual repositories, just add openSUSE Leap OSS. On s390x, use 15.3 or newer, because that is the earliest openSUSE that is built.
  - Allow pandoc to not be installed (e.g. currently not in openSUSE Leap 15.3 OSS s390x)
  - Install libpmem on supported architectures only (cf. #2341)
  - Install ninja for QEMU (cf. #3264)
  - Install protobuf for required architectures (cf. #3612)
- ci: Fix openSUSE package install
  - Allow pandoc to not be installed (e.g. currently not in openSUSE Leap 15.3 OSS s390x)
  - Install libpmem on supported architectures only (cf. #2341)
  - Install ninja for QEMU (cf. #3264)
  - Install protobuf for required architectures (cf. #3612)
- ci: Support SUSE Docker install for s390x
  - s390x can't use download.docker.com, must use distro package. Support SUSE Linux Enterprise & openSUSE.

Fixes: #3728