### PR TITLE
makefile: Remove agent tracing shutdown test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ agent-shutdown:
 
 # Tracing requires the agent to shutdown cleanly,
 # so run the shutdown test first.
-tracing: agent-shutdown
+tracing:
 	bash tracing/tracing-test.sh
 
 vcpus:


### PR DESCRIPTION
The agent tracing shutdown test should only run on the CI JOB of
CRI_CONTAINERD_K8S_MINIMAL but currently is running on multiple CI JOBS
which are not the one that is indicated. Also the test is not even
working properly on the CRI_CONTAINERD_K8S_MINIMAL job as we can see
from https://github.com/kata-containers/tests/issues/3774 and the only
CI_JOB where tracing is running is the one that is having an issue.
This PR removes that test in order to avoid CI failures in other
CI JOBS.

Fixes #3986

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>