### PR TITLE
metrics: support pulling container images from different registries

### DIFF
--- a/metrics/storage/blogbench_dockerfile/Dockerfile.in
+++ b/metrics/storage/blogbench_dockerfile/Dockerfile.in
@@ -1,11 +1,11 @@
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2021 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # Set up an Ubuntu image with 'blogbench' installed
 
 # Usage: FROM [image name]
-FROM public.ecr.aws/lts/ubuntu
+FROM @UBUNTU_REGISTRY@/ubuntu
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"

--- a/metrics/storage/fio_dockerfile/Dockerfile.in
+++ b/metrics/storage/fio_dockerfile/Dockerfile.in
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set up an Ubuntu image with the components needed to run `fio`
-FROM ubuntu
+FROM @UBUNTU_REGISTRY@/ubuntu
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"

--- a/metrics/storage/web-tooling-dockerfile/Dockerfile.in
+++ b/metrics/storage/web-tooling-dockerfile/Dockerfile.in
@@ -5,7 +5,7 @@
 # Set up an Ubuntu image with 'web tooling' installed
 
 # Usage: FROM [image name]
-FROM ubuntu:latest
+FROM @UBUNTU_REGISTRY@/ubuntu:latest
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"


### PR DESCRIPTION
Mitigate image registries rate limit issue.
Define a list of public container registries and use it to build
the images used to run metrics.

fixes #3968

Signed-off-by: Julio Montes <julio.montes@intel.com>