### PR TITLE
metrics: Recalculate KSM memory values for metrics

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -42,9 +42,9 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 44380.0
-minpercent = 10.0
-maxpercent = 10.0
+midval = 54538.11
+minpercent = 15.0
+maxpercent = 15.0
 
 [[metric]]
 name = "blogbench"


### PR DESCRIPTION
It seems that the change to qemu 6.1 introduced higher ksm memory values
which makes the metrics CI unstable. This PR is recalculating the value
for the metrics limits.

Fixes #4023

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>