### PR TITLE
k8s: enable memory hotplug test for arm64

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -39,4 +39,3 @@ kubernetes:
   - k8s-expose-ip
   - k8s-oom
   - k8s-block-volume
-  - k8s-memory


### PR DESCRIPTION
enable memory hotplug test in k8s integration test

Fixes: #3885
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>