### PR TITLE
ci: Remove duplicated settings on CI JOB definition for metrics

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -201,23 +201,17 @@ case "${CI_JOB}" in
 	export experimental_kernel="true"
 	export experimental_qemu="true"
 	;;
-"METRICS")
+"METRICS"|"METRICS_EXPERIMENTAL")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	export METRICS_CI=1
-	;;
-"METRICS_EXPERIMENTAL")
-	init_ci_flags
-	export CRI_CONTAINERD="yes"
-	export CRI_RUNTIME="containerd"
-	export DEFVIRTIOFSCACHESIZE="1024"
-	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="yes"
-	export METRICS_CI=1
-	export experimental_kernel="true"
-	export experimental_qemu="true"
+	if [ "$CI_JOB" == "METRICS_EXPERIMENTAL" ]; then
+		export DEFVIRTIOFSCACHESIZE="1024"
+		export experimental_kernel="true"
+		export experimental_qemu="true"
+	fi
 ;;
 esac


### PR DESCRIPTION
This PR simplifies and removes the duplicated setting for the CI JOBS
flags for METRICS and METRICS_EXPERIMENTAL.

Fixes #3991

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>