### PR TITLE
metrics: Get kata extract environment for metrics

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -197,7 +197,7 @@ show_system_ctr_state() {
 }
 
 common_init(){
-	if [ "$CTR_RUNTIME" == "io.containerd.runc.v2" ] || [ "$RUNTIME" == "containerd-shim-kata-v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ] || [ "$RUNTIME" == "containerd-shim-kata-v2" ]; then
 		extract_kata_env
 	else
 		# We know we have nothing to do for runc or shimv2


### PR DESCRIPTION
This PR fixes the proper CTR RUNTIME to for kata 2.0 in order to
avoid the warning message of unrecognised runtime and get the proper
kata extract environment.

Fixes #3946

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>