### PR TITLE
integration/containerd: print containerd logs only if file exists

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -151,10 +151,13 @@ cleanup() {
 trap cleanup EXIT
 
 err_report() {
-	echo "ERROR: containerd log :"
-	echo "-------------------------------------"
-	cat "${REPORT_DIR}/containerd.log"
-	echo "-------------------------------------"
+	local log_file="${REPORT_DIR}/containerd.log"
+	if [ -f "$log_file" ]; then
+		echo "ERROR: containerd log :"
+		echo "-------------------------------------"
+		cat "${log_file}"
+		echo "-------------------------------------"
+	fi
 }
 
 trap err_report ERR


### PR DESCRIPTION
The err_report() is executed when the script exits with error. It should print
the content of the containerd logs file only if it exits, the script might
have failed before even containerd start.

Fixes #3879
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>