### PR TITLE
Update static-checks URLs and spelling word lists

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -169,18 +169,18 @@ Notes:
 
 Examples:
 
-- Run all tests on a specific branch (stable or master) of runtime repository:
+- Run all tests on a specific branch (stable or main) of kata-containers repo:
 
-  $ $script_name github.com/kata-containers/runtime true
+  $ $script_name github.com/kata-containers/kata-containers true
 
 - Auto-detect repository and run golang tests for current repository:
 
   $ KATA_DEV_MODE=true $script_name --golang
 
-- Run all tests on the agent repository, forcing the tests to consider all
-  files, not just those changed by a PR branch:
+- Run all tests on the kata-containers repository, forcing the tests to
+  consider all files, not just those changed by a PR branch:
 
-  $ $script_name github.com/kata-containers/agent --all
+  $ $script_name github.com/kata-containers/kata-containers --all
 
 
 EOT
@@ -246,7 +246,7 @@ static_check_commits()
 {
 	# Since this script is called from another repositories directory,
 	# ensure the utility is built before running it.
-	# for master branch
+	# for main branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
 	# for main branch
 	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
@@ -272,7 +272,7 @@ static_check_commits()
 	ERROR: checkcommits failed. See the document below for help on formatting
 	commits for the project.
 
-		https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#patch-format
+		https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
 
 EOT
 		exit 1
@@ -824,7 +824,7 @@ static_check_docs()
 		"$cmd" check "$doc" || { info "spell check failed for document $doc" && docs_failed=1; }
 	done
 
-	[ $docs_failed -eq 0 ] || die "spell check failed, See https://github.com/kata-containers/documentation/blob/master/Documentation-Requirements.md#spelling for more information."
+	[ $docs_failed -eq 0 ] || die "spell check failed, See https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md#spelling for more information."
 }
 
 # Tests to apply to all files.
@@ -913,7 +913,7 @@ static_check_files()
 #   vendor tooling config file. If not, the user simply hacked the vendor files
 #   rather than following the correct process:
 #
-#   https://github.com/kata-containers/community/blob/master/VENDORING.md
+#   https://github.com/kata-containers/community/blob/main/VENDORING.md
 #
 # - Ensure vendor metadata is valid.
 static_check_vendor()

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -21,6 +21,7 @@ config/AB
 crypto		# Cryptography
 DaemonSet/AB
 deliverable/AB
+dev
 devicemapper/B
 deploy
 dialer
@@ -116,3 +117,4 @@ webhook/AB
 whitespace
 workflow/A
 Xeon/A
+yaml

--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -41,6 +41,7 @@ Kubernetes/B
 Launchpad/B
 LevelDB/B
 libcontainer/B
+libelf/B
 libvirt/B
 Linkerd/B
 Logrus/B
@@ -80,4 +81,5 @@ Vexxhost/B
 virtcontainers/B
 VMWare/B
 Yamux/B
+yq/B
 Zun/B


### PR DESCRIPTION
Fixes: #3819

see also: kata-containers/kata-containers#2425

Before:
```
$ ./kata-spell-check.sh check ~/project/kata/kata-containers/tools/packaging/kernel/README.md 
INFO: Spell checking file '/home/dcmiddle/project/kata/kata-containers/tools/packaging/kernel/README.md'
WARNING: Word 'dev': did you mean one of the following?: deb, derv, div, den, rev, deg, def, dew, Nev, Rev, evade
WARNING: Word 'libelf': did you mean one of the following?: libel, libels, lib elf, lib-elf, libel f, belief
WARNING: Word 'yaml': did you mean one of the following?: yam, yams, yawl, ya ml, ya-ml, yam l
WARNING: Word 'yq': did you mean one of the following?: y, q, ye, sq, ya, yr, yo, yd, Sq
ERROR: Spell check failed for file: '/home/dcmiddle/project/kata/kata-containers/tools/packaging/kernel/README.md'
```
After:
```
$ ./kata-spell-check.sh check ~/project/kata/kata-containers/tools/packaging/kernel/README.md 
INFO: Spell checking file '/home/dcmiddle/project/kata/kata-containers/tools/packaging/kernel/README.md'
INFO: Spell check successful for file: '/home/dcmiddle/project/kata/kata-containers/tools/packaging/kernel/README.md'
```
