### PR TITLE
ci: fix install failure for the webhook

### DIFF
--- a/kata-webhook/Dockerfile
+++ b/kata-webhook/Dockerfile
@@ -5,8 +5,8 @@ FROM golang:latest AS builder
 
 WORKDIR /go/src/kata-pod-annotate
 
-COPY ../vendor ./
-COPY . ./
+COPY vendor/ ./vendor
+COPY kata-webhook/* ./
 RUN CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate
 
 FROM alpine:latest

--- a/kata-webhook/README.md
+++ b/kata-webhook/README.md
@@ -14,7 +14,7 @@ Kubernetes YAML files required to instantiate the admission
 controller.
 
 ```bash
-$ docker build -t quay.io/kata-containers/kata-webhook-example:latest .
+$ docker build -t quay.io/kata-containers/kata-webhook-example:latest -f Dockerfile ..
 ```
 
 > **Note:**

--- a/kata-webhook/deploy/webhook-registration.yaml.tpl
+++ b/kata-webhook/deploy/webhook-registration.yaml.tpl
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-annotate-webhook

--- a/kata-webhook/deploy/webhook-registration.yaml.tpl
+++ b/kata-webhook/deploy/webhook-registration.yaml.tpl
@@ -11,6 +11,9 @@ metadata:
     kind: mutator
 webhooks:
   - name: pod-annotate-webhook.kata.xyz
+    sideEffects: None
+    failurePolicy: Ignore
+    admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: pod-annotate-webhook

--- a/kata-webhook/go.mod
+++ b/kata-webhook/go.mod
@@ -1,0 +1,3 @@
+module module-path
+
+go 1.16


### PR DESCRIPTION
Update the webhook reference to stop using the deprecated reference.

Fixes: #3996

Signed-off-by: Julien Ropé <jrope@redhat.com>