### PR TITLE
ci: fix image instalation on baremetal

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -58,6 +58,12 @@ build_rust_image() {
 			;;
 	esac
 	info "Install ${target_image} to ${image_path}"
+	if [ -f "${image_path}" ]; then
+		# try to umount it first, it can be mounted as a read-only file
+		file="$(realpath ${image_path}/$(basename ${file_to_install}))"
+		sudo umount "${file}" || true
+		sudo rm -f "${file}"
+	fi
 	sudo install -D "${file_to_install}" "${image_path}"
 	popd
 }


### PR DESCRIPTION
In a previous commit the rootfs image was converted to read-only, hence
the installation script on baremetal is failing because it tries to
overwrite it, let's try to umount and delete it before installing the
new image.

fixes #3789

Signed-off-by: Julio Montes <julio.montes@intel.com>