### PR TITLE
Selective enablement of tests

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -19,6 +19,7 @@ export CONTAINER_DEFAULT_RUNTIME="${CONTAINER_DEFAULT_RUNTIME:-$CONTAINER_RUNTIM
 export RUNTIME_ROOT="${RUNTIME_ROOT:-/run/vc}"
 export RUNTIME_TYPE="${RUNTIME_TYPE:-vm}"
 export STORAGE_OPTIONS="--storage-driver overlay"
+export PRIVILEGED_WITHOUT_HOST_DEVICES=true
 
 # Skip the cri-o tests if TEST_CRIO is not true
 # and we are on a CI job.

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -32,3 +32,8 @@ declare -A skipCRIOTests=(
 ['test "ctr with absent mount that should be rejected"']='This is not working'
 );
 
+# The following lists tests that should be skipped in specific cri-o versions.
+# When adding a test here, you need to provide the version of cri-o where the
+# bug was fixed. The script will skip this test in all previous versions.
+declare -A fixedInCrioVersion=();
+

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -8,7 +8,6 @@
 # Currently these are the CRI-O tests that are not working
 
 declare -A skipCRIOTests=(
-['test "ctr lifecycle"']='FIXME: See https://github.com/kata-containers/kata-containers/issues/2096'
 ['test "ctr logging"']='This is not working'
 ['test "ctr journald logging"']='Not implemented'
 ['test "ctr logging \[tty=true\]"']='FIXME: See https://github.com/kata-containers/tests/issues/4069'

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -16,7 +16,6 @@ declare -A skipCRIOTests=(
 ['test "ctr partial line logging"']='This is not working'
 ['test "ctr execsync"']='FIXME: See https://github.com/cri-o/cri-o/pull/5041'
 ['test "ctr execsync should not overwrite initial spec args"']='This is not working'
-['test "privileged ctr device add"']='FIXME: See https://github.com/cri-o/cri-o/pull/5054'
 ['test "ctr execsync std{out,err}"']='This is not working'
 ['test "ctr oom"']='This is not working'
 ['test "ctr \/etc\/resolv.conf rw\/ro mode"']='This is not working'
@@ -26,7 +25,6 @@ declare -A skipCRIOTests=(
 ['test "ctr resources"']='This is not working'
 ['test "ctr with non-root user has no effective capabilities"']='This is not working'
 ['test "ctr with low memory configured should not be created"']='This is not working'
-['test "privileged ctr -- check for rw mounts"']='FIXME: See https://github.com/cri-o/cri-o/pull/5054'
 ['test "annotations passed through"']='This is not working'
 ['test "ctr with default_env set in configuration"']='This is not working'
 ['test "ctr with absent mount that should be rejected"']='This is not working'
@@ -35,5 +33,8 @@ declare -A skipCRIOTests=(
 # The following lists tests that should be skipped in specific cri-o versions.
 # When adding a test here, you need to provide the version of cri-o where the
 # bug was fixed. The script will skip this test in all previous versions.
-declare -A fixedInCrioVersion=();
+declare -A fixedInCrioVersion=(
+['test "privileged ctr device add"']="1.22"
+['test "privileged ctr -- check for rw mounts"']="1.22"
+);
 

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -14,7 +14,6 @@ declare -A skipCRIOTests=(
 ['test "ctr log max"']='Not implemented'
 ['test "ctr log max with minimum value"']='Not implemented'
 ['test "ctr partial line logging"']='This is not working'
-['test "ctr execsync"']='FIXME: See https://github.com/cri-o/cri-o/pull/5041'
 ['test "ctr execsync should not overwrite initial spec args"']='This is not working'
 ['test "ctr execsync std{out,err}"']='This is not working'
 ['test "ctr oom"']='This is not working'
@@ -36,5 +35,6 @@ declare -A skipCRIOTests=(
 declare -A fixedInCrioVersion=(
 ['test "privileged ctr device add"']="1.22"
 ['test "privileged ctr -- check for rw mounts"']="1.22"
+['test "ctr execsync"']="1.22"
 );
 


### PR DESCRIPTION
- Add some code to the test script to selectively enable tests based on the version of cri-o being tested
- Enable several tests that we were skipping, for specific versions of cri-o
- Also enable a test fixed in kata - as we are testing against "main", there is no need to check the version here