### PR TITLE
Revert "kata-webhook: Use temporary webhook image"

### DIFF
--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -20,8 +20,7 @@ spec:
     spec:
       containers:
         - name: pod-annotate-webhook
-          # FIXME: https://github.com/kata-containers/tests/issues/4080
-          image: quay.io/wainersm/kata-webhook-api-v1:latest
+          image: quay.io/kata-containers/kata-webhook-example:latest
           imagePullPolicy: Always
           env:
             - name: RUNTIME_CLASS


### PR DESCRIPTION
This reverts commit 43b47ecefea5c6e2c3ac81fe41ca782680dbfa58.

Fixes #4080