### PR TITLE
docker: provides rw permission of docker.sock for all uses

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -181,7 +181,7 @@ install_docker(){
 	fi
 	restart_docker_service
 	sudo gpasswd -a ${USER} docker
-	sudo chmod g+rw /var/run/docker.sock
+	sudo chmod 666 /var/run/docker.sock
 }
 
 install_docker_s390x(){


### PR DESCRIPTION
Currently, the permission of docker.sock is set to be
srw-rw---- 1 root docker 0 xx y zz:tt /var/run/docker.sock
and add the jenkins user to docker group. But that configuration will
not take effect unitl relogin the session, which means the docker
can't be used by jenkins user in the whole CI journey.
It seems there is no way to log out and log back in the auto ci. So, I
have to set the permission of docker.sock to rw for all user, even
though it will open a secure hole.

Fixes: #3847
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>