### PR TITLE
ci: Add Makefile target for QAT

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -89,6 +89,13 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	;;
+"BAREMETAL-QAT")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="qemu"
+	export KUBERNETES="no"
+	;;
 "CRI_CONTAINERD"|"CRI_CONTAINERD_K8S")
 	# This job only tests containerd + k8s
 	init_ci_flags

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -33,6 +33,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running pmem integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		;;
+	"BAREMETAL-QAT")
+		echo "INFO: Running QAT integration test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
+		;;
 	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_INITRD")
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ log-parser:
 pentest:
 	bash -f pentest/all.sh
 
+qat:
+	bash -f integration/qat/qat_test.sh
+
 agent-shutdown:
 	bash tracing/test-agent-shutdown.sh
 
@@ -195,6 +198,7 @@ help:
 	list-install-targets \
 	log-parser \
 	pentest \
+	qat \
 	sandbox-cgroup \
 	test \
 	tracing \


### PR DESCRIPTION
Add Makefile target for QAT and define QAT value for CI_JOB
environment variable

fixes #4000

Signed-off-by: Julio Montes <julio.montes@intel.com>