### PR TITLE
metrics: Remove unsupported footprint density report

### DIFF
--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -13,17 +13,6 @@ This report was generated using the data from the **`r resultdirs`** results dir
 
 \pagebreak
 
-# Container PSS footprint
-This [test](https://github.com/kata-containers/tests/blob/main/metrics/density/memory_usage.sh)
-measures the PSS footprint of all the container runtime components whilst running a number
-of parallel containers. The results are the mean footprint proportion for a single
-container.
-
-```{r memory-footprint, echo=FALSE, fig.cap="Memory PSS footprint"}
-source('memory-footprint.R')
-```
-\pagebreak
-
 # Container scaling system footprint
 This [test](https://github.com/kata-containers/tests/blob/main/metrics/density/footprint_data.sh)
 measures the system memory footprint impact whilst running an increasing number


### PR DESCRIPTION
This PR removes the footprint density metrics that were used on kata 1.x
and that is not supported on kata 2.0

Fixes #4153

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>