### PR TITLE
metrics: Remove proxy from json results

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -52,8 +52,6 @@ EOF
 		"RuntimeConfig": "$RUNTIME_CONFIG_PATH",
 		"Hypervisor": "$HYPERVISOR_PATH",
 		"HypervisorVersion": "$HYPERVISOR_VERSION",
-		"Proxy": "$PROXY_PATH",
-		"ProxyVersion": "$PROXY_VERSION",
 		"Shim": "$SHIM_PATH",
 		"ShimVersion": "$SHIM_VERSION",
 		"machinename": "$(uname -n)"


### PR DESCRIPTION
This PR removes proxy component as it is not longer used in kata 2.x
for the json results that we obtain when we run metrics tests.

Fixes #3742

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>