### PR TITLE
metrics: Update runtime variable in density tests

### DIFF
--- a/metrics/density/fast_footprint.sh
+++ b/metrics/density/fast_footprint.sh
@@ -79,7 +79,6 @@ function dump_caches() {
 function init() {
 	restart_containerd_service
 
-	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_cmds $REQUIRED_COMMANDS
 	sudo ctr image pull "$PAYLOAD"
 
@@ -306,7 +305,7 @@ launch_containers() {
 		echo "Launch iteration ${iter}"
 		for n in $(seq 1 $PARALLELISM); do
 			containers+=($(random_name))
-			sudo ctr run $PAYLOAD_RUNTIME_ARGS -d --runtime=$CONTAINERD_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS &
+			sudo ctr run $PAYLOAD_RUNTIME_ARGS -d --runtime=$CTR_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS &
 		done
 
 		if [[ $PAYLOAD_SLEEP ]]; then
@@ -322,7 +321,7 @@ launch_containers() {
 
 	for n in $(seq 1 $leftovers); do
 		containers+=($(random_name))
-		sudo ctr run $PAYLOAD_RUNTIME_ARGS -d --runtime=$CONTAINERD_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS &
+		sudo ctr run $PAYLOAD_RUNTIME_ARGS -d --runtime=$CTR_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS &
 	done
 }
 

--- a/metrics/density/footprint_data.sh
+++ b/metrics/density/footprint_data.sh
@@ -65,7 +65,6 @@ function dump_caches() {
 function init() {
 	restart_containerd_service
 
-	CONTAINERD_RUNTIME="io.containerd.kata.v2"
 	check_cmds $REQUIRED_COMMANDS
 	sudo ctr image pull "$PAYLOAD"
 
@@ -282,7 +281,7 @@ function go() {
 
 	for i in $(seq 1 $MAX_NUM_CONTAINERS); do
 		containers+=($(random_name))
-		sudo ctr run --memory-limit $PAYLOAD_RUNTIME_ARGS --rm --runtime=$CONTAINERD_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS
+		sudo ctr run --memory-limit $PAYLOAD_RUNTIME_ARGS --rm --runtime=$CTR_RUNTIME $PAYLOAD ${containers[-1]} sh -c $PAYLOAD_ARGS
 
 		if [[ $PAYLOAD_SLEEP ]]; then
 			sleep $PAYLOAD_SLEEP


### PR DESCRIPTION
Currently at metrics common we have defined the CTR_RUNTIME variable
which is currently the runtime that we are using for metrics tests.
This PR updates the density scripts to use that variable instead of
repeating the value with two variables.

Fixes #3814

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>