### PR TITLE
ci: Enable data race detection on ARM and Power

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -22,9 +22,8 @@ long_options=(
 # "go test -timeout X"
 timeout_value=${KATA_GO_TEST_TIMEOUT:-30s}
 
-# -race flag is supported only on amd64/x86_64 arch , hence 
-# enabling the flag depending on the arch.
-[ "$(go env GOARCH)" = "amd64" ] && race="-race"
+# -race flag is not supported on s390x
+[ "$(go env GOARCH)" != "s390x" ] && race="-race"
 
 # Notes:
 #


### PR DESCRIPTION
Run `go test` with `-race` on architectures that support this by now.
This might also help uncover the root cause of #4131, even though that
has only been observed on s390x thus far.

Fixes: #4141
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @jodh-intel