### PR TITLE
tests: Skip cri integration tests on ARM

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -36,8 +36,11 @@ case "${CI_JOB}" in
 	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_INITRD")
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
-		echo "INFO: Containerd checks"
-		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		# Issue https://github.com/kata-containers/tests/issues/3906
+		if [ "$(uname -m)" != "aarch64" ]; then
+			echo "INFO: Containerd checks"
+			sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		fi
 		[ "${CI_JOB}" != "CRI_CONTAINERD" ] && \
 			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		echo "INFO: Running vcpus test"


### PR DESCRIPTION
This PR skips the cri integration tests on ARM as they are randomly failing
until the issue gets properly fixed.

Fixes #3906

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>