### PR TITLE
metrics: Enable memory footprint test on clh

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -47,16 +47,18 @@ run() {
 			disable_ksm
 		fi
 
-		# Run the density tests - no KSM, so no need to wait for settle
-		# (so set a token 5s wait)
-		bash density/memory_usage.sh 20 5
-
 		# Run the time tests
 		bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 	fi
 
-	# Run storage tests
 	restart_docker_service
+
+	# Run the density tests - no KSM, so no need to wait for settle
+	# (so set a token 5s wait)
+	disable_ksm
+	bash density/memory_usage.sh 20 5
+
+	# Run storage tests
 	bash storage/blogbench.sh
 
 	# Run the density test inside the container

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
@@ -8,6 +8,19 @@
 # values set specifically for packet.com c1.small worker.
 
 [[metric]]
+name = "memory-footprint"
+type = "json"
+description = "measure container average footprint"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
+checktype = "mean"
+midval = 122481.45
+minpercent = 5.0
+maxpercent = 5.0
+
+[[metric]]
 name = "memory-footprint-inside-container"
 type = "json"
 description = "measure memory inside the container"


### PR DESCRIPTION
This PR enables memory footprint test for metrics CI for clh.

Fixes #4065

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>