### PR TITLE
k8s: improve the replication test

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app: nginx
+    app: nginx-rc-test
   template:
     metadata:
       name: nginx
       labels:
-        app: nginx
+        app: nginx-rc-test
     spec:
       terminationGracePeriodSeconds: 0
       runtimeClassName: kata


### PR DESCRIPTION
This contain a couple of improvements:

 - in case of test failure let's print the description of the replication
controller deployment, so to help debug;
 - use array to hold the list of pods as the current code only works if
   replicas is equal to one;
 - if we are unfortunate to have leftovers pods from previous tests which
   application is tagged as 'nginx' then it will mess with the replication test. So
   let's tag our app as 'nginx-rc-test' to avoid that.

Fixes #4214
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>