### PR TITLE
ci: remove -f from Makefile qat target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ pentest:
 	bash -f pentest/all.sh
 
 qat:
-	bash -f integration/qat/qat_test.sh
+	bash integration/qat/qat_test.sh
 
 agent-shutdown:
 	bash tracing/test-agent-shutdown.sh


### PR DESCRIPTION
Remove -f from Makefile qat target to honor wild card [asterisk]
for filename expansion in globbing.

fixes #4008

Signed-off-by: Julio Montes <julio.montes@intel.com>