### PR TITLE
ci: Fix ctr cannot delete a non stopped container

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -170,21 +170,6 @@ function get_test_version(){
 	get_dep_from_yaml_db "${db}" "${dependency}"
 }
 
-function waitForProcess(){
-        wait_time="$1"
-        sleep_time="$2"
-        cmd="$3"
-        while [ "$wait_time" -gt 0 ]; do
-                if eval "$cmd"; then
-                        return 0
-                else
-                        sleep "$sleep_time"
-                        wait_time=$((wait_time-sleep_time))
-                fi
-        done
-        return 1
-}
-
 kill_stale_process()
 {
 	clean_env

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -253,3 +253,20 @@ restart_docker_service() {
 
 	return 0
 }
+
+function waitForProcess(){
+	wait_time="$1"
+	sleep_time="$2"
+	cmd="$3"
+	while [ "$wait_time" -gt 0 ]; do
+		if eval "$cmd"; then
+			return 0
+		else
+			sleep "$sleep_time"
+			wait_time=$((wait_time-sleep_time))
+		fi
+	done
+	return 1
+}
+
+

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -170,14 +170,21 @@ clean_env_ctr()
 	local i=""
 	local containers=( $(sudo ctr c list -q) )
 	local count_running="${#containers[@]}"
+	local count_stopped=0
+	local time_out=10
+	local sleep_time=1
 
 	[ "$count_running" -eq "0" ] && return 0
 
 	for i in "${containers[@]}"; do
-		sudo ctr tasks kill $(sudo ctr task ls | grep $i)
+		sudo ctr tasks kill "$i"
 	done
-	sleep 1
-	sudo ctr containers delete $(sudo ctr c list -q)
+
+	cmd="[[ $(sudo ctr tasks list | grep -c "STOPPED") == "$count_running" ]]"
+	info "Wait until the containers gets removed"
+	waitForProcess "${time_out}" "${sleep_time}" "$cmd"
+
+	sudo ctr containers delete ${containers[@]}
 }
 
 
@@ -268,5 +275,3 @@ function waitForProcess(){
 	done
 	return 1
 }
-
-


### PR DESCRIPTION
For the function clean_env_ctr, adds a loop that waits
until all running processes are stopped before to proceed
to delete all running containers.

Fixes #3896

Signed-off-by: David Esparza <david.esparza.borquez@intel.com>