### PR TITLE
ci: Create config-settings.go pre-static checks

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -132,6 +132,9 @@ if [ "${METRICS_CI}" = "false" ]; then
 	# We run static checks on GitHub Actions for x86_64, 
 	# hence run them on Jenkins for non-x86_64 only.	
 	if [ "$arch" != "x86_64" ]; then
+		if [ "${kata_repo}" == "${katacontainers_repo}" ]; then
+			make -C src/runtime pkg/katautils/config-settings.go
+		fi
 		specific_branch=""
 		# If not a PR, we are testing on stable or master branch.
 		[ -z "$pr_number" ] && specific_branch="true"


### PR DESCRIPTION
Static checks need this file so that modules like kata-runtime can be
built and tested.

Fixes: #4044
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @Amulyam24 @jongwu