### PR TITLE
integration/kubernetes: allow to run block volume test with ordinary users

### DIFF
--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -20,7 +20,7 @@ setup() {
 
 	# Create Loop Device
 	tmp_disk_image=$(mktemp --tmpdir disk.XXXXXX.img)
-	sudo truncate "$tmp_disk_image" --size "$vol_capacity"
+	truncate "$tmp_disk_image" --size "$vol_capacity"
 	loop_dev=$(sudo losetup -f)
 	sudo losetup "$loop_dev" "$tmp_disk_image"
 }


### PR DESCRIPTION
This will allow to run the kubernetes suite with a non-root user, i.e., all tests should pass with `make kubernetes`.

Fixes #3873
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>