### PR TITLE
metrics: Remove fio information from metrics report

### DIFF
--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -54,28 +54,6 @@ source('lifecycle-time.R')
 ```
 \pagebreak
 
-# Storage I/O
-
-Measure storage I/O bandwidth, latency and IOPS using 
-this [test](https://github.com/kata-containers/tests/blob/main/metrics/storage/fio.sh).
-
-This test measures using separate random read and write tests.
-
-## Reads
-
-```{r fio-reads, echo=FALSE, fig.cap="Storage I/O Reads", results='asis'}
-source('fio-reads.R')
-```
-
-\pagebreak
-
-## Writes
-
-```{r fio-writes, echo=FALSE, fig.cap="Storage I/O Writes", results='asis'}
-source('fio-writes.R')
-```
-\pagebreak
-
 # Test setup details
 
 This table describes the test system details, as derived from the information contained


### PR DESCRIPTION
This PR removes fio information from metrics report generation as this
is not longer being used on kata 2.0 metrics

Fixes #4159

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>