### PR TITLE
vagrantfile: Fix vagrant up fedora

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -102,6 +102,12 @@ main()
 		pkgs_to_install+=" ${rust_agent_pkgs[@]}"
 	fi
 
+	# The redis-server package fails to install if IPv6 is disabled. Let's
+	# check if that's the case and then enable it.
+	if [ $(sudo sysctl -n net.ipv6.conf.all.disable_ipv6) -eq 1 ]; then
+		sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+	fi
+
 	chronic sudo -E apt -y install $pkgs_to_install
 
 	[ "$setup_type" = "minimal" ] && exit 0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,18 +71,6 @@ EOF
     echo "cd $kata_tests_repo_dir" >> #{guest_home_dir}/.bashrc
     sudo -E PATH=$PATH -u #{guest_user} \
     echo "source $env_file" >> #{guest_home_dir}/.bashrc
-
-    distro=$(source /etc/os-release; echo $ID)
-    case "$distro" in
-      "ubuntu")
-        # TODO: redis-server package fails to install if IPv6 is disabled. Move this
-        # code to the setup script.
-        if [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) -eq 1 ]]; then
-          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
-          sudo sed -i 's/\(net.ipv6.conf.all.disable_ipv6\).*/\1=0/' /etc/sysctl.conf
-        fi
-        ;;
-    esac
   SHELL
 
   config.vm.define "fedora", autostart: false do |fedora|


### PR DESCRIPTION
The aim with this pull request is to fix the `vagrant up fedora` command which is not currently working. I also send a bonus commit that is just an improvement. I tested both `vagrant up fedora` and `vagrant up ubuntu` to ensure no regressions with ubuntu.

@dgibson reported the problem on #3760 but actually I never hit the same issue. Here instead it has crashed because of commit 26cef9d.

@Jakob-Naucke I didn't touch your code which forces the use of Podman on Fedora-likes. Instead I ensure it work with this vagrant file. TBH, I don't know why (and didn't investigate) on the Fedora box with cgroups v2, Podman fails to build the guest image.

Fixes #3760