### PR TITLE
lib/common.bash: strengthen the clean_env_ctr function

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -170,14 +170,16 @@ clean_env_ctr()
 	local i=""
 	local containers=( $(sudo ctr c list -q) )
 	local count_running="${#containers[@]}"
+	local tasks=""
 
 	[ "$count_running" -eq "0" ] && return 0
 
 	for i in "${containers[@]}"; do
-		sudo ctr tasks kill $(sudo ctr task ls | grep $i)
+		tasks="$(sudo ctr task ls | grep $i || true)"
+		[ -n "$tasks" ] && sudo ctr tasks kill $tasks
 	done
 	sleep 1
-	sudo ctr containers delete $(sudo ctr c list -q)
+	sudo ctr containers delete ${containers[@]}
 }
 
 


### PR DESCRIPTION
A container may not have tasks, so the `ctr tasks kill` is gonna fail
the clean_env_ctr(); which is usually used on clean up functions. Instead
let's check if there are tasks to be killed.

Fixes #3836
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>