### PR TITLE
spellcheck: Add word "swappiness" to dictionary

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -89,6 +89,7 @@ signoff/A
 stalebot/B
 startup
 subdirectory/A
+swappiness
 sysctl/AB
 teardown
 templating


### PR DESCRIPTION
Add word "swappiness" to dictionary in spellcheck.

Fixes: #3730

Signed-off-by: Hui Zhu <teawater@antfin.com>