### PR TITLE
github: Don't run static checks for go 1.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
go 1.14 already reached its EOL and has already been removed from
kata-containers/kata-containers repo.

See:
https://github.com/kata-containers/kata-containers/commit/e386069158a9da167d9f64efc1e9402e53571f15
https://endoflife.date/go

Fixes: #3733

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>