### PR TITLE
ci: Also test firecracker with jailer

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -178,7 +178,7 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_kernel="true"
 	;;
-"FIRECRACKER")
+"FIRECRACKER"|"FIRECRACKER_JAILER")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -96,6 +96,13 @@ case "${CI_JOB}" in
 		echo "INFO: Running Kubernetes tests with Firecracker"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
+	"FIRECRACKER_JAILER")
+		echo "INFO: Running Kubernetes tests with Firecracker (with jailer)"
+		sudo sed -i -e 's/^#jailer_path/jailer_path/' "/usr/share/defaults/kata-containers/configuration.toml"
+		sudo -E PATH="$PATH" bash -c "make kubernetes"
+		# revert to the current "default" behaviour, which is not using the jailer
+		sudo sed -i -e 's/^jailer_path/#jailer_path/' "/usr/share/defaults/kata-containers/configuration.toml"
+		;;
 	"VFIO")
 		echo "INFO: Running VFIO functional tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vfio"


### PR DESCRIPTION
FIRECRACKER_JAILER is a target introduced and used by the two* CIs,
which have been recently introduced to avoid regressions when running
firecracker with the jailer.

*: The CIs using this CI_JOB target:
   - kata-containers-2.0-tests-firecracker-jailer-ubuntu-PR
   - kata-containers-2.0-firecracker-jailer-ubuntu-PR

Fixes: #3802

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>
Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>