### PR TITLE
ci: set GO111MODULE="auto" in install_bats.sh

### DIFF
--- a/.ci/install_bats.sh
+++ b/.ci/install_bats.sh
@@ -12,7 +12,7 @@ which bats && exit
 BATS_REPO="github.com/bats-core/bats-core"
 
 echo "Install BATS from sources"
-go get -d "${BATS_REPO}" || true
+GO111MODULE="auto" go get -d "${BATS_REPO}" || true
 pushd "${GOPATH}/src/${BATS_REPO}"
 sudo -E PATH=$PATH sh -c "./install.sh /usr"
 popd


### PR DESCRIPTION
Since the bump to Golang 1.16 (commit 188c129f3) scripts which uses `go
get -d` to download code should export GO111MODULE="auto" in case they
don't source lib.sh (commit 1474f085c7). That's the case of
install_bats.sh.

Fixes #3781
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>