### PR TITLE
CCv0 | ci: Refer to CCv0 branch on CCv0 branch

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -13,7 +13,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
-export kata_default_branch="${kata_default_branch:-main}"
+export kata_default_branch="${kata_default_branch:-CCv0}"
 
 
 # Name of systemd service for the throttler

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -40,7 +40,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-main}
+branch=${branch:-CCv0}
 
 # Which static check functions to consider.
 handle_funcs="all"
@@ -249,7 +249,7 @@ static_check_commits()
 	# for main branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
 	# for main branch
-	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'main' && git fetch -v)
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'CCv0' && git fetch -v)
 
 	command -v checkcommits &>/dev/null || \
 		die 'checkcommits command not found. Ensure that "$GOPATH/bin" is in your $PATH.'
@@ -262,7 +262,7 @@ static_check_commits()
 			--ignore-fixes-for-subsystem "release" \
 			--verbose \
 			HEAD \
-			main; \
+			CCv0; \
 			rc="$?";
 	} || true
 
@@ -1237,7 +1237,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "main" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "CCv0" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
-3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
-4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/CCv0/integration/kubernetes)
+   - [Containerd](https://github.com/kata-containers/tests/tree/CCv0/integration/containerd)
+2. [Stability tests](https://github.com/kata-containers/tests/tree/CCv0/integration/stability)
+3. [Metrics](https://github.com/kata-containers/tests/tree/CCv0/metrics)
+4. [VFIO](https://github.com/kata-containers/tests/tree/CCv0/functional/vfio)
 
 ## CI Content
 
@@ -183,7 +183,7 @@ You need to install the following to run Kata Containers tests:
 - [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
-  [versions database](https://github.com/kata-containers/kata-containers/blob/main/versions.yaml).
+  [versions database](https://github.com/kata-containers/kata-containers/blob/CCv0/versions.yaml).
 
 - `make`.
 

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -90,7 +90,7 @@ categories:
       Issue cannot be resolved (too hard/impossible, would be too slow,
       insufficient resources, etc).
     url: |
-      https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md
+      https://github.com/kata-containers/kata-containers/blob/CCv0/docs/Documentation-Requirements.md
 
   - name: new-contributor
     description: Small, self-contained tasks suitable for newcomers.
@@ -110,7 +110,7 @@ categories:
   - name: related
     description: |
       Related project. Base set can be generated from
-      https://github.com/kata-containers/kata-containers/blob/main/versions.yaml.
+      https://github.com/kata-containers/kata-containers/blob/CCv0/versions.yaml.
 
   - name: release
     description: Related to production of new versions.

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -50,7 +50,7 @@ create_file() {
 	local block_size=4096
 	local data_offset=$((1024*1024*2))
 	local dax_alignment=$((1024*1024*2))
-	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/osbuilder/image-builder/nsdax.gpl.c"
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/CCv0/tools/osbuilder/image-builder/nsdax.gpl.c"
 
 	truncate -s "${SIZE}" "${FILE}"
 	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,7 +10,7 @@ description: |
   This file contains test specific version details.
   For other version details, see the main database:
 
-  https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
+  https://github.com/kata-containers/kata-containers/blob/CCv0/versions.yaml
 
 docker_images:
   description: "Docker hub images used for testing"


### PR DESCRIPTION
This commit forces all the checks and references to point to CCv0 branch
rather than pointing to `main`.  This will guarantee that changes done
on `main` won't affect the testing of this specific branch.

Fixes: #3853

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>

Note: I've cherry-picked fidencio's change in PR #3854, so I can investigate the fedora failure whilst he is on vacation