### PR TITLE
ci: Allow use entry point for new VM.

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -29,13 +29,15 @@ handle_error() {
 trap 'handle_error $LINENO' ERR
 
 # Repository to be tested
-repo_to_test="${1}"
+repo_to_test="${1:-}"
 [ -z "${repo_to_test}" ] && echo "kata repo no provided" && exit 1
 
 repo_to_test=${repo_to_test#"https://"}
 repo_to_test=${repo_to_test%".git"}
 
 # PR info provided by the caller
+ghprbPullId=${ghprbPullId:-}
+ghprbTargetBranch=${ghprbTargetBranch:-}
 export ghprbPullId
 export ghprbTargetBranch
 
@@ -48,12 +50,17 @@ tests_repo="github.com/kata-containers/tests"
 
 # Clone as golang would do it with GOPATH
 tests_repo_dir="${GOPATH}/src/${tests_repo}"
-mkdir -p "${tests_repo_dir}"
-git clone "https://${tests_repo}.git" "${tests_repo_dir}"
+[ -d "$tests_repo_dir" ] || git clone "https://${tests_repo}.git" "${tests_repo_dir}"
 cd "${tests_repo_dir}"
 
+echo "INFO: Running CI scripts for repo $repo_to_test"
 # Checkout to target branch: master, stable-X.Y, main etc
-git checkout "origin/${ghprbTargetBranch}"
+if [ "${ghprbTargetBranch}" != "" ]; then
+	echo "INFO: Target branch ${ghprbTargetBranch}"
+	git checkout "origin/${ghprbTargetBranch}"
+else
+	echo "INFO: No git target branch provided"
+fi
 
 # If the changes are in the repository to test:
 # Update the repository first so we can catch most of changes
@@ -61,11 +68,14 @@ git checkout "origin/${ghprbTargetBranch}"
 # So lets try to keep this file small, simple and generic to avoid need
 # update it in the future
 if [ "${repo_to_test}" == "${tests_repo}" ]; then
-	pr_number="${ghprbPullId}"
-	pr_branch="PR_${pr_number}"
-	git fetch origin "pull/${pr_number}/head:${pr_branch}"
-	git checkout "${pr_branch}"
-	git rebase "origin/${ghprbTargetBranch}"
+	if [ "$ghprbPullId" != "" ]; then
+		echo "INFO: Early test PR checkout to ${ghprbPullId}"
+		pr_number="${ghprbPullId}"
+		pr_branch="PR_${pr_number}"
+		git fetch origin "pull/${pr_number}/head:${pr_branch}"
+		git checkout "${pr_branch}"
+		git rebase "origin/${ghprbTargetBranch}"
+	fi
 fi
 
 if [ "${CI_JOB}" == "VFIO" ] && [ ${FORCE_JENKINS_JOB_BUILD} = 0 ]; then


### PR DESCRIPTION
- Dont fail if test repository is already cloned
- Checkout to target branch only if provided
e.g. 
```sh
#!/bin/bash

set -e
set -x

curl -OL https://raw.githubusercontent.com/kata-containers/tests/main/.ci/ci_entry_point.sh
export CI_JOB="CLOUD-HYPERVISOR-K8S-CONTAINERD"
export DEBUG=true
bash -x ci_entry_point.sh "https://github.com/kata-containers/kata-containers"
```

Signed-off-by: Carlos Venegas <jose.carlos.venegas.munoz@intel.com>