### PR TITLE
test: Remove terminal for docker run in qat test

### DIFF
--- a/integration/qat/qat_test.sh
+++ b/integration/qat/qat_test.sh
@@ -56,7 +56,7 @@ build_install_qat_image_and_kernel() {
 	sudo rm -rf output && mkdir -p output
 	sudo docker rmi -f kataqat
 	sudo docker build --rm --label kataqat --tag kataqat:latest .
-	sudo docker run -ti --rm --privileged -e "QAT_DRIVER_VER=${QAT_DRIVER_VER}" -e "QAT_DRIVER_URL=${QAT_DRIVER_URL}" -v /dev:/dev -v ${PWD}/output:/output  kataqat
+	sudo docker run -i --rm --privileged -e "QAT_DRIVER_VER=${QAT_DRIVER_VER}" -e "QAT_DRIVER_URL=${QAT_DRIVER_URL}" -v /dev:/dev -v ${PWD}/output:/output  kataqat
 
 	sudo rm -f ${kata_vmlinux_path} ${kata_image_path}
 


### PR DESCRIPTION
To avoid the failure of the "input device is not a TTY" this
PR removes t from docker run.

Fixes #4002

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>