### PR TITLE
lib: Ensure the StartBurstLimit is disabled when restarting services

### DIFF
--- a/.ci/containerd_devmapper_setup.sh
+++ b/.ci/containerd_devmapper_setup.sh
@@ -9,6 +9,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+cidir=$(dirname "$0")
+source "${cidir}/../lib/common.bash"
+
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 containerd_config_dir="/etc/containerd"
@@ -76,4 +79,4 @@ else
 EOT
 fi
 
-sudo systemctl restart containerd
+restart_containerd_service

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -61,17 +61,6 @@ jenkins_url="http://jenkins.katacontainers.io"
 # Path where cached artifacts are found.
 cached_artifacts_path="lastSuccessfulBuild/artifact/artifacts"
 
-# If we fail for any reason a message will be displayed
-die() {
-	msg="$*"
-	echo "ERROR: $msg" >&2
-	exit 1
-}
-
-info() {
-	echo -e "INFO: $*"
-}
-
 # Clone repo only if $kata_repo_dir is empty
 # Otherwise, we assume $kata_repo is cloned and in correct branch, e.g. a PR or local change
 clone_kata_repo() {

--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -59,7 +59,7 @@ run() {
 	fi
 
 	# Run storage tests
-	sudo systemctl restart docker
+	restart_docker_service
 	bash storage/blogbench.sh
 
 	# Skip: Issue: https://github.com/kata-containers/tests/issues/3203

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -64,7 +64,7 @@ install_docker() {
 		"${cidir}/../cmd/container-manager/manage_ctr_mgr.sh" docker install
 	fi
 
-	sudo systemctl restart docker
+	restart_docker_service
 }
 
 enable_nested_virtualization() {

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -179,7 +179,7 @@ install_docker(){
 		# If tag received is invalid, then return an error message
 		die "Unrecognized tag. Tag supported is: swarm"
 	fi
-	sudo systemctl restart docker
+	restart_docker_service
 	sudo gpasswd -a ${USER} docker
 	sudo chmod g+rw /var/run/docker.sock
 }
@@ -283,7 +283,7 @@ ExecStart=/usr/bin/dockerd ${docker_options}
 EOF
 	echo "Reloading unit files and starting docker service"
 	sudo systemctl daemon-reload
-	sudo systemctl restart docker
+	restart_docker_service
 }
 
 # This function configures docker to work by default with the

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -207,7 +207,7 @@ main() {
 
 	setup_configuration_file
 
-	sudo systemctl restart containerd
+	restart_containerd_service
 	sudo modprobe vfio
 	sudo modprobe vfio-pci
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -52,15 +52,6 @@ readonly default_containerd_config_backup="$CONTAINERD_CONFIG_FILE.backup"
 readonly kata_config="/etc/kata-containers/configuration.toml"
 readonly default_kata_config="/usr/share/defaults/kata-containers/configuration.toml"
 
-info() {
-	echo -e "INFO: $*"
-}
-
-die() {
-	echo >&2 "ERROR: $*"
-	exit 1
-}
-
 ci_config() {
 	sudo mkdir -p $(dirname "${kata_config}")
 	sudo cp "${default_kata_config}" "${kata_config}"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -10,6 +10,9 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../../../lib/common.bash"
+
 # runc is installed in /usr/local/sbin/ add that path
 export PATH="$PATH:/usr/local/sbin"
 
@@ -67,7 +70,6 @@ ci_config() {
 		fi
 	fi
 
-	SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 	if [ -n "${CI}" ]; then
 		(
 		echo "Install cni config"
@@ -157,37 +159,12 @@ err_report() {
 
 trap err_report ERR
 
-restart_docker() {
-	info "restart docker service"
-
-	back_file=$(mktemp)
-
-	#avoid the "Start request repeated too quickly" error
-        if [ -f "/lib/systemd/system/docker.service" ]; then
-		cp /lib/systemd/system/docker.service ${back_file}
-                sudo sed -i 's/StartLimitBurst.*$/StartLimitBurst=0/g' /lib/systemd/system/docker.service
-        elif [ -f "/usr/lib/systemd/system/docker.service" ]; then
-		cp /usr/lib/systemd/system/docker.service ${back_file}
-                sudo sed -i 's/StartLimitBurst.*$/StartLimitBurst=0/g' /usr/lib/systemd/system/docker.service
-        fi
-        sudo systemctl daemon-reload
-        sudo systemctl restart docker
-
-	#recover docker service file
-	if [ -f "/lib/systemd/system/docker.service" ]; then
-		sudo mv ${back_file} /lib/systemd/system/docker.service
-	elif [ -f "/usr/lib/systemd/system/docker.service" ]; then
-		sudo mv ${back_file} /usr/lib/systemd/system/docker.service
-	fi
-        sudo systemctl daemon-reload
-}
-
 check_daemon_setup() {
 	info "containerd(cri): Check daemon works with runc"
 	create_containerd_config "runc"
 
 	#restart docker service as TestImageLoad depends on it
-	restart_docker
+	restart_docker_service
 
 	sudo -E PATH="${PATH}:/usr/local/bin" \
 		REPORT_DIR="${REPORT_DIR}" \
@@ -219,7 +196,7 @@ EOF
 	sudo cp "$default_containerd_config" "$default_containerd_config_backup"
 	sudo cp $CONTAINERD_CONFIG_FILE "$default_containerd_config"
 
-	sudo systemctl restart containerd
+	restart_containerd_service
 
 	sudo crictl pull $image
 	podid=$(sudo crictl runp $pod_yaml)
@@ -234,7 +211,7 @@ testContainerStop() {
 	sudo crictl rmp $podid
 
 	sudo cp "$default_containerd_config_backup" "$default_containerd_config"
-	sudo systemctl restart containerd
+	restart_containerd_service
 }
 
 TestKilledVmmCleanup() {

--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -21,8 +21,7 @@ IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
 WAIT_TIME="60"
 
 function setup() {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 	check_processes
 	save_ksm_settings
 	set_ksm_aggressive

--- a/integration/sandbox_cgroup/sandbox_cgroup_test.sh
+++ b/integration/sandbox_cgroup/sandbox_cgroup_test.sh
@@ -26,8 +26,7 @@ if [ -z "${TEST_SANDBOX_CGROUP_ONLY}" ]; then
 fi
 
 function setup() {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_processes
 }

--- a/integration/stability/agent_stability_test.sh
+++ b/integration/stability/agent_stability_test.sh
@@ -28,8 +28,7 @@ start_time=$(date +%s)
 end_time=$((start_time+timeout))
 
 function setup {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 	sudo ctr image pull $IMAGE
 	sudo ctr run --runtime=$CONTAINERD_RUNTIME -d $IMAGE $CONTAINER_NAME sh -c $PAYLOAD_ARGS
 }

--- a/integration/stability/hypervisor_stability_kill_test.sh
+++ b/integration/stability/hypervisor_stability_kill_test.sh
@@ -19,9 +19,8 @@ CONTAINER_NAME="${CONTAINER_NAME:-test}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 
 setup()  {
-	sudo systemctl restart containerd
+	restart_containerd_service
 	extract_kata_env
-	clean_env_ctr
 	HYPERVISOR_NAME=$(basename ${HYPERVISOR_PATH})
 	sudo ctr image pull $IMAGE
 	[ $? != 0 ] && die "Unable to get image $IMAGE"

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -158,7 +158,7 @@ check_mounts() {
 }
 
 init() {
-	sudo systemctl restart containerd
+	restart_containerd_service
 	extract_kata_env
 	kill_all_containers
 

--- a/integration/vcpus/default_vcpus_test.sh
+++ b/integration/vcpus/default_vcpus_test.sh
@@ -30,8 +30,7 @@ if [ "$TEST_INITRD" == "yes" ]; then
 fi
 
 function setup() {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 	check_processes
 	extract_kata_env
 	sudo sed -i "s/${name} = 1/${name} = 4/g" "${RUNTIME_CONFIG_PATH}"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -30,24 +30,24 @@ experimental_qemu="${experimental_qemu:-false}"
 
 die() {
 	local msg="$*"
-	echo "ERROR: $msg" >&2
+	echo -e "[$(basename $0):${BASH_LINENO[0]}] ERROR: $msg" >&2
 	exit 1
 }
 
 warn() {
 	local msg="$*"
-	echo "WARNING: $msg"
+	echo -e "[$(basename $0):${BASH_LINENO[0]}] WARNING: $msg"
 }
 
 info() {
 	local msg="$*"
-	echo "INFO: $msg"
+	echo -e "[$(basename $0):${BASH_LINENO[0]}] INFO: $msg"
 }
 
 handle_error() {
 	local exit_code="${?}"
 	local line_number="${1:-}"
-	echo "Failed at $line_number: ${BASH_COMMAND}"
+	echo -e "[$(basename $0):$line_number] ERROR: $(eval echo "$BASH_COMMAND")"
 	exit "${exit_code}"
 }
 trap 'handle_error $LINENO' ERR

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -174,3 +174,76 @@ clean_env_ctr()
 		sudo ctr c rm $(sudo ctr c list -q)
 	fi
 }
+
+# Restarts a systemd service while ensuring the start-limit-burst is set to 0.
+# Outputs warnings to stdio if something has gone wrong.
+#
+# Returns 0 on success, 1 otherwise
+restart_systemd_service_with_no_burst_limit() {
+	local service=$1
+	info "restart $service service"
+
+	local active=$(systemctl show "$service.service" -p ActiveState | cut -d'=' -f2)
+	[ "$active" == "active" ] || warn "Service $service is not active"
+
+	local start_burst=$(systemctl show "$service".service -p StartLimitBurst | cut -d'=' -f2)
+	if [ "$start_burst" -ne 0 ]
+	then
+		local unit_file=$(systemctl show "$service.service" -p FragmentPath | cut -d'=' -f2)
+		[ -f "$unit_file" ] || { warn "Can't find $service's unit file: $unit_file"; return 1; }
+
+		local start_burst_set=$(sudo grep StartLimitBurst $unit_file | wc -l)
+		if [ "$start_burst_set" -eq 0 ]
+		then
+			sudo sed -i '/\[Service\]/a StartLimitBurst=0' "$unit_file"
+		else
+			sudo sed -i 's/StartLimitBurst.*$/StartLimitBurst=0/g' "$unit_file"
+		fi
+
+		sudo systemctl daemon-reload
+	fi
+
+	sudo systemctl restart "$service"
+
+	local state=$(systemctl show "$service.service" -p SubState | cut -d'=' -f2)
+	[ "$state" == "running" ] || { warn "Can't restart the $service service"; return 1; }
+
+	start_burst=$(systemctl show "$service.service" -p StartLimitBurst | cut -d'=' -f2)
+	[ "$start_burst" -eq 0 ] || { warn "Can't set start burst limit for $service service"; return 1; }
+
+	return 0
+}
+
+restart_containerd_service() {
+	restart_systemd_service_with_no_burst_limit containerd || return 1
+
+	local retries=5
+	local counter=0
+	until [ "$counter" -ge "$retries" ] || sudo ctr --connect-timeout 1s version > /dev/null 2>&1
+	do
+		info "Waiting for containerd socket..."
+		((counter++))
+	done
+
+	[ "$counter" -ge "$retries" ] && { warn "Can't connect to containerd socket"; return 1; }
+
+	clean_env_ctr
+	return 0
+}
+
+restart_docker_service() {
+	restart_systemd_service_with_no_burst_limit docker || return 1
+
+	local retries=5
+	local counter=0
+	until [ "$counter" -ge "$retries" ] || sudo docker version > /dev/null 2>&1
+	do
+		info "Waiting for docker socket..."
+		sleep 1
+		((counter++))
+	done
+
+	[ "$counter" -ge "$retries" ] && { warn "Can't connect to docker socket"; return 1; }
+
+	return 0
+}

--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -77,8 +77,7 @@ function dump_caches() {
 }
 
 function init() {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 
 	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_cmds $REQUIRED_COMMANDS

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -63,8 +63,7 @@ function dump_caches() {
 }
 
 function init() {
-	sudo systemctl restart containerd
-	clean_env_ctr
+	restart_containerd_service
 
 	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_cmds $REQUIRED_COMMANDS

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -129,7 +129,8 @@ metrics_onetime_init()
 	fi
 
 	# Restart services
-	sudo systemctl restart docker containerd
+	restart_docker_service
+	restart_containerd_service
 
 	# We want this to be seen in sub shells as well...
 	# otherwise init_env() cannot check us

--- a/metrics/storage/webtooling.sh
+++ b/metrics/storage/webtooling.sh
@@ -79,7 +79,7 @@ function main() {
 	local cmds=()
 	cmds+=("docker")
 
-	sudo systemctl restart containerd
+	restart_containerd_service
 	init_env
 	check_cmds "${cmds[@]}"
 	check_ctr_images "$IMAGE" "$DOCKERFILE"

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -240,7 +240,7 @@ check_jaeger_status()
 setup()
 {
 	# containerd must be running in order to use ctr to generate traces
-	sudo systemctl restart containerd
+	restart_containerd_service
 
 	start_jaeger
 


### PR DESCRIPTION
Too many systemd service restarts in a short period of time may result in systemd disabling the service.

Add a function to the common library that abstracts the service restart.

Use the opportunity to add error messages and return error codes so then later will be possible to stop the test if something goes wrong.

Improve a  little the logs while at it.