### PR TITLE
tracing: Skip agent test shutdown on Metrics CI

### DIFF
--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -760,7 +760,7 @@ setup()
 		exit 0
 	fi
 
-	[ "${METRICS_CI:-}" = "true" ] && {
+	[ "${CI_JOB:-}" = "METRICS" ] && {
 		info "Exiting as not running on metrics CI"
 		exit 0
 	}


### PR DESCRIPTION
We do not want to run the test shutdown on Metrics CI this PR will skip this test.

Fixes #3980

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>