### PR TITLE
ci/setup: Print the environment variables

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -459,3 +459,13 @@ calc_qemu_files_sha256sum() {
 
 	sha256sum_from_files $files
 }
+
+# Outputs to stdout the environment variables of the current script.
+print_environment() {
+	if [ -n "$(command -v env)" ]
+	then
+		echo environment variables for $(basename "$0"):
+		env
+		echo "#########################################"
+	fi
+}

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -152,6 +152,7 @@ main() {
 
 	[ "$setup_type" = "minimal" ] && info "finished minimal setup" && exit 0
 
+	print_environment
 	install_docker
 	enable_nested_virtualization
 	install_kata


### PR DESCRIPTION
Being able to reproduce a CI failure would help developers to
better debug failed tests.
Currently there is no way to run the same CI job(test) on a
local server since the workflow is based on environment variables we don't have access to.

Add the list of the environment variables to the procenv-user-log .

Fixes: #3764

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>