### PR TITLE
stable-2.2 | k8s: add test to check capabilities of pod

### DIFF
--- a/integration/kubernetes/k8s-caps.bats
+++ b/integration/kubernetes/k8s-caps.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+        export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+        pod_name="pod-caps"
+        get_pod_config_dir
+# We expect the capabilities mask to very per distribution, runtime
+# configuration. Even for this, we should expect a few common items to
+# not be set in the mask unless we are failing to apply capabilities. If
+# we fail to configure, we'll see all bits set for permitted: 0x03fffffffff
+# We do expect certain parts of the mask to be common when we set appropriately:
+#  b20..b23 should be cleared for all (no CAP_SYS_{PACCT, ADMIN, NICE, BOOT})
+#  b0..b11 are consistent across the distros:
+#  0x5fb: 0101 1111 1011
+#         | |        \- should be cleared (CAP_DAC_READ_SEARCH)
+#         |  \- should be cleared (CAP_LINUX_IMMUTABLE)
+#          \- should be cleared (CAP_NET_BROADCAST)
+# Example match:
+#   CapPrm:       00000000a80425fb
+        expected="CapPrm.*..0..5fb$"
+}
+
+@test "Check capabilities of pod" {
+        # Create pod
+        kubectl create -f "${pod_config_dir}/pod-caps.yaml"
+        # Check pod creation
+        kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+        kubectl logs "$pod_name" | grep -q "$expected"
+        kubectl exec "$pod_name" -- sh -c "cat /proc/self/status" | grep -q "$expected"
+}
+
+teardown() {
+        # Debugging information
+        echo "expected capability mask:"
+        echo "$expected"
+        echo "observed: "
+        kubectl logs "pod/$pod_name"
+        kubectl exec "$pod_name" -- sh -c "cat /proc/self/status | grep Cap"
+        kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -21,6 +21,7 @@ trap '${kubernetes_dir}/cleanup_env.sh' EXIT
 
 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-block-volume.bats" \
+	"k8s-caps.bats" \
 	"k8s-configmap.bats" \
 	"k8s-copy-file.bats" \
 	"k8s-cpu-ns.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-caps
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+    - name: test-container
+      image: quay.io/prometheus/busybox:latest
+      command: ["sh"]
+      args: ["-c", "cat /proc/self/status | grep Cap && sleep infinity"]
+  restartPolicy: Never


### PR DESCRIPTION
Check permitted capabilities of a given container process, as well as
from exec session into same container.

Fixes: #4081

Signed-off-by: Eric Ernst <eric_ernst@apple.com>