### PR TITLE
backports for stable-2.1

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -198,7 +198,7 @@ kill_stale_process()
 {
 	clean_env
 	extract_kata_env
-	stale_process_union=( "${stale_process_union[@]}" "${PROXY_PATH}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
+	stale_process_union=( "${stale_process_union[@]}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do
 		[ -z "${stale_process}" ] && continue
 		local pids=$(pgrep -d ' ' -f "${stale_process}")

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You need to install the following to run Kata Containers tests:
 
 The recommended method to set up Kata Containers is to use the official and latest
 stable release. You can find the official documentation to do this in the
-[Kata Containers installation user guides](https://github.com/kata-containers/documentation/blob/master/install/README.md).
+[Kata Containers installation user guides](https://github.com/kata-containers/kata-containers/blob/main/docs/install/README.md).
 
 To try the latest commits of Kata use the CI scripts, which build and install from the
 `kata-containers` repositories, with the following steps:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For example:
 ```
 
 In this example, we tell the CI to fetch the pull request 999 from the `kata-containers`
-repository and use that rather than the `master` branch when testing the changes
+repository and use that rather than the `main` branch when testing the changes
 contained in this pull request.
 
 ## CLI tools

--- a/cmd/check-markdown/README.md
+++ b/cmd/check-markdown/README.md
@@ -15,7 +15,7 @@ All these repositories contain documents written in
 [GitHub-Flavoured Markdown](https://github.github.com/gfm)
 format.
 
-[Linking in documents is strongly encouraged](https://github.com/kata-containers/documentation/blob/master/Documentation-Requirements.md)
+[Linking in documents is strongly encouraged](https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md)
 but due to the number of internal and external document links, it is easy for
 mistakes to be made. Also, links can become stale when one document is updated
 but the documents it depends on are not.

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -90,7 +90,7 @@ categories:
       Issue cannot be resolved (too hard/impossible, would be too slow,
       insufficient resources, etc).
     url: |
-      https://github.com/kata-containers/documentation/blob/master/Limitations.md
+      https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md
 
   - name: new-contributor
     description: Small, self-contained tasks suitable for newcomers.

--- a/cmd/log-parser/README.md
+++ b/cmd/log-parser/README.md
@@ -35,7 +35,7 @@ The tool requires that the following fields are defined for each log record:
   that generates the log record.
 
 - Source field (`source`): a single word that specifies the name of a unique
-  part of the system (e.g. `proxy`, `runtime`, `shim`).
+  part of the system (e.g. `runtime`).
 
 - Timestamp field (`time`): in [RFC3339](https://tools.ietf.org/html/rfc3339)
   format and including a nanosecond value.
@@ -49,25 +49,16 @@ Additional to the fields above, the tool also expects the following field:
 
 The primary logfiles the tool reads are:
 
-- The [proxy](https://github.com/kata-containers/proxy) log.
-
-  This log also includes embedded log entries from the
-  [agent](https://github.com/kata-containers/agent). `kata-log-parser`
-  automatically unpacks and displays the entries. During this process, the
-  encapsulating proxy log messages are discarded.
-
-- The [runtime](https://github.com/kata-containers/runtime) log.
+- The [runtime](https://github.com/kata-containers/kata-containers/tree/main/src/runtime) log.
 
   This log also includes
   [virtcontainers](https://github.com/containers/virtcontainers) log entries.
-
-- The [shim](https://github.com/kata-containers/shim) log.
 
 ## Usage
 
 To merge all logs:
 
-1. [Enable full debug](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#enable-full-debug).
+1. [Enable full debug](https://github.com/kata-containers/kata-containers/blob/main/docs/Developer-Guide.md#enable-full-debug).
 1. Clear the systemd journal (optional):
    ```
    $ sudo systemctl stop systemd-journald
@@ -76,17 +67,9 @@ To merge all logs:
    ```
 1. Create a container.
 1. Collect the logs.
-    1. Save the proxy log, which includes agent log details:
-       ```
-       $ sudo journalctl -q -o cat -a -t kata-proxy > ./proxy.log
-       ```
     1. Save the runtime log:
        ```
        $ sudo journalctl -q -o cat -a -t kata-runtime > ./runtime.log
-       ```
-    1. Save the shim log:
-       ```
-       $ sudo journalctl -q -o cat -a -t kata-shim > ./shim.log
        ```
     1. Save the throttler logs:
        ```
@@ -104,5 +87,5 @@ To merge all logs:
    ```
 1. To run the program:
    ```
-   $ kata-log-parser proxy.log runtime.log shim.log vc-throttler.log ksm-throttler.log
+   $ kata-log-parser runtime.log vc-throttler.log ksm-throttler.log
    ```

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -31,7 +31,7 @@ This directory contains the metrics tests for Kata Containers.
 
 The tests within this directory have a number of potential use cases:
 - CI checks for regressions on PRs
-- CI data gathering for master branch merges
+- CI data gathering for main branch merges
 - Developer use for pre-checking code changes before raising a PR
 - As part of report generation
 


### PR DESCRIPTION
5423ef46 docs: Update checkcommits README information
444e638d docs: Update readme metrics documentation
c660af67 docs: Update documentation url for kata 2.0
9971d230 labels: Update github labels for documentation
5112449e docs: Update breaking compatibility section
fa650cec ci: Remove proxy at the kill stale process function
accaa483 docs: Update log-parser documentation
