### PR TITLE
metrics: Support memory inside test in history tool

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -41,6 +41,9 @@ test_queries+=(".\"memory-footprint\".Results | .[] | .average.Result")
 tests+=("memory-footprint-ksm")
 test_queries+=(".\"memory-footprint-ksm\".Results | .[] | .average.Result")
 
+tests+=("memory-footprint-inside-container")
+test_queries+=(".\"memory-footprint-inside-container\".Results | .[] | .memtotal.Result")
+
 # What is the base URL of the Jenkins server
 url_base="http://jenkins.katacontainers.io/job"
 


### PR DESCRIPTION
This PR includes the memory inside test at the history tool.

Fixes #4109

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>