### PR TITLE
checkmetrics: Bump boot time latency to take cgroup management overhead

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -16,9 +16,9 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.62
-minpercent = 5.0
-maxpercent = 5.0
+midval = 0.67
+minpercent = 10.0
+maxpercent = 10.0
 
 [[metric]]
 name = "memory-footprint"


### PR DESCRIPTION
Our current values do not take the cgroup creation and management
overhead into account.

Fixes #3804

Signed-off-by: Samuel Ortiz <samuel.e.ortiz@protonmail.com>