### PR TITLE
webhook: point the image to quay.io

### DIFF
--- a/kata-webhook/README.md
+++ b/kata-webhook/README.md
@@ -14,7 +14,7 @@ Kubernetes YAML files required to instantiate the admission
 controller.
 
 ```bash
-$ docker build -t katadocker/kata-webhook-example:latest .
+$ docker build -t quay.io/kata-containers/kata-webhook-example:latest .
 ```
 
 > **Note:**

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: pod-annotate-webhook
-          image: katadocker/kata-webhook-example:latest
+          image: quay.io/kata-containers/kata-webhook-example:latest
           imagePullPolicy: Always
           env:
             - name: RUNTIME_CLASS


### PR DESCRIPTION
Now that the project owns https://quay.io/kata-containers, let's take
advantage of that and host our webhook example image there.  This will
immediately help consumers of the image that are facing pull limitations
due to the current dockerhub policy.

Fixes: #3749

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>