### PR TITLE
metrics: Fix unknown runtime error at memory test

### DIFF
--- a/metrics/density/memory_usage.sh
+++ b/metrics/density/memory_usage.sh
@@ -294,7 +294,7 @@ get_docker_memory_usage(){
 EOF
 )"
 
-	elif [ "$RUNTIME" == "kata-qemu" ] || [ "$RUNTIME" == "kata-fc" ] || [ "$RUNTIME" == "kata-runtime" ]; then
+	else [ "$RUNTIME" == "kata-runtime" ] || [ "$RUNTIME" == "kata-fc" ] || [ "$RUNTIME" == "kata-qemu" ]
 		# Get PSS memory of VM runtime components.
 		# And check that the smem search has found the process - we get a "0"
 		#  back if that procedure fails (such as if a process has changed its name
@@ -341,8 +341,6 @@ EOF
 	}
 EOF
 )"
-	else
-		die "Unknown runtime: $RUNTIME"
 	fi
 
 	metrics_json_add_array_element "$json"
@@ -386,6 +384,14 @@ main(){
 
 	check_cmds "${SMEM_BIN}" bc
 	check_images "$IMAGE"
+
+	if [ "${CTR_RUNTIME}" == "io.containerd.run.kata.v2" ]; then
+		export RUNTIME="kata-runtime"
+        elif [ "${CTR_RUNTIME}" == "io.containerd.runc.v2" ]; then
+		export RUNTIME="runc"
+        else
+		die "Unknown runtime ${CTR_RUNTIME}"
+	fi
 
 	metrics_json_init
 	save_config

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -44,7 +44,7 @@ metrics_json_init() {
 EOF
 )"
 
-	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ]; then
 		metrics_json_add_fragment "$json"
 
 		local json="$(cat << EOF
@@ -81,7 +81,7 @@ EOF
 EOF
 )"
 
-	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ]; then
 		metrics_json_add_fragment "$json"
 
 		# Now add a runtime specific environment section if we can
@@ -89,31 +89,28 @@ EOF
 		if [ "$iskata" == "1" ]; then
 			local rpath="$(command -v kata-runtime)"
 			local json="$(cat << EOF
-		"kata-env" :
-		$($rpath kata-env --json)
+			"kata-env" :
+				$($rpath kata-env --json)
 EOF
 )"
-	fi
-		metrics_json_add_fragment "$json"
-	else
-		if [ "$CTR_RUNTIME" == "io.containerd.runc.v2" ]; then
-			local output=$(runc -v)
-			local runcversion=$(grep version <<< "$output" | sed 's/runc version //')
-			local runccommit=$(grep commit <<< "$output" | sed 's/commit: //')
-			local json="$(cat << EOF
-	"runc-env" :
-	{
-		"Version": {
-			"Semver": "$runcversion",
-			"Commit": "$runccommit"
-		}
-	}
-EOF
-)"
-			metrics_json_add_fragment "$json"
-		else
-			warning "Unrecognised runtime - no env extracted"
 		fi
+	fi
+
+	if [ "$CTR_RUNTIME" == "io.containerd.runc.v2" ]; then
+		metrics_json_add_fragment "$json"
+		local output=$(runc -v)
+		local runcversion=$(grep version <<< "$output" | sed 's/runc version //')
+		local runccommit=$(grep commit <<< "$output" | sed 's/commit: //')
+		local json="$(cat << EOF
+		"runc-env" :
+		{
+			"Version": {
+				"Semver": "$runcversion",
+				"Commit": "$runccommit"
+			}
+		}
+EOF
+)"
 	fi
 
 	metrics_json_end_of_system


### PR DESCRIPTION
Currently for the memory test we are using containerd and a as runtime io.containerd.kata.v2,
however, we can not extract general information like hypervisor path in order to get the pss
memory for the hypervisor. This PR fixes that issue by using kata-runtime when we are using
io.containerd.kata.v2 so we can get the information properly.

Fixes #3935

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>