### PR TITLE
metrics: Enable boot time metrics for clh

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -46,9 +46,6 @@ run() {
 			# And now ensure KSM is turned off for the rest of the tests
 			disable_ksm
 		fi
-
-		# Run the time tests
-		bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 	fi
 
 	restart_docker_service
@@ -63,6 +60,9 @@ run() {
 
 	# Run the density test inside the container
 	bash density/memory_usage_inside_container.sh
+
+	# Run the time tests
+	bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 
 	# Skip: Issue: https://github.com/kata-containers/tests/issues/3203
 	# Run the cpu statistics test

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric4.toml
@@ -8,6 +8,19 @@
 # values set specifically for packet.com c1.small worker.
 
 [[metric]]
+name = "boot-times"
+type = "json"
+description = "measure container lifecycle timings"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
+checktype = "mean"
+midval = 0.60
+minpercent = 15.0
+maxpercent = 15.0
+
+[[metric]]
 name = "memory-footprint"
 type = "json"
 description = "measure container average footprint"


### PR DESCRIPTION
This PR enables the boot time metrics test for clh.

Fixes #4104

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>