### PR TITLE
Static checks: adds a checker for dockerfiles

### DIFF
--- a/.ci/openshift-ci/images/Dockerfile.installer
+++ b/.ci/openshift-ci/images/Dockerfile.installer
@@ -7,16 +7,16 @@
 #
 FROM registry.centos.org/centos:8
 
-RUN yum install -y rsync dracut
+RUN yum install -y rsync dracut && \
+  yum clean all
 
 # Load the installation files.
-COPY ./_out ./_out
+COPY ./_out $WORKDIR/_out
 
 # QEMU was built separated from other components (agent, runtime...) so the
 # tarball's content should be merged with the remain of the installation.
-COPY ./kata-static-qemu.tar.gz .
-RUN tar -C ./_out/build_install -xvzf ./kata-static-qemu.tar.gz
+ADD ./kata-static-qemu.tar.gz $WORKDIR/_out/build_install
 
 COPY ./entrypoint.sh /usr/bin
 
-ENTRYPOINT /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1147,6 +1147,14 @@ static_check_dockerfiles()
 	local ignore_files
 	# Put here a list of files which should be ignored.
         local ignore_files=(
+		"tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in"
+		"tools/osbuilder/rootfs-builder/centos/Dockerfile.in"
+		"tools/osbuilder/rootfs-builder/debian/Dockerfile.in"
+		"tools/osbuilder/rootfs-builder/fedora/Dockerfile.in"
+		"tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in"
+		"tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in"
+		"tools/packaging/tests/Dockerfile/Dockerfile.in"
+		"tools/packaging/tests/Dockerfile/FedoraDockerfile.in"
         )
 	local linter_cmd="hadolint"
 
@@ -1182,11 +1190,15 @@ static_check_dockerfiles()
 	linter_cmd+=" --ignore DL3041"
 	# "DL3033 warning: Specify version with `yum install -y <package>-<version>`"
 	linter_cmd+=" --ignore DL3033"
+	# "DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`" 
+	linter_cmd+=" --ignore DL3018"
 	# "DL3003 warning: Use WORKDIR to switch to a directory"
 	# See https://github.com/hadolint/hadolint/issues/70
 	linter_cmd+=" --ignore DL3003"
 	# "DL3048 style: Invalid label key"
 	linter_cmd+=" --ignore DL3048"
+        # DL3037 warning: Specify version with `zypper install -y <package>=<version>`.
+	linter_cmd+=" --ignore DL3037"
 
 	local file
 	for file in $files; do
@@ -1201,7 +1213,7 @@ static_check_dockerfiles()
 		# dockerfile. Some of our dockerfiles are actually templates
 		# with special syntax, thus the linter might fail to build
 		# the AST. Here we handle Dockerfile templates.
-		if [[ "$file" =~ Dockerfile.in$ ]]; then
+		if [[ "$file" =~ Dockerfile.*.in$ ]]; then
 			# In our templates, text with marker as @SOME_NAME@ is
 			# replaceable. Usually it is used to replace in a
 			# FROM command (e.g. `FROM @UBUNTU_REGISTRY@/ubuntu`)

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1175,6 +1175,11 @@ static_check_dockerfiles()
 
         [ -z "$files" ] && info "No Dockerfiles to check" && return 0
 
+	# As of this writing hadolint is only distributed for x86_64
+	if [ "$(uname -m)" != "x86_64" ]; then
+		info "Skip checking as $linter_cmd is not available for $(uname -m)"
+		return 0
+	fi
 	has_hadolint_or_install
 
 	linter_cmd+=" --no-color"

--- a/conformance/posixfs/Dockerfile
+++ b/conformance/posixfs/Dockerfile
@@ -3,16 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM debian
+FROM debian:bullseye
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
 
 RUN apt-get update && \
-    apt-get -y install autoconf git bc libacl1-dev libacl1 acl gcc make perl g++ perl-modules && \
-    git clone https://github.com/pjd/pjdfstest.git && \
-    cd pjdfstest && \
-    autoreconf -ifs && \
+    apt-get -y --no-install-recommends install autoconf git bc libacl1-dev libacl1 acl gcc make perl g++ perl-modules && \
+    apt-get clean && rm -rf /var/lib/apt/lists && \
+    git clone https://github.com/pjd/pjdfstest.git /pjdfstest
+WORKDIR /pjdfstest
+RUN autoreconf -ifs && \
     ./configure && \
     make
 

--- a/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
+++ b/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
@@ -3,7 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM quay.io/libpod/ubuntu
+# The image has only the 'latest' tag so it needs to ignore DL3007
+#hadolint ignore=DL3007
+FROM quay.io/libpod/ubuntu:latest
 RUN apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get -y install stress
+    apt-get -y --no-install-recommends install stress && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/kata-webhook/Dockerfile
+++ b/kata-webhook/Dockerfile
@@ -1,14 +1,14 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM golang:latest AS builder
+FROM golang:1.16-alpine3.14 AS builder
 
 WORKDIR /go/src/kata-pod-annotate
 
 COPY . ./
 RUN CGO_ENABLED=0 go build -o /go/bin/kata-pod-annotate
 
-FROM alpine:latest
+FROM alpine:3.14
 COPY --from=builder /go/bin/kata-pod-annotate /kata-pod-annotate
 ENTRYPOINT ["/kata-pod-annotate"]
 

--- a/metrics/network/iperf3_dockerfile/Dockerfile
+++ b/metrics/network/iperf3_dockerfile/Dockerfile
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM fedora
+FROM fedora:34
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
 
 # Install iperf3
 RUN dnf -y update && \
-    dnf -y install iperf3
+    dnf -y install iperf3 && \
+    dnf clean all
 
 CMD ["/bin/bash"]

--- a/metrics/network/iperf_dockerfile/Dockerfile
+++ b/metrics/network/iperf_dockerfile/Dockerfile
@@ -11,6 +11,9 @@ LABEL DOCKERFILE_VERSION="1.0"
 # Install iperf
 RUN apt-get update && \
     apt-get remove -y unattended-upgrades && \
-    apt-get install -y iperf
+    apt-get install -y --no-install-recommends iperf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
 
 CMD ["/bin/bash"]

--- a/metrics/network/nuttcp_dockerfile/Dockerfile
+++ b/metrics/network/nuttcp_dockerfile/Dockerfile
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu
+# hadolint ignore=DL3007
+FROM ubuntu:latest
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
@@ -14,12 +15,15 @@ ARG NUTTCP_VERSION="7.3.2"
 # Install iperf
 RUN apt-get update && \
     apt-get remove -y unattended-upgrades && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
     build-essential \
-    curl
+    curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
 
 # Install nuttcp (Network performance measurement tool)
-RUN cd $HOME && \
+RUN cd "$HOME" && \
     curl -OkL "http://nuttcp.net/nuttcp/beta/nuttcp-${NUTTCP_VERSION}.c" && \
     gcc nuttcp-${NUTTCP_VERSION}.c -o nuttcp
 

--- a/metrics/report/report_dockerfile/Dockerfile
+++ b/metrics/report/report_dockerfile/Dockerfile
@@ -25,10 +25,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install the extra doc processing parts we need for our Rmarkdown PDF flow.
 RUN apt-get update -qq && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     texlive-latex-base \
     texlive-fonts-recommended \
-    latex-xcolor
+    latex-xcolor && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists
 
 # Install the extra R packages we need.
 RUN install2.r --error --deps TRUE \

--- a/metrics/storage/blogbench_dockerfile/Dockerfile.in
+++ b/metrics/storage/blogbench_dockerfile/Dockerfile.in
@@ -5,7 +5,8 @@
 # Set up an Ubuntu image with 'blogbench' installed
 
 # Usage: FROM [image name]
-FROM @UBUNTU_REGISTRY@/ubuntu
+# hadolint ignore=DL3007
+FROM @UBUNTU_REGISTRY@/ubuntu:latest
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
@@ -15,13 +16,17 @@ ENV BLOGBENCH_URL "https://download.pureftpd.org/pub/blogbench"
 ENV BLOGBENCH_VERSION 1.1
 
 RUN apt-get update && \
-	apt-get install -y build-essential curl && \
+	apt-get install -y --no-install-recommends build-essential curl && \
 	apt-get remove -y unattended-upgrades && \
-	curl -OkL ${BLOGBENCH_URL}/blogbench-${BLOGBENCH_VERSION}.tar.gz && \
-	tar xzf blogbench-${BLOGBENCH_VERSION}.tar.gz && \
-	cd blogbench-${BLOGBENCH_VERSION} && \
-	export arch=$(uname -m) && \
-	./configure --build=${arch} && \	
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/ && \
+	curl -OkL "${BLOGBENCH_URL}/blogbench-${BLOGBENCH_VERSION}.tar.gz" && \
+	tar xzf "blogbench-${BLOGBENCH_VERSION}.tar.gz" -C /
+WORKDIR "/blogbench-${BLOGBENCH_VERSION}"
+#	cd "blogbench-${BLOGBENCH_VERSION}" && \
+RUN arch="$(uname -m)" && \
+	export arch && \
+	./configure --build="${arch}" && \
 	make && \
 	make install-strip
 

--- a/metrics/storage/fio_dockerfile/Dockerfile.in
+++ b/metrics/storage/fio_dockerfile/Dockerfile.in
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Set up an Ubuntu image with the components needed to run `fio`
-FROM @UBUNTU_REGISTRY@/ubuntu
+# hadolint ignore=DL3007
+FROM @UBUNTU_REGISTRY@/ubuntu:latest
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
@@ -12,8 +13,9 @@ LABEL DOCKERFILE_VERSION="1.0"
 #ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-	apt-get install -y fio && \
-	apt-get remove -y unattended-upgrades
+	apt-get install -y --no-install-recommends fio && \
+	apt-get remove -y unattended-upgrades && \
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Pull in our actual worker scripts
 COPY . /scripts

--- a/metrics/storage/web-tooling-dockerfile/Dockerfile.in
+++ b/metrics/storage/web-tooling-dockerfile/Dockerfile.in
@@ -5,6 +5,7 @@
 # Set up an Ubuntu image with 'web tooling' installed
 
 # Usage: FROM [image name]
+# hadolint ignore=DL3007
 FROM @UBUNTU_REGISTRY@/ubuntu:latest
 
 # Version of the Dockerfile
@@ -15,11 +16,13 @@ ENV WEB_TOOLING_URL "https://github.com/v8/web-tooling-benchmark"
 ENV NODEJS_VERSION "setup_14.x"
 
 RUN apt-get update && \
-	apt-get install -y build-essential git curl sudo && \
+	apt-get install -y --no-install-recommends build-essential git curl sudo && \
 	apt-get remove -y unattended-upgrades && \
 	curl -OkL https://deb.nodesource.com/${NODEJS_VERSION} && chmod +x ${NODEJS_VERSION} && ./${NODEJS_VERSION} && \
-	apt-get install -y nodejs && \
-	git clone ${WEB_TOOLING_URL} && \
-	cd /web-tooling-benchmark/ && npm install --unsafe-perm
+	apt-get install -y --no-install-recommends nodejs && \
+	apt-get clean && rm -rf /var/lib/apt/lists && \
+	git clone ${WEB_TOOLING_URL} /web-tooling-benchmark
+WORKDIR /web-tooling-benchmark/
+RUN npm install --unsafe-perm
 
 CMD ["/bin/bash"]

--- a/versions.yaml
+++ b/versions.yaml
@@ -79,6 +79,11 @@ externals:
     url: "github.com/golangci/golangci-lint"
     version: "v1.41.1"
 
+  hadolint:
+    description: "the dockerfile linter used by static-checks"
+    url: "https://github.com/hadolint/hadolint"
+    version: "2.7.0"
+
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"
     url: "https://github.com/vmware-tanzu/sonobuoy"


### PR DESCRIPTION
This will introduce a new checker to inspect the dockerfiles of the project with use of the [hadolint](https://github.com/hadolint/hadolint) tool.

Before turn on that check, it will be needed to delint all the dockerfiles. I already did it for the tests repository, remaining to change the files in the kata-containers repository.

Fixes #4149
Depends-on: github.com/kata-containers/kata-containers#3109 