### PR TITLE
ci: Fix cannot delete a non stopped container in s390x KSM test

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -180,7 +180,7 @@ clean_env_ctr()
 	info "Wait until the containers gets removed"
 	for i in "${containers[@]}"; do
 		tasks="$(sudo ctr task ls | grep $i || true)"
-		[ -n "$tasks" ] && sudo ctr tasks kill $tasks
+		[ -n "$tasks" ] && sudo ctr tasks kill -a $tasks
 	done
 
 	# do not stop if the command fails, it will be evaluated by waitForProcess


### PR DESCRIPTION
clean_env_ctr function was updated to kill all tasks on the
container.

This fixes the issue that prevents stop and delete
running tasks on runc containers.

Fixes #3961

Signed-off-by: David Esparza <david.esparza.borquez@intel.com>