### PR TITLE
openshift-ci: adapt scripts to test like OpenShift Sandboxed Containers

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -60,6 +60,37 @@ sandboxed_containers_build_configs() {
 	export DEFENABLEANNOTATIONS=['\".*\"']
 }
 
+# This ensures the guest image is built to work with the host Kernel akin to
+# OpenShift Sandboxed Containers.
+sandboxed_containers_image_configs() {
+	# It needs to overwrite some variables of
+	# kata-containers/tools/osbuilder/Makefile.
+	export DRACUT_KVERSION="$(get_test_version "openshift-ci.dracut_kernel.version")"
+	[ -n "$DRACUT_KVERSION" ] || \
+		die "Unabled to get the kernel version from versions.yaml"
+	export DRACUT_CONF_DIR=$(mktemp -d --tmpdir dracut.conf.d.XXXX)
+	yum install -y "kernel-modules-${DRACUT_KVERSION}"
+	# Unlike the kernel installed by the .ci/install_kata_kernel.sh script,
+	# the host kernel doesn't have the needed modules built static. Thus,
+	# we need to package them as loadable modules into the guest image.
+	cp -r "${kata_repo_dir}/tools/osbuilder/dracut/dracut.conf.d"/* \
+		"${DRACUT_CONF_DIR}"
+	cat <<-EOF >> "${DRACUT_CONF_DIR}/10-drivers.conf"
+	drivers+="irqbypass "
+	drivers+="vfio "
+	drivers+="vfio_iommu_type1 "
+	drivers+="vfio-pci "
+	drivers+="vfio_virqfd "
+	drivers+="virtio_blk "
+	drivers+="virtio_console "
+	drivers+="virtiofs "
+	drivers+="virtio_net "
+	drivers+="virtio_scsi "
+	drivers+="vmw_vsock_virtio_transport "
+	dracutmodules+=" bash rescue "
+	EOF
+}
+
 # Let the scripts know it is in CI context.
 export OPENSHIFT_CI="true"
 export CI="true"
@@ -105,15 +136,17 @@ export PREFIX="/opt/kata"
 
 "${cidir}/install_kata_kernel.sh"
 
+if [ "${SANDBOXED_CONTAINERS_CONF:-no}" == "yes" ]; then
+	info "Apply build configurations akin to Openshift Sandboxed Containers"
+	sandboxed_containers_build_configs
+	sandboxed_containers_image_configs
+fi
+
 # osbuilder's make define a VERSION variable which value might clash with
 # VERSION sourced from /etc/os-release.
 unset VERSION
 "${cidir}/install_kata_image.sh"
 
-if [ "${SANDBOXED_CONTAINERS_CONF:-no}" == "yes" ]; then
-	info "Apply build configurations akin to Openshift Sandboxed Containers"
-	sandboxed_containers_build_configs
-fi
 "${cidir}/install_runtime.sh"
 
 # The resulting kata installation will be merged in rhcos filesystem, and

--- a/.ci/openshift-ci/cluster/configs/crio_kata.conf
+++ b/.ci/openshift-ci/cluster/configs/crio_kata.conf
@@ -2,15 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-[crio.runtime]
-manage_ns_lifecycle = true
-
-[crio.runtime.runtimes.runc]
-runtime_path = ""
-runtime_type = "oci"
-runtime_root = "/run/runc"
-
-[crio.runtime.runtimes.kata]
+[crio.runtime.runtimes.kata-ci]
 runtime_path = "/opt/kata/bin/containerd-shim-kata-v2"
 runtime_type = "vm"
 runtime_root = "/run/vc"

--- a/.ci/openshift-ci/cluster/deploy_webhook.sh
+++ b/.ci/openshift-ci/cluster/deploy_webhook.sh
@@ -7,13 +7,21 @@
 # This script builds the kata-webhook and deploys it in the test cluster.
 #
 # You should export the KATA_RUNTIME variable with the runtimeclass name
-# configured in your cluster in case it is not the default "kata".
+# configured in your cluster in case it is not the default "kata-ci".
 #
 set -e
+set -o nounset
+set -o pipefail
 
 script_dir="$(dirname $0)"
 webhook_dir="${script_dir}/../../../kata-webhook"
 source "${script_dir}/../../lib.sh"
+KATA_RUNTIME=${KATA_RUNTIME:-kata-ci}
+
+info "Creates the kata-webhook ConfigMap"
+RUNTIME_CLASS="${KATA_RUNTIME}" \
+	envsubst < "${script_dir}/deployments/configmap_kata-webhook.yaml.in" \
+	| oc apply -f -
 
 pushd "${webhook_dir}" >/dev/null
 # Build and deploy the webhook
@@ -23,5 +31,5 @@ info "Builds the kata-webhook"
 info "Deploys the kata-webhook"
 oc apply -f deploy/
 # Check the webhook was deployed and is working.
-./webhook-check.sh
+RUNTIME_CLASS="${KATA_RUNTIME}" ./webhook-check.sh
 popd >/dev/null

--- a/.ci/openshift-ci/cluster/deployments/configmap_installer_kernel.yaml
+++ b/.ci/openshift-ci/cluster/deployments/configmap_installer_kernel.yaml
@@ -3,12 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Instruct the daemonset installer to configure Kata Containers to use the
-# system QEMU.
+# host kernel.
 #
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ci.kata.installer.qemu
+  name: ci.kata.installer.kernel
 data:
-  qemu_path: /usr/libexec/qemu-kiwi
   host_kernel: "yes"

--- a/.ci/openshift-ci/cluster/deployments/configmap_installer_qemu.yaml
+++ b/.ci/openshift-ci/cluster/deployments/configmap_installer_qemu.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Instruct the daemonset installer to configure Kata Containers to use the
+# system QEMU.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ci.kata.installer.qemu
+data:
+  qemu_path: /usr/libexec/qemu-kiwi

--- a/.ci/openshift-ci/cluster/deployments/configmap_kata-webhook.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/configmap_kata-webhook.yaml.in
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Apply customizations to the kata-webhook.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kata-webhook
+data:
+  runtime_class: ${RUNTIME_CLASS}

--- a/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
@@ -35,6 +35,12 @@ spec:
                   valueFrom:
                   fieldRef:
                    fieldPath: spec.nodeName
+                - name: QEMU_PATH
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ci.kata.installer.qemu
+                      key: qemu_path
+                      optional: true
             hostNetwork: true
             hostPID: true
             #nodeName: $NODE_NAME

--- a/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/daemonset_kata-installer.yaml.in
@@ -41,6 +41,12 @@ spec:
                       name: ci.kata.installer.qemu
                       key: qemu_path
                       optional: true
+                - name: USE_HOST_KERNEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: ci.kata.installer.kernel
+                      key: host_kernel
+                      optional: true
             hostNetwork: true
             hostPID: true
             #nodeName: $NODE_NAME

--- a/.ci/openshift-ci/cluster/deployments/machineconfig_kata_runtime.yaml.in
+++ b/.ci/openshift-ci/cluster/deployments/machineconfig_kata_runtime.yaml.in
@@ -9,7 +9,7 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 50-kata
+  name: 50-kata-ci
 spec:
   config:
     ignition:
@@ -20,4 +20,4 @@ spec:
               source: data:text/plain;charset=utf-8;base64,${KATA_CRIO_CONF_BASE64}
         filesystem: root
         mode: 0420
-        path: /etc/crio/crio.conf.d/50-kata
+        path: /etc/crio/crio.conf.d/50-kata-ci

--- a/.ci/openshift-ci/cluster/deployments/machineconfig_sandboxedcontainers_extension.yaml
+++ b/.ci/openshift-ci/cluster/deployments/machineconfig_sandboxedcontainers_extension.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-enable-sandboxed-containers-extension
+spec:
+  extensions:
+  - sandboxed-containers

--- a/.ci/openshift-ci/cluster/deployments/runtimeclass_kata.yaml
+++ b/.ci/openshift-ci/cluster/deployments/runtimeclass_kata.yaml
@@ -5,10 +5,10 @@
 # Define the "kata" runtime class
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
-  name: kata
-handler: kata
+  name: kata-ci
+handler: kata-ci
 overhead:
   podFixed:
     memory: "160Mi"

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -158,7 +158,7 @@ wait_for_reboot
 # Add a runtime class for kata
 info "Adding the kata runtime class"
 oc apply -f ${deployments_dir}/runtimeclass_kata.yaml
-oc get runtimeclass/kata || die "kata runtime class not found"
+oc get -f ${deployments_dir}/runtimeclass_kata.yaml || die "kata runtime class not found"
 
 # Set SELinux to permissive mode
 if [ ${SELINUX_PERMISSIVE} == "yes" ]; then

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -23,6 +23,10 @@ SELINUX_PERMISSIVE=${SELINUX_PERMISSIVE:-no}
 #
 KATA_WITH_SYSTEM_QEMU=${KATA_WITH_SYSTEM_QEMU:-no}
 
+# Set to 'yes' if you want to configure Kata Containers to use the host kernel.
+#
+KATA_WITH_HOST_KERNEL=${KATA_WITH_HOST_KERNEL:-no}
+
 # The daemonset name.
 #
 export DAEMONSET_NAME="kata-deploy"
@@ -149,6 +153,10 @@ if [ "${KATA_WITH_SYSTEM_QEMU}" == "yes" ]; then
 	# Export additional information for the installer to deal with
 	# the QEMU path, for example.
 	oc apply -f ${deployments_dir}/configmap_installer_qemu.yaml
+fi
+
+if [ "${KATA_WITH_HOST_KERNEL}" == "yes" ]; then
+	oc apply -f ${deployments_dir}/configmap_installer_kernel.yaml
 fi
 
 info "Applying the Kata Containers installer daemonset"

--- a/.ci/openshift-ci/images/entrypoint.sh
+++ b/.ci/openshift-ci/images/entrypoint.sh
@@ -18,6 +18,8 @@ HOST_MOUNT=/host
 
 # Overwrite the default QEMU path on configuration.toml
 QEMU_PATH=${QEMU_PATH:-}
+# Overwrite the default Kernel path on configuration.toml
+USE_HOST_KERNEL=${USE_HOST_KERNEL:-no}
 
 function terminate()
 {
@@ -49,12 +51,22 @@ function update_qemu_path()
 		"$toml"
 }
 
+# Set the Kernel path on configuration.toml to the host's.
+#
+function update_kernel_path()
+{
+	local toml="${SRC}/opt/kata/share/defaults/kata-containers/configuration.toml"
+	local kernel_path="/lib/modules/$(uname -r)/vmlinuz"
+	sed -i 's#^kernel = ".*"#kernel = "'${kernel_path}'"#g' "$toml"
+}
+
 if [ "$(id -u)" -ne 0 ]; then
 	echo "ERROR: $0 must be executed by privileged user"
 	terminate
 fi
 
 [ -n "$QEMU_PATH" ] && update_qemu_path
+[ "$USE_HOST_KERNEL" == "yes" ] && update_kernel_path
 
 # Some files are copied over /usr which on Red Hat CoreOS (rhcos) is mounted
 # read-only by default. So re-mount it as read-write, otherwise files won't

--- a/.ci/openshift-ci/images/entrypoint.sh
+++ b/.ci/openshift-ci/images/entrypoint.sh
@@ -21,7 +21,7 @@ QEMU_PATH=${QEMU_PATH:-}
 # Overwrite the default Kernel path on configuration.toml
 USE_HOST_KERNEL=${USE_HOST_KERNEL:-no}
 
-function terminate()
+terminate()
 {
 	# Sending a termination message. Can be used by an orchestrator that
 	# will look into this file to check the installation has finished
@@ -39,7 +39,7 @@ function terminate()
 
 # Set the QEMU path on configuration.toml to $QEMU_PATH, also update
 # virtiofsd's path.
-function update_qemu_path()
+update_qemu_path()
 {
 	local toml="${SRC}/opt/kata/share/defaults/kata-containers/configuration.toml"
 	# Make a copy of the original file, it can help with debugging.
@@ -53,7 +53,7 @@ function update_qemu_path()
 
 # Set the Kernel path on configuration.toml to the host's.
 #
-function update_kernel_path()
+update_kernel_path()
 {
 	local toml="${SRC}/opt/kata/share/defaults/kata-containers/configuration.toml"
 	local kernel_path="/lib/modules/$(uname -r)/vmlinuz"

--- a/.ci/openshift-ci/smoke/http-server.yaml
+++ b/.ci/openshift-ci/smoke/http-server.yaml
@@ -18,4 +18,4 @@ spec:
         - containerPort: 8080
       command: ["python3"]
       args: [ "-m", "http.server", "8080"]
-  runtimeClassName: kata
+  runtimeClassName: kata-ci

--- a/.ci/openshift-ci/smoke/service.yaml
+++ b/.ci/openshift-ci/smoke/service.yaml
@@ -17,7 +17,7 @@ spec:
       targetPort: 8080
 # Create the route to the app's service '/'.
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: http-server-route

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -24,7 +24,11 @@ spec:
           imagePullPolicy: Always
           env:
             - name: RUNTIME_CLASS
-              value: kata
+              valueFrom:
+                configMapKeyRef:
+                  name: kata-webhook
+                  key: runtime_class
+                  optional: true
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem
             - -tls-key-file=/etc/webhook/certs/key.pem

--- a/versions.yaml
+++ b/versions.yaml
@@ -81,3 +81,9 @@ externals:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"
     version: "0.50.0"
+
+# This section contains versions used by the OpenShift CI jobs scripts.
+openshift-ci:
+  dracut_kernel:
+    description: "kernel that dracut should be pulling modules in the initramfs"
+    version: "4.18.0-305.19.1.el8_4.x86_64"


### PR DESCRIPTION
This is the needed changes on Kata Containers side to allow:
1) build with same configuration as OpenShift Sandboxed Containers
2) configure the runtime to use the host kernel
3) configure the runtime to use the system QEMU

Fixes #4163  