### PR TITLE
docs: Update github labels archive documentation

### DIFF
--- a/cmd/github-labels/archive/README.md
+++ b/cmd/github-labels/archive/README.md
@@ -46,10 +46,10 @@ Run the following for reach repository:
 $ labeler scan -r ${github_repo_slug} ${output_file}
 ```
 
-For example, to save the labels for the `runtime` repository:
+For example, to save the labels for the `tests` repository:
 
 ```sh
-$ labeler scan -r kata-container/runtime runtime.yaml
+$ labeler scan -r kata-containers/tests tests.yaml
 
 ```
 


### PR DESCRIPTION
This PR updates the github labels archive documentation for kata 2.0

Fixes #3944

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>