### PR TITLE
Backport ci: fix deps resolving

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -12,7 +12,6 @@ set -o errtrace
 
 cidir=$(dirname "$0")
 source "/etc/os-release" || source "/usr/lib/os-release"
-source "${cidir}/lib.sh"
 
 CI_JOB=${CI_JOB:-}
 ghprbPullId=${ghprbPullId:-}
@@ -165,6 +164,7 @@ fi
 # according to the job type.
 pushd "${GOPATH}/src/${tests_repo}"
 source ".ci/ci_job_flags.sh"
+source "${cidir}/lib.sh"
 popd
 
 "${ci_dir_name}/setup.sh"


### PR DESCRIPTION
Fixes: #4021
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

This also fixes the issue of checking out `kata-containers:main` when `stable` should be used.
/cc @snir911 @GabyCT