### PR TITLE
tests: Revert "tests: use containerd to replace cri-containerd"

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -25,9 +25,10 @@ source "${script_dir}/lib.sh"
 CONTAINERD_OS=$(go env GOOS)
 CONTAIENRD_ARCH=$(go env GOARCH)
 
-containerd_tarball_version=$(get_version "externals.containerd.version")
+cri_containerd_tarball_version=$(get_version "externals.cri-containerd.version")
+cri_containerd_repo=$(get_version "externals.cri-containerd.url")
 
-containerd_version=${containerd_tarball_version#v}
+cri_containerd_version=${cri_containerd_tarball_version#v}
 
 echo "Set up environment"
 if [ "$ID" == centos ] || [ "$ID" == rhel ] || [ "$ID" == sles ]; then
@@ -38,23 +39,21 @@ fi
 install_from_source() {
 	echo "Trying to install containerd from source"
 	(
-		containerd_repo=$(get_version "externals.containerd.url")
-		go get "${containerd_repo}"
-		cd "${GOPATH}/src/${containerd_repo}" >>/dev/null
+		cd "${GOPATH}/src/${cri_containerd_repo}" >>/dev/null
 		git fetch
-		git checkout "${containerd_tarball_version}"
+		git checkout "${cri_containerd_tarball_version}"
 		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
-		tarball_name="cri-containerd-cni-${containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
+		tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
 		sudo tar -xvf "./releases/${tarball_name}" -C /
 	)
 }
 
 install_from_static_tarball() {
 	echo "Trying to install containerd from static tarball"
-	local tarball_url=$(get_version "externals.containerd.tarball_url")
+	local tarball_url=$(get_version "externals.cri-containerd.tarball_url")
 
-	local tarball_name="cri-containerd-cni-${containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
-	local url="${tarball_url}/${containerd_tarball_version}/${tarball_name}"
+	local tarball_name="cri-containerd-cni-${cri_containerd_version}-${CONTAINERD_OS}-${CONTAIENRD_ARCH}.tar.gz"
+	local url="${tarball_url}/${cri_containerd_tarball_version}/${tarball_name}"
 
 	echo "Download tarball from ${url}"
 	if ! curl -OL -f "${url}"; then
@@ -65,6 +64,7 @@ install_from_static_tarball() {
 	sudo tar -xvf "${tarball_name}" -C /
 }
 
+go get "${cri_containerd_repo}"
 install_from_static_tarball || install_from_source
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
This reverts commit 393e0714667fe45cf9feece5d3f1ce51f53f82fd.

On the mentioned commit we moved to using containerd instead of
cri-containerd for parsing the crioptions.  However, it turned out to
cause issues when using "not too new enough" versions of containerd,
which happens to be the case on cloud providers services such as AKS.

Tao already proposed to revert the offending commit on the
`kata-containers` repo, but that requires the change reverted on the
tests repo as well, so let's do it.

Fixes: #4173
Depends-on: github.com/kata-containers/kata-containers#3000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>