### PR TITLE
kata-webhook: request cpu/memory to the pod and a few improvements

### DIFF
--- a/kata-webhook/create-certs.sh
+++ b/kata-webhook/create-certs.sh
@@ -3,10 +3,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
 
 WEBHOOK_NS=${1:-"default"}
 WEBHOOK_NAME=${2:-"pod-annotate"}
 WEBHOOK_SVC="${WEBHOOK_NAME}-webhook"
+
+if ! command -v openssl &>/dev/null; then
+	echo "ERROR: command 'openssl' not found."
+	exit 1
+elif ! command -v kubectl &>/dev/null; then
+	echo "ERROR: command 'kubectl' not found."
+	exit 1
+fi
+
+cleanup() {
+	rm -f ./webhookCA*
+	rm -f ./webhook.crt
+}
+
+trap cleanup EXIT
 
 # Create certs for our webhook
 touch $HOME/.rnd
@@ -25,5 +44,3 @@ kubectl create secret generic \
 CA_BUNDLE=$(cat ./webhook.crt | base64 -w0)
 sed "s/CA_BUNDLE/${CA_BUNDLE}/" ./deploy/webhook-registration.yaml.tpl > ./deploy/webhook-registration.yaml
 
-# Clean
-rm ./webhookCA* && rm ./webhook.crt

--- a/kata-webhook/create-certs.sh
+++ b/kata-webhook/create-certs.sh
@@ -38,7 +38,7 @@ kubectl create secret generic \
     ${WEBHOOK_SVC}-certs \
     --from-file=key.pem=./webhookCA.key \
     --from-file=cert.pem=./webhook.crt \
-    --dry-run -o yaml > ./deploy/webhook-certs.yaml
+    --dry-run=client -o yaml > ./deploy/webhook-certs.yaml
 
 # Set the CABundle on the webhook registration
 CA_BUNDLE=$(cat ./webhook.crt | base64 -w0)

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -33,6 +33,10 @@ spec:
             - name: webhook-certs
               mountPath: /etc/webhook/certs
               readOnly: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "250Mi"
       volumes:
         - name: webhook-certs
           secret:


### PR DESCRIPTION
Primarily this should fix a test case which is failing on OpenShift CI (see #3858). While I am at it, I improved the `create-certs.sh` script a little bit. 