### PR TITLE
ci: improve cleanup

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -27,6 +27,7 @@ esac
 export KUBECONFIG="$HOME/.kube/config"
 sudo -E kubeadm reset -f --cri-socket="${cri_runtime_socket}"
 
+[ "${container_engine}" == "docker" ] && restart_docker_service
 registry_server_teardown
 
 sudo systemctl stop "${cri_runtime}"


### PR DESCRIPTION
When running K8s tests with crio on ubuntu, the default
container runtime used is docker(unlike podman on fedora likes). 
To remove the running resources, restarting docker would be required.

Fixes: #3871

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>