### PR TITLE
crio: Use k8s 1.22 for the external cri-o ci

### DIFF
--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -37,7 +37,7 @@ export CI_JOB="EXTERNAL_CRIO"
 export INSTALL_KATA="yes"
 export GO111MODULE=auto
 
-latest_release="1.21"
+latest_release="1.22"
 
 sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]

--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -56,9 +56,6 @@ pr_branch="PR_${pr_number}"
 branch_release_number=$(echo ${PULL_BASE_REF} | cut -d'-' -f 2)
 [ "$branch_release_number" == "main" ] && branch_release_number=${latest_release}
 
-# Workaround to test release-1.22 against kubernetes 1.21, while we figure out the needed fixes for our kata webhook.
-[ "$branch_release_number" == "1.22" ] && branch_release_number=${latest_release}
-
 export ghprbGhRepository="${REPO_OWNER}/${REPO_NAME}"
 export GOROOT="/usr/local/go"
 


### PR DESCRIPTION
CRI-O CI has been testing kata-containers against k8s 1.21.  However, on
the kata-containers side we're "already" testing against k8s 1.22, and
we definitely should do the same with CRI-O CI.

Fixes: #4133

And whileh here ... let's also remove the workaround used for forcing the usage of k8s 1.21.