### PR TITLE
ci: skip "ctr logging [tty=true]"

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -11,6 +11,7 @@ declare -a skipCRIOTests=(
 'test "ctr lifecycle"'
 'test "ctr logging"'
 'test "ctr journald logging"'
+'test "ctr logging \[tty=true\]"' # FIXME: See https://github.com/kata-containers/tests/issues/4069
 'test "ctr log max"'
 'test "ctr log max with minimum value"'
 'test "ctr partial line logging"'


### PR DESCRIPTION
Adding this test to the skip list to prevent random failures of the CI.

Fixes: #4067

Signed-off-by: Julien Ropé <jrope@redhat.com>