### PR TITLE
ci: Fix random failures in starting docker.socket

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -178,6 +178,8 @@ install_docker(){
 		# If tag received is invalid, then return an error message
 		die "Unrecognized tag. Tag supported is: swarm"
 	fi
+	sudo systemctl daemon-reload
+	sudo systemctl start docker.socket
 	restart_docker_service
 	sudo gpasswd -a ${USER} docker
 	sudo chmod g+rw /var/run/docker.sock


### PR DESCRIPTION
Sometimes we hit random failures in restarting docker.service and we
got the following error failed to load listeners: no sockets found via
socket activation: make sure the service was started by systemd. This PR
tries to avoid hitting that issue.

Fixes #4092

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>