### PR TITLE
integration: containerd cri integration tests using containerd repo

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -21,7 +21,7 @@ CI=${CI:-""}
 source "${script_dir}/lib.sh"
 
 #Use cri contaienrd tarball format.
-#https://github.com/containerd/cri/blob/master/docs/installation.md#release-tarball
+#https://github.com/containerd/containerd/blob/main/docs/cri/installation.md#release-tarball
 CONTAINERD_OS=$(go env GOOS)
 CONTAIENRD_ARCH=$(go env GOARCH)
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -285,12 +285,12 @@ delete_containerd_cri_stale_resource() {
 	# stop containerd service
 	sudo systemctl stop containerd
 	# remove stale binaries
-	containerd_cri_dir="github.com/containerd/cri"
-	release_dir="${GOPATH}/src/${containerd_cri_dir}/_output/release-stage"
+	containerd_cri_dir=$(get_version "externals.containerd.url")
+	release_bin_dir="${GOPATH}/src/${containerd_cri_dir}/bin"
 	binary_dir_union=( "/usr/local/bin" "/usr/local/sbin" )
 	for binary_dir in ${binary_dir_union[@]}
 	do
-		for stale_binary in ${release_dir}/${binary_dir}/*
+		for stale_binary in ${release_bin_dir}/*
 		do
 			sudo rm -rf ${binary_dir}/$(basename ${stale_binary})
 		done


### PR DESCRIPTION
Since the containerd/cri repo had been deprecated, thus we should
switch to integration tests from containerd repo instead of
containerd/cri.

Fixes: #4198

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>