### PR TITLE
versions: Update flannel version to v0.14.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -49,7 +49,7 @@ externals:
 
   flannel:
     url: "https://github.com/coreos/flannel"
-    version: "v0.13.0-rc2"
+    version: "v0.14.0"
 
   xurls:
     description: |


### PR DESCRIPTION
This fixes setting up flannel on Kubernetes v1.22.0.
Without this fix applying kube-flannel with fail with error:
no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1".