### PR TITLE
ci: cri-o integration tests - get cri-o version from jenkins' environment

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -76,7 +76,7 @@ do
 done
 
 # selectively skip tests depending on the version of cri-o we're testing with
-CRIO_VERSION=$(git status | head -n1 | awk '{print $NF}' | cut -d'-' -f 2)
+CRIO_VERSION=$(echo ${PULL_BASE_REF} | cut -d'-' -f 2)
 echo GOT CRIO VERSION $CRIO_VERSION
 if [ "$CRIO_VERSION" != "main" ]; then
     if [ -z "$CRIO_VERSION" ]; then


### PR DESCRIPTION
Use the PULL_BASE_REF variable exported by the jenkins job to get the version of cri-o we're testing against.

