### PR TITLE
static-checks: skip check_headers on .dockerignore files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -475,6 +475,7 @@ static_check_license_headers()
 		local missing=$(egrep \
 			--exclude=".git/*" \
 			--exclude=".gitignore" \
+			--exclude=".dockerignore" \
 			--exclude="Gopkg.lock" \
 			--exclude="*.gpl.c" \
 			--exclude="*.ipynb" \


### PR DESCRIPTION
We'll need to add a `.dockerignore` file as part of our kata-deploy
tool.  However, `static-checks.sh` would try to check for the expected
headers in that file, leading to a breakage.

In order to avoid sych a breakage, let's treat the `.dockerignore` file
exactly as we treat the `.gitignore` files, and exclude it from the
header_check.

Fixes: #4095

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>