### PR TITLE
metrics: Replace clean_env for clean_env_ctr for launch times script

### DIFF
--- a/metrics/time/launch_times.sh
+++ b/metrics/time/launch_times.sh
@@ -258,7 +258,7 @@ main() {
 	done
 	metrics_json_end_array "Results"
 	metrics_json_save
-	clean_env
+	clean_env_ctr
 }
 
 main "$@"


### PR DESCRIPTION
This PR replaces the clean_env for the proper clean_env_ctr function which
is the correct one to clean an environment that is using containerd.

Fixes #4053

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>