### PR TITLE
integration-tests.sh: Remove duplicate line in main

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -385,8 +385,6 @@ main() {
 		passing_test+=("TestContainerListStatsWithSandboxIdFilter")
 	fi
 
-	create_containerd_config "${containerd_runtime_test}"
-
 	for t in "${passing_test[@]}"
 	do
 		sudo -E PATH="${PATH}:/usr/local/bin" \


### PR DESCRIPTION
Remove duplicate line
`create_containerd_config "${containerd_runtime_test}"`
in main.

Fixes: #3761

Signed-off-by: Hui Zhu <teawater@antfin.com>