### PR TITLE
ci: skip k8s-inotify on ppc64le

### DIFF
--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -8,3 +8,4 @@ kubernetes:
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-oom
+  - k8s-inotify


### PR DESCRIPTION
There is no multiarch image supported,
skip the test for now.

Fixes: #4202

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>