### PR TITLE
ci: Only use sudo in Rust installation if required

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -38,6 +38,6 @@ if [ "${rustarch}" == "powerpc64le" ] || [ "${rustarch}" == "s390x" ] ; then
 	rustup target add ${rustarch}-unknown-linux-gnu
 else
 	rustup target add ${rustarch}-unknown-linux-musl
-	sudo ln -sf /usr/bin/g++ /bin/musl-g++
+	$([ "$(whoami)" != "root" ] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
 fi
 rustup component add rustfmt


### PR DESCRIPTION
so that when we build the agent in Docker, we do not need to install
sudo in the container.

Fixes: #3800
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>