### PR TITLE
metrics: Enable memory footprint inside container for QEMU

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -71,3 +71,16 @@ checktype = "mean"
 midval = 55808.66
 minpercent = 10.0
 maxpercent = 10.0
+
+[[metric]]
+name = "memory-footprint-inside-container"
+type = "json"
+description = "measure memory inside the container"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"memory-footprint-inside-container\".Results | .[] | .memtotal.Result"
+checktype = "mean"
+midval = 4139564.0
+minpercent = 5.0
+maxpercent = 5.0


### PR DESCRIPTION
This PR enables the memory footprint inside container for QEMU in
order to be run on the metrics CI.

Fixes #4070

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>