### PR TITLE
metrics: Replace clean_env for clean_env_ctr

### DIFF
--- a/metrics/density/memory_usage_inside_container.sh
+++ b/metrics/density/memory_usage_inside_container.sh
@@ -69,7 +69,7 @@ EOF
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
 	metrics_json_save
-	clean_env
+	clean_env_ctr
 }
 
 main "$@"


### PR DESCRIPTION
This PR is replacing clean_env for clean_env_ctr which is the correct
function to clean an environment while using containerd for the
memory usage script.

Fixes #3976

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>