### PR TITLE
ci: Add io.containerd.kata.v2 as a runtime

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -57,7 +57,7 @@ trap 'handle_error $LINENO' ERR
 # want in reality, but this function knows the names of the default
 # and recommended Kata docker runtime install names.
 is_a_kata_runtime(){
-	if [ "$1" = "containerd-shim-kata-v2" ]; then
+	if [ "$1" = "containerd-shim-kata-v2" ] || [ "$1" = "io.containerd.kata.v2" ]; then
 		echo "1"
 	else
 		echo "0"

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -106,7 +106,7 @@ EOF
 )"
 			metrics_json_add_fragment "$json"
 		else
-			warning "Unrecognised runtime ${RUNTIME} - no env extracted"
+			warning "Unrecognised runtime - no env extracted"
 		fi
 	fi
 


### PR DESCRIPTION
Currently some tests scripts are using io.containerd.kata.v2 as a runtime
so in this PR we are adding this to be recognized as a kata runtime, it
also fixes the unrecognised runtime message.

Fixes #3894

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>