### PR TITLE
ci: Instructions to run the CI locally

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -112,3 +112,41 @@ based on those labels. Possible labels are listed below:
 >   - CI machine issues.
 >   - Problems with third party checks.
 >   - Breaking circular dependencies between PRs.
+
+### Running the CI locally
+
+The CI can run on a local VM using the following instructions:
+- Setup a Fedora VM
+  - Create a Fedora VM having at least 4G RAM and a 30GB disk.
+  - Create a `sudo` user that does not require `sudo` password.
+  - Run the bash commands replacing the `fedora` user with the created one and the`CI_JOB` with the desired one:
+    ```sh
+    dnf install -y git vim make wget openssl driverctl pciutils
+    dnf remove -y qemu-guest-agent
+    wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+    sudo -H -u fedora bash -c 'mkdir -p ~/go/src/github.com/kata-containers'
+    sudo -H -u fedora bash -c 'cd ~/go/src/github.com/kata-containers && git clone https://github.com/kata-containers/tests.git'
+    sudo -H -u fedora bash -c 'echo export GOPATH=/home/fedora/go >> ~/.bashrc'
+    sudo -H -u fedora bash -c 'echo export PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH >> ~/.bashrc'
+    sudo -H -u fedora bash -c 'echo export USE_DOCKER=true >> ~/.bashrc'
+    sudo -H -u fedora bash -c 'echo export CI_JOB="CRIO_K8S" >> ~/.bashrc'
+    sudo -H -u fedora bash -c 'echo cd ~/go/src/github.com/kata-containers/tests >> ~/.bashrc'
+    sudo -H -u fedora bash -c 'echo source .ci/ci_job_flags.sh >> ~/.bashrc'
+    grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+    ```
+  - Reboot the VM
+- Running the tests
+  - Run the setup script once
+    ```sh
+    .ci/setup.sh
+    ```
+  - Run the tests script as many time as needed
+    ```sh
+    .ci/run.sh
+    ```
+  - Special configurations in order to run the VFIO test
+    - Edit the VM configuration to include 2 virtio-net device and a `vIOMMU`.
+    - Update the kernel command line:
+      ```sh
+      grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0 intel_iommu=on iommu=pt"
+      ```


### PR DESCRIPTION
Add instructions on how to run the CI on a local VM.
Currently only the Fedora instructions are listed, other Operating
Systems might need further or less tweaks.

Fixes #4073

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>