### PR TITLE
ci: Remove unsupported variable

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -7,7 +7,6 @@
 #
 
 export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
-export KATA_NEMU_DESTDIR=${KATA_NEMU_DESTDIR:-"/usr"}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 


### PR DESCRIPTION
This PR removes a unsupported variable that is not longer being used in
kata 2.0 as we are not using nemu anymore.

Fixes #4186

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>