### PR TITLE
work with containerd 1.6.x

### DIFF
--- a/.ci/configure_cni.sh
+++ b/.ci/configure_cni.sh
@@ -11,7 +11,7 @@ echo "Configure CNI"
 cni_net_config_path="/etc/cni/net.d"
 sudo mkdir -p ${cni_net_config_path}
 
-sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
+sudo sh -c 'cat >/etc/cni/net.d/01-mynet.conf <<-EOF
 {
 	"cniVersion": "0.3.0",
 	"name": "mynet",

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -59,7 +59,7 @@ install_from_branch() {
 		cd "${GOPATH}/src/${containerd_repo}" >>/dev/null
 		git fetch
 		git checkout "${containerd_branch}"
-		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
+		sudo -E PATH="$PATH" make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release
 		# SH: The PR containerd version might not match the version.yaml one, so get from build
 		containerd_version=$(_output/cri/bin/containerd --version | awk '{ print substr($3,2); }')
 		tarball_name="cri-containerd-cni-${containerd_version}-${CONTAINERD_OS}-${CONTAINERD_ARCH}.tar.gz"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -49,7 +49,7 @@ build_rust_image() {
 				[[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
 			fi
 			distro="${osbuilder_distro:-ubuntu}"
-			if [ ${CCV0} == "yes"]; then
+			if [ ${CCV0} == "yes" ]; then
 				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" SKOPEO_UMOCI=yes make -e "image"
 			else
 				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -460,8 +460,8 @@ main() {
 
 	git reset HEAD
 	git checkout master
-	# switch to the default pause image set by containerd:1.5.x
-	sed -i 's#k8s.gcr.io/pause:3.[0-9]#k8s.gcr.io/pause:3.5#' integration/main_test.go
+	# switch to the default pause image set by containerd:1.6.x
+	sed -i 's#k8s.gcr.io/pause:3.[0-9]#k8s.gcr.io/pause:3.6#' integration/main_test.go
 	cp "${SCRIPT_PATH}/container_restart_test.go.patch" ./integration/container_restart_test.go
 
 	#test cri using the built/installed containerd instead of containerd built in cri


### PR DESCRIPTION
- fix: Shell syntax error. 
- fix: support containerd 1.6.x

Depends-on: https://github.com/kata-containers/kata-containers/pull/2733

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>