### PR TITLE
arm64: fix fail to download toolchain issue

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -49,7 +49,7 @@ build_uefi()
 
 	mkdir toolchain
 	pushd toolchain/
-	curl -LO "${TOOLCHAIN_SOURCE_URL}" && tar -xf "${TOOLCHAIN_ARCHIVE}"
+	curl -kLO "${TOOLCHAIN_SOURCE_URL}" && tar -xf "${TOOLCHAIN_ARCHIVE}"
 	popd
 
 	make -C acpica/


### PR DESCRIPTION
SSL certification fail when download compiler toolchain for building edk2.
here we disable curl SSL certificate validating to let it go.

Fixes: #3972
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>