### PR TITLE
k8s: Add seccomp support test

### DIFF
--- a/integration/kubernetes/k8s-seccomp.bats
+++ b/integration/kubernetes/k8s-seccomp.bats
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	extract_kata_env
+
+	# Ensure setting seccomp mode is allowed on guest
+	sudo sed -i 's/disable_guest_seccomp=true/disable_guest_seccomp=false/' ${RUNTIME_CONFIG_PATH}
+
+	pod_name="seccomp-container"
+	get_pod_config_dir
+}
+
+@test "Support seccomp runtime/default profile" {
+	expected_seccomp_mode="2"
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pod-seccomp.yaml"
+
+	# Wait it to complete
+	cmd="kubectl get pods ${pod_name} | grep Completed"
+	waitForProcess "${wait_time}" "${sleep_time}" "${cmd}"
+
+	# Expect Seccomp on mode 2 (filter)
+	seccomp_mode="$(kubectl logs ${pod_name} | sed 's/Seccomp:\s*\([0-9]\)/\1/')"
+	[ "$seccomp_mode" -eq "$expected_seccomp_mode" ]
+}
+
+teardown() {
+	# For debugging purpose
+	echo "seccomp mode is ${seccomp_mode}, expected $expected_seccomp_mode"
+	kubectl describe "pod/${pod_name}"
+
+	kubectl delete -f "${pod_config_dir}/pod-seccomp.yaml" || true
+	sudo sed -i 's/disable_guest_seccomp=false/disable_guest_seccomp=true/'\
+		${RUNTIME_CONFIG_PATH}
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -47,6 +47,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-qos-pods.bats" \
 	"k8s-replication.bats" \
 	"k8s-scale-nginx.bats" \
+	"k8s-seccomp.bats" \
 	"k8s-sysctls.bats" \
 	"k8s-security-context.bats" \
 	"k8s-shared-volume.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/pod-seccomp.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-seccomp.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2021 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccomp-container
+spec:
+  runtimeClassName: kata
+  terminationGracePeriodSeconds: 0
+  restartPolicy: Never
+  containers:
+  - name: busybox
+    image: quay.io/prometheus/busybox:latest
+    command: ["grep", "Seccomp:", "/proc/self/status"]
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault


### PR DESCRIPTION
Added a test case which reproduces the k8s e2e test:
[k8s.io] [sig-node] Security Context should support seccomp runtime/default [LinuxOnly]

The test creates a container configured to use the "runtime/default" seccomp profile, then
it checks the container process is subject to seccomp mode "2" (filtering).

Fixes #1476
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>