### PR TITLE
ci: fix deps resolving

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -12,7 +12,6 @@ set -o errtrace
 
 cidir=$(dirname "$0")
 source "/etc/os-release" || source "/usr/lib/os-release"
-source "${cidir}/lib.sh"
 
 CI_JOB=${CI_JOB:-}
 ghprbPullId=${ghprbPullId:-}
@@ -165,6 +164,7 @@ fi
 # according to the job type.
 pushd "${GOPATH}/src/${tests_repo}"
 source ".ci/ci_job_flags.sh"
+source "${cidir}/lib.sh"
 popd
 
 "${ci_dir_name}/setup.sh"


### PR DESCRIPTION
IIUC this should fix the mess with the dependencies between branches
When PR for kata-containers is send and this PR **Depends-on** some PR in tests, this tests PR is not merged/applied until the resolve-kata-dependencies.sh is called, hence, sourcing lib.sh before resolve-kata-dependencies.sh will result in lib.sh from the plain tests target branch (without merging the tests PR we depends-on). if the tests PR changes touched lib.sh these changes are not used (although we "depends-on" them"), this may cause a mess

Thing is, i think i cannot really test it before it's merged @Jakob-Naucke @marcel-apf  WDYT?
(https://github.com/kata-containers/tests/pull/3890 or similar might still be needed to fix completely the issue on stable)
@fidencio 

Fixes: #3889
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>