### PR TITLE
integration/kubernetes: volume tests for empty/missing configmap/secret

### DIFF
--- a/integration/kubernetes/k8s-optional-empty-configmap.bats
+++ b/integration/kubernetes/k8s-optional-empty-configmap.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	get_pod_config_dir
+}
+
+@test "Optional and Empty ConfigMap Volume for a pod" {
+	config_name="empty-config"
+	pod_name="optional-empty-config-test-pod"
+
+	# Create Empty ConfigMap
+	kubectl create configmap "$config_name"
+
+	# Create a pod that consumes the "empty-config" and "optional-missing-config" ConfigMaps as volumes
+	kubectl create -f "${pod_config_dir}/pod-optional-empty-configmap.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+	# Check configmap folders exist
+	kubectl exec $pod_name -- sh -c ls /empty-config
+	kubectl exec $pod_name -- sh -c ls /optional-missing-config
+}
+
+teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+	kubectl delete configmap "$config_name"
+}

--- a/integration/kubernetes/k8s-optional-empty-secret.bats
+++ b/integration/kubernetes/k8s-optional-empty-secret.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	get_pod_config_dir
+}
+
+@test "Optional and Empty Secret Volume for a pod" {
+	secret_name="empty-secret"
+	pod_name="optional-empty-secret-test-pod"
+
+	# Create Empty Secret
+	kubectl create secret generic "$secret_name"
+
+	# Create a pod that consumes the "empty-secret" and "optional-missing-secret" Secrets as volumes
+	kubectl create -f "${pod_config_dir}/pod-optional-empty-secret.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+	# Check secret folders exist
+	kubectl exec $pod_name -- sh -c ls /empty-secret
+	kubectl exec $pod_name -- sh -c ls /optional-missing-secret
+}
+
+teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+	kubectl delete secret "$secret_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -36,6 +36,8 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-memory.bats" \
 	"k8s-number-cpus.bats" \
 	"k8s-oom.bats" \
+	"k8s-optional-empty-configmap.bats" \
+	"k8s-optional-empty-secret.bats" \
 	"k8s-parallel.bats" \
 	"k8s-pid-ns.bats" \
 	"k8s-pod-quota.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: optional-empty-config-test-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+    - name: test-container
+      image: quay.io/prometheus/busybox:latest
+      command: ["tail", "-f", "/dev/null"]
+      volumeMounts:
+        - mountPath: /empty-config
+          name: empty-config
+        - mountPath: /optional-missing-config
+          name: optional-missing-config
+  volumes:
+    - name: empty-config
+      configMap:
+        name: empty-config
+    - name: optional-missing-config
+      configMap:
+        name: optional-missing-config
+        optional: true
+  restartPolicy: Never

--- a/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: optional-empty-secret-test-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+    - name: test-container
+      image: quay.io/prometheus/busybox:latest
+      command: ["tail", "-f", "/dev/null"]
+      volumeMounts:
+        - mountPath: /empty-secret
+          name: empty-secret
+        - mountPath: /optional-missing-secret
+          name: optional-missing-secret
+  volumes:
+    - name: empty-secret
+      secret:
+        secretName: empty-secret
+    - name: optional-missing-secret
+      secret:
+        secretName: optional-missing-secret
+        optional: true
+  restartPolicy: Never


### PR DESCRIPTION
These tests makes sure that if a configmap/secret is present but empty, or if the volume is declared `optional: true` that the agent will still create the volumeMount folder.

Signed-off-by: Simon Kaegi <simon_kaegi@ca.ibm.com>