### PR TITLE
ci: Install gcc pre-static checks

### DIFF
--- a/.ci/install_gcc.sh
+++ b/.ci/install_gcc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+source "$(dirname "${0}")/../lib/common.bash"
+
+declare -A package_managers
+package_managers=([debian]=apt [fedora]=dnf [suse]=zypper)
+
+info "Install gcc"
+for distro in "${!package_managers[@]}"; do
+	if grep -Eq "\<${distro}\>" /etc/os-release 2> /dev/null; then
+		sudo "${package_managers["${distro}"]}" install -y gcc
+		exit 0
+	fi
+done
+
+die "Failed to install gcc"

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -132,6 +132,7 @@ if [ "${METRICS_CI}" = "false" ]; then
 	# We run static checks on GitHub Actions for x86_64, 
 	# hence run them on Jenkins for non-x86_64 only.	
 	if [ "$arch" != "x86_64" ]; then
+		"${ci_dir_name}/install_gcc.sh"
 		specific_branch=""
 		# If not a PR, we are testing on stable or master branch.
 		[ -z "$pr_number" ] && specific_branch="true"


### PR DESCRIPTION
Static checks require gcc and should be run before the full setup to
catch errors early for the full setup takes quite some time. Add a
simple `.ci/install_gcc.sh` and call it.

Fixes: #4044
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @Amulyam24 @jongwu