### PR TITLE
metrics: Fix RUNTIME at metrics json results

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -72,7 +72,7 @@ EOF
 
 	local json="$(cat << EOF
 	"test" : {
-		"runtime": "${RUNTIME}",
+		"runtime": "${CTR_RUNTIME}",
 		"testname": "${TEST_NAME}"
 	}
 EOF


### PR DESCRIPTION
Currently the RUNTIME that we are using on metrics for kata 2.0
is defined as CTR_RUNTIME, this PR fixes the correspondent name
of the variable.

Fixes #3823

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>