### PR TITLE
stable-2.2 | vfio: checkout target branch

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -153,6 +153,9 @@ ${environment}
     git clone https://\${tests_repo} "\${tests_repo_dir}"
     cd "\${tests_repo_dir}"
 
+    # Checkout to target branch: master, stable-X.Y, main etc
+    git checkout "origin/\${ghprbTargetBranch}"
+
     trap "cd \${tests_repo_dir}; sudo -E PATH=\$PATH .ci/teardown.sh ${artifacts_dir} || true; sudo chown -R \${USER} ${artifacts_dir}" EXIT
 
     if echo \${GIT_URL} | grep -q tests; then


### PR DESCRIPTION
It will fix deps resolving with vfio (on stable branches)

!!! Adding do-not-merged until https://github.com/kata-containers/tests/pull/3890 is merged !!!

Fixes: #3889
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>