### PR TITLE
tracing: Move tracing test to different job

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -58,6 +58,8 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
 		echo "INFO: Running kata-monitor test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
+		echo "INFO: Running tracing test"
+		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -743,22 +743,11 @@ setup()
 		exit 0
 	}
 
-	# For reasons unknown the ss(1) command core dumps when running in the
-	# "jenkins-ci-ubuntu-1804-containerd-k8s-e2e-minimal" job:
-	#
-	#  17:20:06 + ss -Hp --vsock
-	#  17:20:06 tracing/test-agent-shutdown.sh: line 556: 13682 Segmentation fault      (core dumped) agent_addr=$(get_agent_vsock_address || true)
-	#
-	# This is not reproducible locally
-
-	if [ "${CI_JOB:-}" = 'CRI_CONTAINERD_K8S_MINIMAL' ]
-	then
-		local msg=""
-		msg+="FIXME: Exiting due to known problematic CI environment (${CI_JOB:-})"
-		msg+=": see https://github.com/kata-containers/tests/issues/3774"
-		info "$msg"
+	# Do not run on ppc64le for now
+	[ "$(uname -m)" = "ppc64le" ] && {
+		info "Exiting, do not run on ppc64le"
 		exit 0
-	fi
+	}
 
 	[ "${CI_JOB:-}" = "METRICS" ] && {
 		info "Exiting as not running on metrics CI"

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -43,7 +43,7 @@ set -o errtrace
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../.ci/lib.sh"
 
-RUNTIME=${RUNTIME:-"io.containerd.kata.v2"}
+CTR_RUNTIME=${CTR_RUNTIME:-"io.containerd.kata.v2"}
 
 # Kata always uses this value
 EXPECTED_VSOCK_PORT="1024"
@@ -942,7 +942,7 @@ start_agent_in_kata_vm()
 		-s \"$KATA_TMUX_VM_SESSION\" \
 		\"sudo ctr run \
 			--snapshotter '$snapshotter' \
-			--runtime '${RUNTIME}' \
+			--runtime '${CTR_RUNTIME}' \
 			--rm \
 			-t '${CTR_IMAGE}' \
 			'$container_id' \

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -333,6 +333,25 @@ main()
 {
 	local cmd="${1:-}"
 
+	source /etc/os-release || source /usr/lib/os-release
+
+        # Only run on Ubuntu LTS for now
+        [ "${ID:-}" = ubuntu ] && grep -q LTS <<< "${VERSION:-}" || {
+                info "Exiting as not running on Ubuntu LTS"
+                exit 0
+        }
+
+        # Do not run on ppc64le for now
+        [ "$(uname -m)" = "ppc64le" ] && {
+                info "Exiting, do not run on ppc64le"
+                exit 0
+        }
+
+        [ "${CI_JOB:-}" = "METRICS" ] && {
+                info "Exiting as not running on metrics CI"
+                exit 0
+        }
+
 	case "$cmd" in
 		clean) success="true"; cleanup; exit 0;;
 		help|-h|-help|--help) usage; exit 0;;


### PR DESCRIPTION
Since the current job that ran the tracing test is disabled, move it to
an existing job.

Fixes #4195

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>