### PR TITLE
metrics: Use containerd runc runtime for metrics

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -90,8 +90,8 @@ EOF
 )"
 		metrics_json_add_fragment "$json"
 	else
-		if [ "$RUNTIME" == "runc" ]; then
-			local output=$(docker-runc -v)
+		if [ "$CTR_RUNTIME" == "io.containerd.runc.v2" ]; then
+			local output=$(runc -v)
 			local runcversion=$(grep version <<< "$output" | sed 's/runc version //')
 			local runccommit=$(grep commit <<< "$output" | sed 's/commit: //')
 			local json="$(cat << EOF


### PR DESCRIPTION
Currently at the metrics tests scripts we are using containerd and when
we are running with RunC this is being called io.containerd.runc.v2, this
PR updates this current runtime to get proper results at metrics.

Fixes #3826

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>