### PR TITLE
ci: Checkout reference branch in Kata repo

### DIFF
--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -99,10 +99,10 @@ clone_repos() {
 			git merge "origin/${branch}"
 			# And show what we merged on top of to aid debugging
 			git log --oneline "origin/${branch}~1..HEAD"
-		else
+		elif [ -n "${branch}" ]
+		then
 			echo "Checking out to ${branch}"
-			#TODO: remove next commented lines
-			#git fetch origin && git checkout "$branch"
+			git fetch origin && git checkout "$branch"
 		fi
 		popd
 	done


### PR DESCRIPTION
When we have a PR on branch `X`, the kata-containers/kata-containers
repo should use branch `X` too. Add (re-enable?) this functionality in
`.ci/resolve-kata-dependencies.sh`.

Fixes: #4030
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

@chavafg were you going anywhere else with that TODO?