### PR TITLE
ci: Check if the rootfs_img is writable before binding read-only

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,7 +22,7 @@ if [ "$(uname -m)" == "x86_64" ]; then
 	/usr/share/defaults/kata-containers/configuration.toml \
 	/etc/kata-containers/configuration.toml 2> /dev/null \
 	| cut -d= -f2 | tr -d '"' | tr -d ' ' || true)"
-	if [ -n "${rootfs_img}" ]; then
+	if [ -n "${rootfs_img}" ] && [ -w "${rootfs_img}" ]; then
 		echo "INFO: making rootfs image read-only"
 		sudo mount --bind -r "${rootfs_img}" "${rootfs_img}"
 	fi


### PR DESCRIPTION
When running the ci locally is more user friendly to run setup once,
then run.sh several times. The second time the rootfs_img is not writable
anymore, but the binding will fail.
Fix it by checking the file before binding.

Fixes #3883

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>