### PR TITLE
metrics: Update minpercent for boot time

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -17,7 +17,7 @@ description = "measure container lifecycle timings"
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.67
-minpercent = 10.0
+minpercent = 15.0
 maxpercent = 10.0
 
 [[metric]]


### PR DESCRIPTION
This PR updates the minpercent for boot time as it has been seen that sometimes
the boot time is less to the current one by decreasing the minpercent we will
avoid random failures when checking the minimum value for boot time, this is
not a performance degradation.

Fixes #3929

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>