### PR TITLE
docs: Update github labels documentation with kata 2.0 repository

### DIFF
--- a/cmd/github-labels/README.md
+++ b/cmd/github-labels/README.md
@@ -30,7 +30,7 @@ repository (in order to generate the combined labels database) and the name of
 a file to write the combined database:
 
 ```sh
-$ ./github-labels.sh generate github.com/kata-containers/runtime /tmp/combined.yaml
+$ ./github-labels.sh generate github.com/kata-containers/kata-containers /tmp/combined.yaml
 ```
 
 This script validates the combined labels database by performing a number of

--- a/cmd/github-labels/github-labels.sh
+++ b/cmd/github-labels/github-labels.sh
@@ -149,7 +149,7 @@ Examples:
 
   # Generate combined labels database for runtime repo and write to
   # specified file
-  \$ ${script_name} generate github.com/kata-containers/runtime /tmp/out.yaml
+  \$ ${script_name} generate github.com/kata-containers/kata-containers /tmp/out.yaml
 
 EOT
 }


### PR DESCRIPTION
This PR updates github labels document to reflect kata 2.0 repositories

Fixes #3963

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>