### PR TITLE
Revert "crio: Remove internal Red Hat registry"

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -38,7 +38,7 @@ popd
 echo "Configure registries"
 sudo mkdir -p /etc/containers/registries.conf.d/
 cat <<EOF| sudo tee "/etc/containers/registries.conf.d/ciregistries.conf"
-unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.redhat.com", "registry.centos.org", "docker.io"]
+unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.redhat.com", "registry.centos.org", "docker.io", "registry-proxy.engineering.redhat.com"]
 
 [aliases]
   # centos


### PR DESCRIPTION
This reverts commit 08d930c337ad35c442d4255bb77c9a107a20c297.

```
crio: Remove internal Red Hat registry

This was mistakenly added as part of
66eea16d6301d7a9710e236bfa7834792c5f9de0

Fixes: #4165

```

The only reason for reverting this is to test golang 1.17 bump, and this
should *NOT* be merged.

Depends-on: github.com/kata-containers/kata-containers#3017

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>