### PR TITLE
stable-2.1 | ci: Set GO111MODULE="auto" in lib.sh

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -37,6 +37,14 @@ else
 	export GOPATH="${GOPATH:-$HOME/go}"
 fi
 
+# Support Golang 1.16.x.
+# By default in Golang >= 1.16 GO111MODULE is set to "on",
+# some subprojects in this repo may not support "go modules",
+# set GO111MODULE to "auto" to enable module-aware mode only when
+# a go.mod file is present in the current directory.
+export GO111MODULE="auto"
+
+
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
1474f085c7023e1eb77210132dcf24a972880560 ci: Set GO111MODULE="auto" in lib.sh
6780b3626c13b47bac04f2259872783cabb78a10 github: Don't run static checks for go 1.14