### PR TITLE
qemu: get qemu version of arm from arch independent label

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -8,8 +8,8 @@ set -e
 
 source "${cidir}/lib.sh"
 
-CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.architecture.aarch64.version")
-CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.architecture.aarch64.tag")
+CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.version")
+CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu.tag")
 QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
 # Remove 'https://' from the repo url to be able to git clone the repo
 QEMU_REPO=${QEMU_REPO_URL/https:\/\//}


### PR DESCRIPTION
It's easy to maintain to keep qemu version of arm in consistent with
other arches.

Depends-on: github.com/kata-containers/kata-containers#2732
Fixes: #4019
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>