### PR TITLE
metrics: Enable memory inside container for clh metrics

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -51,9 +51,6 @@ run() {
 		# (so set a token 5s wait)
 		bash density/memory_usage.sh 20 5
 
-		# Run the density test inside the container
-		bash density/memory_usage_inside_container.sh
-
 		# Run the time tests
 		bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 	fi
@@ -61,6 +58,9 @@ run() {
 	# Run storage tests
 	restart_docker_service
 	bash storage/blogbench.sh
+
+	# Run the density test inside the container
+	bash density/memory_usage_inside_container.sh
 
 	# Skip: Issue: https://github.com/kata-containers/tests/issues/3203
 	# Run the cpu statistics test

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
@@ -8,6 +8,19 @@
 # values set specifically for packet.com c1.small worker.
 
 [[metric]]
+name = "memory-footprint-inside-container"
+type = "json"
+description = "measure memory inside the container"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"memory-footprint-inside-container\".Results | .[] | .memtotal.Result"
+checktype = "mean"
+midval = 4139564.0
+minpercent = 5.0
+maxpercent = 5.0
+
+[[metric]]
 name = "blogbench"
 type = "json"
 description = "measure container average of blogbench write"


### PR DESCRIPTION
This PR enables the memory inside container for the clh metrics baseline.

Fixes #4063

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>