### PR TITLE
metrics: Remove unsupported runtime

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -307,7 +307,7 @@ check_for_ksm(){
 #
 # arg1 - timeout in seconds
 wait_ksm_settle(){
-	[[ "$RUNTIME" == "runc" ]] || [[ "$RUNTIME" == "kata-fc" ]] || [[ "$CTR_RUNTIME" == "io.containerd.runc.v2" ]] && return
+	[[ "$RUNTIME" == "runc" ]] || [[ "$CTR_RUNTIME" == "io.containerd.runc.v2" ]] && return
 	local t pcnt
 	local oldscan=-1 newscan
 	local oldpages=-1 newpages


### PR DESCRIPTION
This PR removes unsupported runtime as it is not longer being used in the
metrics CI for kata 2.0

Fixes #4184

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>