### PR TITLE
integration/containerd: Fix cleaning flow

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -151,8 +151,8 @@ fi
 }
 
 cleanup() {
-	[ -d "$tmp_dir" ] && rm -rf "${tmp_dir}"
 	ci_cleanup
+	[ -d "$tmp_dir" ] && rm -rf "${tmp_dir}"
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
Remove the temporary directory after cleaning the CI
since it holds some configuration files used by
the cleaning code.

fixes #3806

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>