### PR TITLE
CCv0 | static-checks: skip license checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -517,6 +517,8 @@ static_check_license_headers()
 			--exclude="tools/packaging/qemu/default-configs/*" \
 			--exclude="src/agent/protocols/protos/gogo/*" \
 			--exclude="src/agent/protocols/protos/google/*" \
+			--exclude="*.tar" \
+			--exclude="*.gpg" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
Skip SPX check on .tar and .gpg

Fixes: #4190
Signed-off-by: stevenhorsman <steven@uk.ibm.com>