### PR TITLE
ci: Skip unstable tests

### DIFF
--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -3,34 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# for now, not all integration test suites are fully passed in ppc64le.
-# some need to be tested, and some need to be refined.
-# sequence of 'test' holds supported integration tests components.
-test:
-  - functional
-  - docker
-
-# for now, not all test suites under docker integration are fully passed in ppc64le.
-# some need to be tested, and some need to be refined.
-# ginkgo offers '-skip=REGEXP' flag to skip specific ones.
-# you can use infos from docker.Describe, docker.Context or docker.It to point to
-# specific test specs or whole container of specs. Issue #1580 tracks all the tests
-# that currently fail on ppc64le.
-docker:
-  Describe:
-    - Update CPU set
-    - CPUs and CPU set
-    - Update CPU constraints
-    - Hotplug memory when create containers
-    - run container and update its memory constraints
-    - check dmesg logs errors
-    - memory constraints
-    - check yum update
-  Context:
-    - run container exceeding memory constraints
-  It:
-
 kubernetes:
   - k8s-block-volume
+  - k8s-limit-range
+  - k8s-number-cpus
   - k8s-oom
-  - k8s-memory


### PR DESCRIPTION
For our current CI, skip unstable tests
and enable memory test.

Fixes: #3869

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>