### PR TITLE
ci: Enable memory tests on s390x

### DIFF
--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -1,8 +1,0 @@
-#
-# Copyright (c) 2019 IBM
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-kubernetes:
-  - k8s-oom
-  - k8s-memory


### PR DESCRIPTION
Following the merge of #3679, a stress image is available on s390x,
thus, the memory tests can be re-enabled.

Fixes: #3840
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>