### PR TITLE
metrics: Get kata-env when using kata with containerd

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -82,7 +82,7 @@ EOF
 	# Now add a runtime specific environment section if we can
 	local iskata=$(is_a_kata_runtime "$RUNTIME")
 	if [ "$iskata" == "1" ]; then
-		local rpath="$(command -v $RUNTIME)"
+		local rpath="$(command -v kata-runtime)"
 		local json="$(cat << EOF
 	"kata-env" :
 	$($rpath kata-env --json)


### PR DESCRIPTION
This PR fixes the issue of extracting the proper kata-runtime kata-env
when we are running with the runtime of io.containerd.run.kata.v2.

Fixes #3766

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>