### PR TITLE
snap: add snap build test for non-x86

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -196,4 +196,20 @@ else
 	"${ci_dir_name}/run.sh"
 fi
 
+test_snap_build() {
+	if [[ "${ID}" == "ubuntu" && "$(uname -m)" != "x86_64" ]]; then
+		echo "Test snap build"
+		sudo apt install -y snapcraft
+		pushd ${cidir}/../../kata-containers
+		sudo snapcraft -d snap --destructive-mode
+		# PREFIX is changed in snap build, change it back
+		PREFIX=
+		popd
+	else
+		echo "Skipping snap test because it is assumed to run elsewhere"
+	fi
+}
+
+test_snap_build
+
 popd


### PR DESCRIPTION
It's not easy for arm64 to test snap build in github action like x86 does,
thus, adding snap build test along with integration test.

Fixes: #3966
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>