### PR TITLE
metrics: Update minimum limit for metrics boot time

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric4.toml
@@ -17,7 +17,7 @@ description = "measure container lifecycle timings"
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.67
-minpercent = 15.0
+minpercent = 20.0
 maxpercent = 10.0
 
 [[metric]]


### PR DESCRIPTION
This PR updates the minimum limit for the boot time metrics as it seems that
the boot time sometimes is less of the current minimum limit.

Fixes #4075

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>