### PR TITLE
tests/integration: Add basic debug information to k8s-memory teardown

### DIFF
--- a/integration/kubernetes/k8s-memory.bats
+++ b/integration/kubernetes/k8s-memory.bats
@@ -48,3 +48,8 @@ setup() {
 	rm -f "${pod_config_dir}/test_within_memory.yaml"
 	kubectl delete pod "$pod_name"
 }
+
+teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name" || true
+}


### PR DESCRIPTION
Since 591c556 "tests: Add some kubectl describe information to teardown of
many k8s tests", most of the Kubernetes bats tests had a kubectl describe
in the teardown path which helps to debug at least some CI failures when
pods fail to reach Ready state.

Unfortunately the k8s-memory.bats test was missed, probably because it
didn't have any teardown code to begin with.  Correct that oversight.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>