### PR TITLE
Allow to reproduce CI jobs locally on VMs - part 2

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Include the VM runner specific targets.
+include job/vm/Makefile.include
+
+.PHONY: help
+help:
+	@echo "Job related targets"
+	@echo ""
+	@echo "  job-run-NAME             - Run the job NAME. Use KATA_TESTS_JOB_RUNNER to set the runner."
+	@echo "  job-list                 - List all available CI jobs"
+	@echo "help: CI targets"
+	@echo "  vm-help                  - Help for the VM runner targets."
+	@echo "Environment variables:"
+	@echo "  KATA_TESTS_JOB_RUNNER:   - local or vm (default)"
+
+.PHONY: job-list
+job-list:
+	@bash ./job/job_runner.sh -l
+
+job-run-%:
+	@bash ./job/job_runner.sh -j "$*"

--- a/.ci/job/job_runner.sh
+++ b/.ci/job/job_runner.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cidir="$(dirname $0)/../"
+source "$cidir/lib.sh"
+
+#
+# Variables that the user can overwrite
+#
+KATA_TESTS_JOB_RUNNER="${KATA_TESTS_JOB_RUNNER:-vm}"
+
+#
+# Script variables
+#
+
+ALL_AVAILABLE_JOBS=(
+	"baremetal-pmem"
+	"cri_containerd_k8s"
+	"cri_containerd_k8s_initrd"
+	"cri_containerd_k8s_complete"
+	"cri_containerd_k8s_minimal"
+	"crio_k8s"
+	"crio_k8s_complete"
+	"crio_k8s_minimal"
+	"cloud-hypervisor-k8s-crio"
+	"cloud-hypervisor-k8s-containerd"
+	"cloud-hypervisor-k8s-containerd-minimal"
+	"Ccloud-hypervisor-k8s-containerd-fullL"
+	"firecracker"
+	"vfio"
+	"virtiofs_experimental"
+	"metrics"
+	"metrics_experimental")
+
+usage() {
+	cat <<-EOF
+	Run a CI job.
+	User can select the runner which will trigger the job within a given environment.
+
+	Usage: $0 [-h] [-l] [-j JOB_ID]
+
+	Options:
+	       -l: list all defined jobs
+	       -j JOB_ID: run the job of JOB_ID
+
+	Environment variables:
+	        KATA_TESTS_JOB_RUNNER: switch between 'local' and 'vm' (default) runners"
+	EOF
+}
+
+list_jobs_id() {
+	echo ${ALL_AVAILABLE_JOBS[@]}
+}
+
+#
+# Note:
+#
+# Any function named as _do_run_NAME is interpreted as the implementation of
+# the NAME runner. So if you want to add new runners then you just need to
+# create a function with that name pattern.
+#
+
+# Local runner implementation.
+_do_run_local() {
+	local job_id="$1"
+	local runner_script="${cidir}/run.sh"
+	local setup_script="${cidir}/setup.sh"
+	# Convert the ID to uppercase.
+	typeset -u CI_JOB="$job_id"
+	# Export it.
+	typeset -x CI_JOB
+	bash "$setup_script"
+	bash "$runner_script"
+}
+
+# VM runner implementation.
+_do_run_vm() {
+	local job_id="$1"
+	local runner_script="${cidir}/job/vm/vm_runner.sh"
+	# Convert the ID to uppercase.
+	typeset -u CI_JOB="$job_id"
+        # Export it.
+        typeset -x CI_JOB
+	bash "$runner_script" -r "$job_id"
+}
+
+# Check if the runner $1 exists.
+# i.e., if the function _do_run_$1 is defined then it returns 0, otherwise return 1.
+_runner_exists() {
+	local runner="$1"
+        LC_ALL=C type "_do_run_${runner}" &>/dev/null
+}
+
+run_job() {
+	local job_id="$1"
+	local runner="$2"
+
+	[ -n "$job_id" ] || \
+		die "It must be provided the job ID."
+	echo "${ALL_AVAILABLE_JOBS[@]}" | grep "\<${job_id}\>" &>/dev/null || \
+		die "Job '$job_id' not found."
+
+	[ -n "$runner" ] || \
+		die "It must be provided a job runner."
+	_runner_exists "$runner" || \
+		die "Runner '$runner' is not implemented."
+
+	echo "Run job '$job_id' on '$runner' runner."
+	"_do_run_${runner}" "$job_id"
+}
+
+main() {
+	if [ $# -lt 1 ]; then
+		usage
+		exit 0
+	fi
+	while getopts hj:l opt; do
+		case $opt in
+			h) usage; exit 0;;
+			l) list_jobs_id;;
+			j) run_job "$OPTARG" "${KATA_TESTS_JOB_RUNNER}";;
+			*) usage; exit 1;;
+		esac
+	done
+}
+
+main $@

--- a/.ci/job/vm/Makefile.include
+++ b/.ci/job/vm/Makefile.include
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Specific Make targets for the VM runner.
+#
+
+KATA_TESTS_VM_ENGINE ?= vagrant
+supported_vm_engines:=$(shell ./job/vm/vm_runner.sh -e)
+
+.PHONY: vm-help
+vm-help:
+	@echo "vm-help: Manage CI VMs with the following targets:"
+	@echo "  vm-clean                 - Destroy all VMs"
+	@echo "  vm-list                  - Print all supported VM names"
+	@echo "Environment variables"
+	@echo "  KATA_TESTS_VM_ENGINE: set the VM engine. Defaults to 'vagrant'."
+	@echo "                        Available engines: $(supported_vm_engines)"
+	@echo "  KATA_TESTS_VM_NAME:   the VM name. "
+
+.PHONY: vm-clean
+vm-clean:
+	@bash job/vm/vm_runner.sh -c
+
+.PHONY: vm-list
+vm-list:
+	@bash job/vm/vm_runner.sh -l

--- a/.ci/job/vm/impl_vagrant.sh
+++ b/.ci/job/vm/impl_vagrant.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Implements the vm_runner interface for Vagrant.
+
+_vagrant() {
+    vagrant --machine-readable $@
+}
+
+is_engine_available() {
+    command -v vagrant &>/dev/null
+    # TODO: need to find a way to check the libvirt provider was
+    # installed and is working.
+}
+
+is_vm_running() {
+    local vm_name=$1
+    local status="$(_vagrant status "$vm_name")"
+    [[ "$status" =~ "${vm_name},state,running" ]]
+}
+
+vm_destroy() {
+    local vm=$1
+    vagrant destroy -f "$vm"
+}
+
+vm_start() {
+    local vm=$1
+    local force_destroy=${2:-"true"}
+    if is_vm_running "$vm" && [ "$force_destroy" == "true" ];then
+        vm_destroy "$vm"
+    fi
+    vagrant up "$vm"
+}
+
+vm_run_cmd() {
+    local vm=$1
+    shift 1
+    vagrant ssh $vm -- $*
+}
+
+list_vms() {
+    local vm_name=""
+    _vagrant status | while read -r line; do
+    if [[ "$line" =~ ^[0-9]+,.*,state, ]]; then
+        echo "$line" | cut -d',' -f2 
+    fi
+    done
+}

--- a/.ci/job/vm/vm_runner.sh
+++ b/.ci/job/vm/vm_runner.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Defines the vm_runner interface.
+
+vm_dir=$(dirname "$0")
+cidir="${vm_dir}/../../"
+source "${cidir}/lib.sh"
+
+# The VM engine. Default to Vagrant.
+KATA_TESTS_VM_ENGINE=${KATA_TESTS_VM_ENGINE:-"vagrant"}
+# The default VM name.
+KATA_TESTS_VM_NAME=${KATA_TESTS_VM_NAME:-"fedora"}
+
+# Some jobs cannot run inside a VM. For instance, those which need bare-metal
+# machine. So here it keeps a list of unsupported jobs.
+UNSUPPORTED_JOBS=(
+	"baremetal-pmem"
+)
+
+#KATA_TESTS_VM_NAME= The VM name
+#KATA_TESTS_VM_ENV_FILE= File that contain variables to be exported in the VM environment
+#KATA_TESTS_VM_ENGINE= The VM engine. Default to Vagrant
+
+# Load a VM engine implementation.
+#
+# A VM engine should implement the following functions:
+#
+#  is_engine_available()
+#  is_vm_running(name)
+#  vm_start(name, force_destroy=true)
+#  vm_destroy(name)
+#  vm_run_cmd(name)
+#  vm_shell()
+#  list_vms()
+#
+# Params:
+#  $1 - the engine name.
+_load_engine() {
+	local name="$1"
+	local impl="${vm_dir}/impl_${name}.sh"
+	if [ -z "$name" ]; then
+		echo "It must be provided a VM engine name."
+		echo "The supported engines: $(do_engine_list)"
+		die "Bailing out..."
+	fi
+	if [ -f "$impl" ]; then
+		source "${vm_dir}/impl_${name}.sh" &>/dev/null
+	else
+		echo "The VM engine '${name}' is not implemented."
+		echo "The supported engines: $(do_engine_list)"
+		die "Bailing out..."
+	fi
+	is_engine_available || \
+		die "The VM engine '${name}' seems not installed or proper configured on the system."
+}
+
+usage() {
+	cat <<-EOF
+	This program implements the VM runner.
+	NOTE: End users should not run it.
+
+	Usage: $0 [-c] [-e] [-h] [-l] [-r JOB_ID]
+
+	Options:
+	       -c: destroy all active VMs
+	       -e: list supported engines
+	       -h: print this help message
+	       -l: list all supported VMs
+	       -r JOB_ID: run the job of JOB_ID
+
+	Environment variables:
+	  KATA_TESTS_VM_ENGINE: choose the VM engine. Defaults to 'vagrant'
+	  KATA_TESTS_VM_NAME: for actions which require a VM "fedora"
+	EOF
+}
+
+# Print the list of implemented engines.
+#
+do_engine_list() {
+        echo $(find ${vm_dir} -name "impl_*.sh" | sed -e 's/.*impl_\(.*\).sh/\1/')
+}
+
+# Destroy all VMs.
+#
+do_vm_clean_all() {
+	local vm
+	echo "Going to destroy all VMs"
+	for vm in $(list_vms); do
+		echo "Destroy: $vm"
+		vm_destroy "$vm" || true
+	done
+}
+
+# Print the list of VM names.
+#
+do_vm_list() {
+	echo "The avaliable VMs:"
+	list_vms
+}
+
+# Run the job $1 in the $2 VM.
+#
+do_run_job() {
+	local job_id="$1"
+	local vm="$2"
+	local cmd
+	echo "Run job $job_id on $vm VM"
+	# Assume $GOPATH is exported
+	cmd='cd ${GOPATH}/src/github.com/kata-containers/tests/.ci'
+	cmd+=' && export KATA_TESTS_JOB_RUNNER=local'
+	cmd+=" && make job-run-${job_id}"
+	echo "Start the VM"
+	vm_start "$vm"
+	echo "Run the command $cmd"
+	vm_run_cmd "$vm" "$cmd"
+}
+
+main () {
+	local action=""
+	_load_engine "${KATA_TESTS_VM_ENGINE}"
+	while getopts cehlr: opt; do
+		case $opt in
+			c) action="vm_clean_all";;
+			e) action="engine_list";;
+			h) usage; exit 0;;
+			l) action="vm_list";;
+			r)
+				action="run_job"
+				job="$OPTARG"
+			;;
+			*) usage; exit 1;;
+		esac
+	done
+	if [ -z "${action}" ]; then
+		usage
+		exit 0
+	elif [ "${action}" == "run_job" ]; then
+		do_run_job "${job}" "${KATA_TESTS_VM_NAME}"
+	else
+		do_${action}
+	fi
+}
+
+main $@

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,6 @@ EOF
       cd "${GOPATH}/src/github.com/kata-containers/tests"
       # Build the osbuilder with same distro as the host.
       export osbuilder_distro="fedora"
-      sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'
     SHELL
   end
 
@@ -101,7 +100,6 @@ EOF
       apt-get install -y make
       # Build the osbuilder with same distro as the host.
       export osbuilder_distro="ubuntu"
-      sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'
     SHELL
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ EOF
       sudo dnf install -y grubby
       # Set the kernel parameter to use cgroups v1.
       sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+      dnf install -y make
     SHELL
 
     fedora.vm.provision "shell", inline: <<-SHELL
@@ -97,6 +98,7 @@ EOF
     ubuntu.vm.provision "shell", inline: <<-SHELL
       source "#{guest_env_file}"
       cd "${GOPATH}/src/github.com/kata-containers/tests"
+      apt-get install -y make
       # Build the osbuilder with same distro as the host.
       export osbuilder_distro="ubuntu"
       sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'


### PR DESCRIPTION
This is a continuation of  https://github.com/kata-containers/tests/pull/3547 ((Allow to reproduce CI jobs locally on VMs).

The goal here is make even easier to execute the CI job whether on localhost or inside VM, by introducing makefile targets and some scripts (called *runners*) that abstract the environment where the job will be executed.

Although I didn't think in every and each details, the initial design is meant to allow us to add new runners (e.g. containers) easily. And for the vm_runner, back-ends other than Vagrant (e.g. pure libvirt scripts) can also be implemented.

There are other improvements already on my mind, for instance, allow the user to login the VM to debug a problem. But I will leave those for a part 3.

A typical usage session would be:
```
[wmoschet@wainer-laptop .ci]$ make help
Job related targets

  job-run-NAME             - Run the job NAME. Use KATA_TESTS_JOB_RUNNER to set the runner.
  job-list                 - List all available CI jobs
help: CI targets
  vm-help                  - Help for the VM runner targets.
Environment variables:
  KATA_TESTS_JOB_RUNNER:   - local or vm (default)
[wmoschet@wainer-laptop .ci]$ make vm-help
vm-help: Manage CI VMs with the following targets:
  vm-clean                 - Destroy all VMs
  vm-list                  - Print all supported VM names
Environment variables
  KATA_TESTS_VM_ENGINE: set the VM engine. Defaults to 'vagrant'.
                        Available engines: vagrant
  KATA_TESTS_VM_NAME:   the VM name.
[wmoschet@wainer-laptop .ci]$ make vm-list
The avaliable VMs:
fedora
ubuntu
[wmoschet@wainer-laptop .ci]$ make job-list
baremetal-pmem cri_containerd_k8s cri_containerd_k8s_initrd cri_containerd_k8s_complete cri_containerd_k8s_minimal crio_k8s crio_k8s_complete crio_k8s_minimal cloud-hypervisor-k8s-crio cloud-hypervisor-k8s-containerd cloud-hypervisor-k8s-containerd-minimal Ccloud-hypervisor-k8s-containerd-fullL firecracker vfio virtiofs_experimental metrics metrics_experimental
[wmoschet@wainer-laptop .ci]$ KATA_TESTS_VM_NAME=fedora make job-run-crio_k8s
[wmoschet@wainer-laptop .ci]$ make vm-clean
```