### PR TITLE
snap: check if kata_repo_dir exist before go into

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -200,7 +200,8 @@ test_snap_build() {
 	if [[ "${ID}" == "ubuntu" && "$(uname -m)" != "x86_64" ]]; then
 		echo "Test snap build"
 		sudo apt install -y snapcraft
-		pushd ${cidir}/../../kata-containers
+		[ ! -d "${kata_repo_dir}" ] && go get -d "${kata_repo}" || true
+		pushd "${kata_repo_dir}"
 		sudo snapcraft -d snap --destructive-mode
 		# PREFIX is changed in snap build, change it back
 		PREFIX=


### PR DESCRIPTION
"kata_repo_dir" may not exist. So before go into it, do check
and get it if there is no such dir.

Depends-on: github.com/kata-containers/kata-containers#2706
Fixes: #4004
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>