### PR TITLE
ci: Fix docker installation and missing dependency for Ubuntu

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -358,22 +358,24 @@ gen_clean_arch() {
 		delete_containerd_cri_stale_resource
 	fi
 
-	#reset k8s service may impact metrics test on x86_64, so limit it to arm64
-	[ $(uname -m) == "aarch64" -a "$(pgrep kubelet)" != "" ] && sudo sh -c 'kubeadm reset -f'
-	info "Remove installed kubernetes packages and configuration"
-	if [ "$ID" == ubuntu ]; then
-		sudo rm -rf /etc/systemd/system/kubelet.service.d
-		sudo apt-get autoremove -y kubeadm kubelet kubectl \
-			$(dpkg -l | awk '{print $2}' | grep -E '^(containerd(.\io)?|docker(\.io|-ce(-cli)?))$')
-	fi
-	# Remove existing k8s related configurations and binaries.
-	sudo sh -c 'rm -rf /opt/cni/bin/*'
-	sudo sh -c 'rm -rf /etc/cni /etc/kubernetes/'
-	sudo sh -c 'rm -rf /var/lib/cni /var/lib/etcd /var/lib/kubelet'
-	sudo sh -c 'rm -rf /run/flannel'
+	if [[ $CI_JOB != "METRICS" ]]; then
+		#reset k8s service may impact metrics test on x86_64, so limit it to arm64
+		[ $(uname -m) == "aarch64" -a "$(pgrep kubelet)" != "" ] && sudo sh -c 'kubeadm reset -f'
+		info "Remove installed kubernetes packages and configuration"
+		if [ "$ID" == ubuntu ]; then
+			sudo rm -rf /etc/systemd/system/kubelet.service.d
+			sudo apt-get autoremove -y kubeadm kubelet kubectl \
+				$(dpkg -l | awk '{print $2}' | grep -E '^(containerd(.\io)?|docker(\.io|-ce(-cli)?))$')
+		fi
+		# Remove existing k8s related configurations and binaries.
+		sudo sh -c 'rm -rf /opt/cni/bin/*'
+		sudo sh -c 'rm -rf /etc/cni /etc/kubernetes/'
+		sudo sh -c 'rm -rf /var/lib/cni /var/lib/etcd /var/lib/kubelet'
+		sudo sh -c 'rm -rf /run/flannel'
 
-	info "Clean up stale network interface"
-	cleanup_network_interface
+		info "Clean up stale network interface"
+		cleanup_network_interface
+	fi
 
 	if [[ $CI_JOB != "METRICS" ]]; then
 		info "Remove Kata package repo registrations"

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -104,11 +104,10 @@ install_docker(){
 		log_message "Installing docker"
 		pkg_name="docker-ce"
 		if [ "$ID" == "ubuntu" ]; then
-			sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common
+			sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common apt-utils
 			repo_url="https://download.docker.com/linux/ubuntu"
 			curl -fsSL "${repo_url}/gpg" | sudo apt-key add -
 			sudo -E add-apt-repository "deb [arch=${arch}] ${repo_url} $(lsb_release -cs) stable"
-			sudo -E apt-get update
 			sudo -E apt-get -y install "${pkg_name}"
 		elif [ "$ID" == "fedora" ]; then
 			repo_url="https://download.docker.com/linux/fedora/docker-ce.repo"


### PR DESCRIPTION
This PR adds a missing dependency for docker installation in order to avoid
an issue like delaying package configuration, since apt-utils is not installed
and it also removes the performing of an update after doing docker installation
as this is related with an issue see moby/moby#41792.

Fixes #3982

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>