### PR TITLE
integration/pmem: fix bare metal CI

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -71,7 +71,7 @@ esac
 check_processes
 
 echo "Build custom stress image"
-registry_image="docker.io/library/registry"
+registry_image="docker.io/library/registry:2"
 arch=$("${SCRIPT_PATH}/../../.ci/kata-arch.sh")
 if [[ "${arch}" == "ppc64le" || "${arch}" == "s390x" ]]; then
 	# that image is not built for these architectures

--- a/integration/pmem/pmem_test.sh
+++ b/integration/pmem/pmem_test.sh
@@ -40,7 +40,6 @@ fi
 
 init() {
 	${dir_path}/../../integration/kubernetes/init.sh
-	docker run -d -p 5000:5000 --restart=always --name registry registry:2
 }
 
 cleanup() {
@@ -59,10 +58,6 @@ cleanup() {
 	rm -rf pmem-csi
 
 	${dir_path}/../../integration/kubernetes/cleanup_env.sh
-
-	docker rm -f $(docker ps -aq)
-	rid=$(docker images -q registry:2)
-	docker rmi -f $(docker images -q | sed '/'$rid'/d')
 }
 
 run_test() {


### PR DESCRIPTION
* Specify a version for the registry image
* Don't re-run a registry from the pmem test
* Don't delete all docker images to avoid rate limit issue

fixes #3837

Signed-off-by: Julio Montes <julio.montes@intel.com>