### PR TITLE
Vfio test improvements

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -142,7 +142,7 @@ ${environment}
     # Make sure the packages were installed
     # Sometimes cloud-init is unable to install them
     sudo dnf makecache
-    sudo dnf install -y git make pciutils
+    sudo dnf install -y git make pciutils driverctl
 
     git config --global user.email "foo@bar"
     git config --global user.name "Foo Bar"

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -183,8 +183,12 @@ clean_env_ctr()
 		[ -n "$tasks" ] && sudo ctr tasks kill $tasks
 	done
 
-	cmd="[[ $(sudo ctr tasks list | grep -c "STOPPED") == "$count_running" ]]"
-	[ ! waitForProcess "${time_out}" "${sleep_time}" "$cmd" ] && sudo systemctl restart containerd
+	# do not stop if the command fails, it will be evaluated by waitForProcess
+	local cmd="[[ $(sudo ctr tasks list | grep -c "STOPPED") == "$count_running" ]]" || true
+
+	local res="ok"
+	waitForProcess "${time_out}" "${sleep_time}" "$cmd" || res="fail"
+	[ "$res" == "ok" ] || sudo systemctl restart containerd
 
 	sudo ctr containers delete ${containers[@]}
 }


### PR DESCRIPTION
Allow multiple test runs.
Enable the debug console so the container can be debugged (requires manually disabling the trap).
Add the kata vm dmesg to the output logs.