### PR TITLE
kubernetes: add integration test for inotify workaround support

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -39,3 +39,4 @@ kubernetes:
   - k8s-expose-ip
   - k8s-oom
   - k8s-block-volume
+  - k8s-inotify

--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -5,3 +5,4 @@
 
 kubernetes:
   - k8s-caps
+  - k8s-inotify

--- a/integration/kubernetes/k8s-inotify.bats
+++ b/integration/kubernetes/k8s-inotify.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	get_pod_config_dir
+}
+
+@test "configmap update works, and preserves symlinks" {
+        pod_name="inotify-configmap-testing"
+
+        # Create configmap for my deployment
+        kubectl apply -f "${pod_config_dir}"/inotify-configmap.yaml
+
+        # Create deployment that expects identity-certs
+        kubectl apply -f "${pod_config_dir}"/inotify-configmap-pod.yaml
+        kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+        # Update configmap
+        kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml
+
+        # Ideally we'd wait for the pod to complete...
+        sleep 120
+
+        # Verify we saw the update
+        result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")
+        echo $result | grep -vq Error
+
+        kubectl delete configmap cm
+}
+
+
+
+teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -31,6 +31,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-env.bats" \
 	"k8s-exec.bats" \
 	"k8s-expose-ip.bats" \
+        "k8s-inotify.bats" \
 	"k8s-job.bats" \
 	"k8s-limit-range.bats" \
 	"k8s-liveness-probes.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inotify-configmap-testing
+spec:
+  containers:
+  - name: c1
+    image: quay.io/kata-containers/fsnotify:latest
+    command: ["bash"]
+    args: ["-c", "inotifywait --timeout 120 -r /config/ && [[ -L /config/config.toml ]] && echo success" ]
+    resources:
+      requests:
+        cpu: 1
+        memory: 50Mi
+      limits:
+        cpu: 1
+        memory: 1024Mi
+    volumeMounts:
+      - name: config
+        mountPath: /config
+  runtimeClassName: kata
+  restartPolicy: Never
+  volumes:
+    - name: config
+      configMap:
+        name: cm

--- a/integration/kubernetes/runtimeclass_workloads/inotify-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-configmap.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+data:
+  config.toml: |-
+    foo original...
+kind: ConfigMap
+metadata:
+  name: cm

--- a/integration/kubernetes/runtimeclass_workloads/inotify-updated-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-updated-configmap.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+data:
+  config.toml: |-
+    foo original...
+    ... updated
+kind: ConfigMap
+metadata:
+  name: cm


### PR DESCRIPTION
Add test to ensure fsnotify works and that symlinks are preserved.

Fixes: #4180

Signed-off-by: Eric Ernst <eric_ernst@apple.com>