### PR TITLE
metrics: Remove old and unsupported runtimes

### DIFF
--- a/metrics/density/memory_usage.sh
+++ b/metrics/density/memory_usage.sh
@@ -393,7 +393,7 @@ main(){
 
 	if [ "$RUNTIME" == "runc" ]; then
 		get_runc_individual_memory
-	elif [ "$RUNTIME" == "cor" ] || [ "$RUNTIME" == "cc-runtime" ] || [ "$RUNTIME" == "kata-runtime" ]; then
+	elif [ "$RUNTIME" == "kata-runtime" ]; then
 		get_individual_memory
 	fi
 


### PR DESCRIPTION
This PR removes old and unsupported runtimes for memory usage
metrics script.

Fixes #3785

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>