### PR TITLE
ci: Kill tasks by whole word in clean_env_ctr

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -179,8 +179,8 @@ clean_env_ctr()
 
 	info "Wait until the containers gets removed"
 	for i in "${containers[@]}"; do
-		tasks="$(sudo ctr task ls | grep $i || true)"
-		[ -n "$tasks" ] && sudo ctr tasks kill $tasks
+		task="$(sudo ctr task ls | grep -E "\<${i}\>" | cut -f1 -d" " || true)"
+		[ -n "${task}" ] && sudo ctr task kill "${task}"
 	done
 
 	# do not stop if the command fails, it will be evaluated by waitForProcess


### PR DESCRIPTION
- grep container for whole word in tasks. Otherwise, e.g. `test1` can be
  caught when `test` is to be removed, and `test1` won't find anything.
- cut name out -- no point in killing `[PID] RUNNING`
- Rename this variable from `tasks` to `task` to avoid confusion. There
  will be no more than one task associated with the container name.

Fixes: #3961
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Btw, I could observe this on x86 too.