### PR TITLE
Update spelling word lists

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -55,6 +55,7 @@ linter/AB
 logfile/A
 Longterm
 longterm
+losetup
 memcpy/A
 mergeable
 metadata
@@ -95,6 +96,7 @@ sysctl/AB
 teardown
 templating
 timestamp/AB
+tmp
 tracability
 ttRPC/B
 udev/B


### PR DESCRIPTION
Adding `tmp` and `losetup` to the main dictionary to ensure that the
spell check passes, having updated the Developer Guide re qemu-img.

Fixes #3927

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>