### PR TITLE
docs: Update readme metrics documentation

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -29,7 +29,7 @@ This directory contains the metrics tests for Kata Containers.
 
 The tests within this directory have a number of potential use cases:
 - CI checks for regressions on PRs
-- CI data gathering for master branch merges
+- CI data gathering for main branch merges
 - Developer use for pre-checking code changes before raising a PR
 - As part of report generation
 


### PR DESCRIPTION
This PR updates the branch reference in the metrics readme documentation
with the current one that we are using on kata 2.0

Fixes #3798

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>