### PR TITLE
ci: Fix unbound variable for init script for kubernetes

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -15,6 +15,7 @@ source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
+CI=${CI:-""}
 RUNTIME=${RUNTIME:-containerd-shim-kata-v2}
 RUNTIME_PATH=${RUNTIME_PATH:-$(command -v $RUNTIME)}
 


### PR DESCRIPTION
While running standalone the kubernetes scripts using `make kubernetes`
without using CI environment we are hitting an error saying that CI
is an unbound variable. This PR is fixing it.

Fixes #3843

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>