### PR TITLE
ci: Add QAT CI job

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -89,7 +89,7 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	;;
-"BAREMETAL-QAT")
+"BAREMETAL-QAT"|"QAT")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -33,7 +33,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running pmem integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		;;
-	"BAREMETAL-QAT")
+	"BAREMETAL-QAT"|"QAT")
 		echo "INFO: Running QAT integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;

--- a/integration/qat/qat_test.sh
+++ b/integration/qat/qat_test.sh
@@ -18,6 +18,7 @@ source "${dir_path}/../../lib/common.bash"
 source "${dir_path}/../../.ci/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 arch=$("${dir_path}"/../../.ci/kata-arch.sh -d)
+CI_JOB="${CI_JOB:-}"
 
 QAT_DRIVER_VER=qat1.7.l.4.14.0-00031.tar.gz
 QAT_DRIVER_URL=https://downloadmirror.intel.com/30178/eng/${QAT_DRIVER_VER}
@@ -131,12 +132,12 @@ run_test() {
 }
 
 main() {
-	trap cleanup EXIT QUIT KILL
-	init
+	[[ $CI_JOB != "BAREMETAL-QAT" ]] || trap cleanup EXIT QUIT KILL
+	[[ $CI_JOB != "BAREMETAL-QAT" ]] || init
 	build_install_qat_image_and_kernel
 	build_openssl_image
-	bind_vfio_dev
-	run_test
+	[[ $CI_JOB != "BAREMETAL-QAT" ]] || bind_vfio_dev
+	[[ $CI_JOB != "BAREMETAL-QAT" ]] || run_test
 }
 
 main


### PR DESCRIPTION
This PR adds the possibility to build QAT to avoid regressions or
failures, however, this will not run the test as a special hardware
is needed.

Fixes #4100

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>