### PR TITLE
ci: add k8s uninstallation to metrics tests

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -348,6 +348,21 @@ gen_clean_arch() {
 	info "remove containers started by ctr"
 	clean_env_ctr
 
+	# reset k8s service may impact metrics test on x86_64
+	[ $(uname -m) != "x86_64" -a "$(pgrep kubelet)" != "" ] && sudo sh -c 'kubeadm reset -f'
+	info "Remove installed kubernetes packages and configuration"
+	if [ "$ID" == ubuntu ]; then
+		sudo rm -rf /etc/systemd/system/kubelet.service.d
+		sudo systemctl daemon-reload
+		sudo apt-get autoremove -y kubeadm kubelet kubectl
+	fi
+
+	# Remove existing k8s related configurations and binaries.
+	sudo sh -c 'rm -rf /opt/cni/bin/*'
+	sudo sh -c 'rm -rf /etc/cni /etc/kubernetes/'
+	sudo sh -c 'rm -rf /var/lib/cni /var/lib/etcd /var/lib/kubelet'
+	sudo sh -c 'rm -rf /run/flannel'
+
 	if [[ $CI_JOB != "METRICS" ]]; then
 		info "delete stale kata resource under ${stale_kata_dir_union[@]}"
 		delete_stale_kata_resource
@@ -357,28 +372,14 @@ gen_clean_arch() {
 		delete_crio_stale_resource
 		info "Remove installed containerd-cri related binaries and configuration"
 		delete_containerd_cri_stale_resource
-	fi
 
-	if [[ $CI_JOB != "METRICS" ]]; then
-		#reset k8s service may impact metrics test on x86_64, so limit it to arm64
-		[ $(uname -m) == "aarch64" -a "$(pgrep kubelet)" != "" ] && sudo sh -c 'kubeadm reset -f'
-		info "Remove installed kubernetes packages and configuration"
 		if [ "$ID" == ubuntu ]; then
-			sudo rm -rf /etc/systemd/system/kubelet.service.d
-			sudo apt-get autoremove -y kubeadm kubelet kubectl \
-				$(dpkg -l | awk '{print $2}' | grep -E '^(containerd(.\io)?|docker(\.io|-ce(-cli)?))$')
+			sudo apt-get autoremove -y $(dpkg -l | awk '{print $2}' | grep -E '^(containerd(.\io)?|docker(\.io|-ce(-cli)?))$')
 		fi
-		# Remove existing k8s related configurations and binaries.
-		sudo sh -c 'rm -rf /opt/cni/bin/*'
-		sudo sh -c 'rm -rf /etc/cni /etc/kubernetes/'
-		sudo sh -c 'rm -rf /var/lib/cni /var/lib/etcd /var/lib/kubelet'
-		sudo sh -c 'rm -rf /run/flannel'
 
 		info "Clean up stale network interface"
 		cleanup_network_interface
-	fi
 
-	if [[ $CI_JOB != "METRICS" ]]; then
 		info "Remove Kata package repo registrations"
 		delete_kata_repo_registrations
 	fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -102,7 +102,6 @@ case "${CI_JOB}" in
 		sudo -E ln -sf "${config_path}/configuration-qemu.toml" "${config_path}/configuration.toml"
 		echo "INFO: Running qemu metrics tests"
 		sudo -E PATH="$PATH" ".ci/run_metrics_PR_ci.sh"
-		echo "INFO: Running cloud hypervisor metrics tests"
 		export KATA_HYPERVISOR="cloud-hypervisor"
 		tests_repo="github.com/kata-containers/tests"
 		pushd "${GOPATH}/src/${tests_repo}"

--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -42,9 +42,6 @@ run() {
 			# Run the memory footprint test - the main test that
 			# KSM affects.
 			bash density/memory_usage.sh 20 300 auto
-
-			# And now ensure KSM is turned off for the rest of the tests
-			disable_ksm
 		fi
 	fi
 
@@ -64,9 +61,10 @@ run() {
 	# Run the time tests
 	bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 
-	# Skip: Issue: https://github.com/kata-containers/tests/issues/3203
-	# Run the cpu statistics test
-	# bash network/cpu_statistics_iperf.sh
+	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
+		# Run the cpu statistics test
+		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b
+	fi
 
 	popd
 }

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -71,3 +71,16 @@ checktype = "mean"
 midval = 55700.0
 minpercent = 10.0
 maxpercent = 10.0
+
+[[metric]]
+name = "network-iperf3-bandwidth"
+type = "json"
+description = "measure container bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3-bandwidth\".Results | .[] | .bandwidth.Result"
+checktype = "mean"
+midval = 42241350194.0
+minpercent = 10.0
+maxpercent = 10.0

--- a/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -26,6 +26,7 @@ source "${SCRIPT_PATH}/../../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 test_repo="${test_repo:-github.com/kata-containers/tests}"
 iperf_file=$(mktemp iperfresults.XXXXXXXXXX)
+TEST_NAME="${TEST_NAME:-IPerf}"
 
 function remove_tmp_file() {
 	rm -rf "${iperf_file}"
@@ -208,6 +209,8 @@ EOF
 }
 
 function main() {
+	init_env
+
 	local OPTIND
 	while getopts ":abcjh:" opt
 	do


### PR DESCRIPTION
IPerf bench runs on top of a K8s setup, for instance ci metrics
needs to clean the k8s setup, before start the test.

Fixes: #4205

Signed-off-by: David Esparza <david.esparza.borquez@intel.com>