### PR TITLE
CCv0 | ci: Add CCv0 features into CI script

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -23,12 +23,13 @@ source "${script_dir}/lib.sh"
 #Use cri contaienrd tarball format.
 #https://github.com/containerd/cri/blob/master/docs/installation.md#release-tarball
 CONTAINERD_OS=$(go env GOOS)
-CONTAIENRD_ARCH=$(go env GOARCH)
+CONTAINERD_ARCH=$(go env GOARCH)
 
 cri_containerd_tarball_version=$(get_version "externals.cri-containerd.version")
 cri_containerd_repo=$(get_version "externals.cri-containerd.url")
 
 cri_containerd_version=${cri_containerd_tarball_version#v}
+cri_containerd_pr="5911" # TODO - put in version.yaml and pull dynamically $(get_version "externals.cri-containerd.pr_id")
 
 echo "Set up environment"
 if [ "$ID" == centos ] || [ "$ID" == rhel ] || [ "$ID" == sles ]; then
@@ -43,8 +44,26 @@ install_from_source() {
 		git fetch
 		git checkout "${cri_containerd_tarball_version}"
 		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
-		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
+		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAINERD_ARCH}.tar.gz"
 		sudo tar -xvf "./releases/${tarball_name}" -C /
+	)
+}
+
+install_from_pr() {
+	warn "Using patched Confidential Computing containerd version: see https://github.com/containerd/containerd/pull/${cri_containerd_pr}"
+	echo "Trying to install containerd from a PR"
+	(
+		cd "${GOPATH}/src/${cri_containerd_repo}" >>/dev/null
+		git fetch origin pull/${cri_containerd_pr}/head:PR_BRANCH
+		git checkout "PR_BRANCH"
+		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
+		# SH: The PR containerd version might not match the version.yaml one, so get from build
+		cri_containerd_version=$(_output/cri/bin/containerd --version | awk '{ print substr($3,2); }')
+		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAINERD_ARCH}.tar.gz"
+		echo "Tarball name is : '${tarball_name}'"
+		sudo tar -xvf "./releases/${tarball_name}" -C /
+		# Clean up PR_BRANCH
+		git checkout main && git branch -D "PR_BRANCH"
 	)
 }
 
@@ -52,7 +71,7 @@ install_from_static_tarball() {
 	echo "Trying to install containerd from static tarball"
 	local tarball_url=$(get_version "externals.cri-containerd.tarball_url")
 
-	local tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
+	local tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAINERD_ARCH}.tar.gz"
 	local url="${tarball_url}/${cri_containerd_tarball_version}/${tarball_name}"
 
 	echo "Download tarball from ${url}"
@@ -65,6 +84,12 @@ install_from_static_tarball() {
 }
 
 go get "${cri_containerd_repo}"
-install_from_static_tarball || install_from_source
+
+# For 'CCv0' we are pulling in a PR of containerd with our custom code
+if [ -n ${cri_containerd_pr} ]; then
+  install_from_pr
+else
+  install_from_static_tarball || install_from_source
+fi
 
 sudo systemctl daemon-reload

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -22,6 +22,7 @@ initrd_name="${initrd_name:-kata-containers-initrd.img}"
 AGENT_INIT="${AGENT_INIT:-${TEST_INITRD:-no}}"
 TEST_INITRD="${TEST_INITRD:-no}"
 build_method="${BUILD_METHOD:-distro}"
+EXTRA_PKGS="${EXTRA_PKGS:-}"
 
 build_rust_image() {
 	export RUST_AGENT="yes"
@@ -42,13 +43,30 @@ build_rust_image() {
 	info "Building ${target_image} with AGENT_INIT=${AGENT_INIT}"
 	case "$build_method" in
 		"distro")
-			distro="${osbuilder_distro:-ubuntu}"
-			if [[ ! "${osbuild_docker:-}" =~ ^(0|false|no)$ ]]; then
-				use_docker="${osbuild_docker:-}"
-				[[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
+			if [ ${CCV0} == "yes"]; then
+				# CCv0 is using skopeo and gpg packages and we've added a few more for debugging. The default distro of ubuntu is really back level, so some are missing there, so use fedora
+				# We also need to split the rootfs create and image build so we can add umoci to the rootfs directly
+				distro=fedora
+				EXTRA_PKGS="skopeo gnupg gpgme-devel vim iputils net-tools iproute"
+				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
+					make -e "rootfs"
+				rootfs_target="$(shell pwd)/$(DISTRO)_rootfs"
+				# CCv0 is using umoci which isn't in a fedora package we can access yet, so grabbing from their webstire
+				go_arch=$("${cidir}"/kata-arch.sh -g)
+				mkdir -p ${rootfs_target}/usr/local/bin/
+				sudo curl -Lo ${rootfs_target}/usr/local/bin/umoci https://github.com/opencontainers/umoci/releases/download/v0.4.7/umoci.${go_arch}
+				sudo chmod u+x ${rootfs_target}/usr/local/bin/umoci
+				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" \
+					make -e "image"
+			else
+				distro="${osbuilder_distro:-ubuntu}"
+				if [[ ! "${osbuild_docker:-}" =~ ^(0|false|no)$ ]]; then
+					use_docker="${osbuild_docker:-}"
+					[[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
+				fi
+				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
+					make -e "${target_image}"
 			fi
-			sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" \
-				make -e "${target_image}"
 			;;
 		"dracut")
 			sudo -E BUILD_METHOD="dracut" make -e "${target_image}"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -70,6 +70,12 @@ export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
 # a go.mod file is present in the current directory.
 export GO111MODULE="auto"
 
+if [ ${ghprbTargetBranch} == "CCv0" ] || [ ${GIT_BRANCH} == "CCv0" ]; then
+	export CCV0="yes"
+	echo "Running CCv0 build"
+	export kata_default_branch="CCv0"
+fi
+
 kata_repo_dir="${GOPATH}/src/${kata_repo}"
 tests_repo_dir="${GOPATH}/src/${tests_repo}"
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -13,8 +13,10 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export kata_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export kata_repo_dir="${GOPATH}/src/${kata_repo}"
-export kata_default_branch="${kata_default_branch:-CCv0}"
+export kata_default_branch="${kata_default_branch:-main}"
 
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+export tests_repo_dir="${GOPATH}/src/${tests_repo}"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"
@@ -498,4 +500,9 @@ print_environment() {
 		env
 		echo "#########################################"
 	fi
+}
+
+warn()
+{
+	echo >&2 "WARNING: $*"
 }

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -40,7 +40,12 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-CCv0}
+if [ ${target_branch} == "CCv0" ]; then
+	branch=${branch:-CCv0}
+	tests_branch=${tests_branch:-CCv0}
+fi
+branch=${branch:-main}
+tests_branch=${tests_branch:-main}
 
 # Which static check functions to consider.
 handle_funcs="all"
@@ -249,7 +254,7 @@ static_check_commits()
 	# for main branch
 	# (cd "${tests_repo_dir}" && make checkcommits)
 	# for main branch
-	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin 'CCv0' && git fetch -v)
+	(cd "${tests_repo_dir}" && make checkcommits && git remote set-branches origin ${tests_branch} && git fetch -v)
 
 	command -v checkcommits &>/dev/null || \
 		die 'checkcommits command not found. Ensure that "$GOPATH/bin" is in your $PATH.'
@@ -262,7 +267,7 @@ static_check_commits()
 			--ignore-fixes-for-subsystem "release" \
 			--verbose \
 			HEAD \
-			CCv0; \
+			${tests_branch}; \
 			rc="$?";
 	} || true
 
@@ -1237,7 +1242,7 @@ main()
 	for func in $all_check_funcs
 	do
 		if [ "$func" = "static_check_commits" ]; then
-			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "CCv0" ]
+			if [ -n "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BRANCH" != "${branch}" ]
 			then
 				echo "Skipping checkcommits"
 				echo "See issue: https://github.com/kata-containers/tests/issues/632"

--- a/integration/kubernetes/e2e_conformance/setup.sh
+++ b/integration/kubernetes/e2e_conformance/setup.sh
@@ -21,7 +21,7 @@ CRI_RUNTIME="${CRI_RUNTIME:-containerd}"
 wait_init_retry="10s"
 
 info "Setup env for K8s e2e testing"
-cd "${GOPATH}/src/github.com/kata-containers/tests/integration/kubernetes"
+cd "${tests_repo_dir}/integration/kubernetes"
 if ! bash ./init.sh; then
 	info "k8s init failed trying again"
 	sudo systemctl restart "${CRI_RUNTIME}"


### PR DESCRIPTION
Make the build understand if they are running against a target branch
of CCv0 or main and update branches dynamically based on this

Add code to get containerd from our CCv0 PR rather than a released build

Add new CCv0 condition to the code that created the kata image.
CCv0 requires some extra packages for running and debug. It also needs
umoci, which is not yet availabe as a distro package, so wget it direct

Fixes: #3887
Depends-on: github.com/kata-containers/kata-containers#2577

Signed-off-by: stevenhorsman <steven@uk.ibm.com>