### PR TITLE
ci: Run static checks when PRs are updated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ on:
   pull_request:
     types:
       - opened
+      - edited
       - reopened
+      - synchronize
       - labeled
       - unlabeled
 


### PR DESCRIPTION
Looking at the changes that could cause the static-checks not to run
when a PR is updated I think 649a5a38c90a7eee351768d5c99c57a1dad636f4
could be the one that introduced such a regression.

Let's (try to) fix this by enforcing the workflow to run also when the
PR has been "edited" and "synchronized".

Fixes: #3772

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>