### PR TITLE
Revert "tests: Install the oldest, rather than the newest supported R…

### DIFF
--- a/.ci/install_rust.sh
+++ b/.ci/install_rust.sh
@@ -14,7 +14,7 @@ source "${cidir}/lib.sh"
 rustarch=$(${cidir}/kata-arch.sh --rust)
 version="${1:-""}"
 if [ -z "${version}" ]; then
-	version=$(get_version "languages.rust.version")
+	version=$(get_version "languages.rust.meta.newest-version")
 fi
 
 echo "Install rust ${version}"


### PR DESCRIPTION
…ust by default"

This reverts commit 7177a5f0e7ec3b15485a4dd44c7040cfec44b1fa.
```
tests: Install the oldest, rather than the newest supported Rust by default

If not given an explicit version install_rust.sh looks up versions.yaml to
find the newest Rust version that's known to work.  One of the main uses of
this script is in the CI, where installing the newest Rust version isn't
really what we want:
  - Rust has strong backwards compatibility, so breakage due to a newer
    Rust compiler version is very unlikely
  - However, breakage due to adding things to the Kata codebase which
    require new Rust features that aren't in the *oldests* supported version
    is very likely.

Therefore, it's much more useful to test with the oldest supported version
rather than the newest.  Change install_rust.sh to do this.

fixes #4188
```

While the intention is really good (and should be persued), right now
this change causes breaks in our CI.  This means that we should either
update the minimum version or fix the issues to ensure everything works
as expected with rust 1.45.0.

However, while this is not done, let's get `kata-containers` unblocked
by reverting this.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>