### PR TITLE
CCv0 - test containerd release/1.5 - DO NOT MERGE

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -54,16 +54,14 @@ install_from_pr() {
 	echo "Trying to install containerd from a PR"
 	(
 		cd "${GOPATH}/src/${cri_containerd_repo}" >>/dev/null
-		git fetch origin pull/${cri_containerd_pr}/head:PR_BRANCH
-		git checkout "PR_BRANCH"
+		git fetch
+		git checkout release/1.5
 		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
 		# SH: The PR containerd version might not match the version.yaml one, so get from build
 		cri_containerd_version=$(_output/cri/bin/containerd --version | awk '{ print substr($3,2); }')
 		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAINERD_ARCH}.tar.gz"
-		echo "Tarball name is : '${tarball_name}'"
+		echo "Tarball name is: '${tarball_name}'"
 		sudo tar -xvf "./releases/${tarball_name}" -C /
-		# Clean up PR_BRANCH
-		git checkout main && git branch -D "PR_BRANCH"
 	)
 }
 


### PR DESCRIPTION
Temp change to test containerd release 1.5 branch with kata pipeline
- The containerd main branch is not compatible with kata's CRI test, so I want to see if the release/1.5 branch works, to investigate if we can use it as a based on our containerd CCv0 changes

Signed-off-by: stevenhorsman <steven@uk.ibm.com>