### PR TITLE
agent: Install Rust for shutdown test

### DIFF
--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -771,6 +771,7 @@ setup()
 		"$cargo" \
 		"$kata_repo_dir"
 
+	cargo --version || "${SCRIPT_PATH}/../.ci/install_rust.sh"
 	local file="${cargo}/env"
 	[ -e "$file" ] && source "$file"
 
@@ -990,7 +991,9 @@ run_agent_ctl()
 	# Note that we don't use the same logic for checking the control tool
 	# since that uses a different build profile compared to the agent.
 	command -v "$agent_ctl_binary_name" &>/dev/null || \
-		(cd "$agent_ctl_dir" && cargo install --path .)
+		(cd "$agent_ctl_dir" && \
+			sudo chown -R "${USER}:" "${kata_repo_dir}" && \
+			cargo install --path .)
 
 	local agent_ctl_path
 	agent_ctl_path=$(command -v "$agent_ctl_binary_name" || true)


### PR DESCRIPTION
The newly introduced agent shutdown test (#3495) needs Rust, but if we
build the agent itself in a container, Rust will not be installed on the
host. Add a Makefile target for this.

Fixes: #3812
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>