### PR TITLE
Install the oldest, rather than newest supported Rust by default

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -14,7 +14,7 @@ source "${cidir}/lib.sh"
 rustarch=$(${cidir}/kata-arch.sh --rust)
 version="${1:-""}"
 if [ -z "${version}" ]; then
-	version=$(get_version "languages.rust.meta.newest-version")
+	version=$(get_version "languages.rust.version")
 fi
 
 echo "Install rust ${version}"

--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -12,8 +12,6 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 rustarch=$(${cidir}/kata-arch.sh --rust)
-# release="nightly"
-# recent functional version
 version="${1:-""}"
 if [ -z "${version}" ]; then
 	version=$(get_version "languages.rust.meta.newest-version")


### PR DESCRIPTION
For the reasons described in #4188 this makes more sense.