### PR TITLE
stable-2.3 | Some backports before the 2.3.0 release

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -39,3 +39,4 @@ kubernetes:
   - k8s-expose-ip
   - k8s-oom
   - k8s-block-volume
+  - k8s-inotify

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -21,7 +21,7 @@ CI=${CI:-""}
 source "${script_dir}/lib.sh"
 
 #Use cri contaienrd tarball format.
-#https://github.com/containerd/cri/blob/master/docs/installation.md#release-tarball
+#https://github.com/containerd/containerd/blob/main/docs/cri/installation.md#release-tarball
 CONTAINERD_OS=$(go env GOOS)
 CONTAIENRD_ARCH=$(go env GOARCH)
 

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -286,12 +286,12 @@ delete_containerd_cri_stale_resource() {
 	# stop containerd service
 	sudo systemctl stop containerd
 	# remove stale binaries
-	containerd_cri_dir="github.com/containerd/cri"
-	release_dir="${GOPATH}/src/${containerd_cri_dir}/_output/release-stage"
+	containerd_cri_dir=$(get_version "externals.containerd.url")
+	release_bin_dir="${GOPATH}/src/${containerd_cri_dir}/bin"
 	binary_dir_union=( "/usr/local/bin" "/usr/local/sbin" )
 	for binary_dir in ${binary_dir_union[@]}
 	do
-		for stale_binary in ${release_dir}/${binary_dir}/*
+		for stale_binary in ${release_bin_dir}/*
 		do
 			sudo rm -rf ${binary_dir}/$(basename ${stale_binary})
 		done

--- a/.ci/ppc64le/configuration_ppc64le.yaml
+++ b/.ci/ppc64le/configuration_ppc64le.yaml
@@ -8,3 +8,4 @@ kubernetes:
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-oom
+  - k8s-inotify

--- a/.ci/s390x/configuration_s390x.yaml
+++ b/.ci/s390x/configuration_s390x.yaml
@@ -5,3 +5,4 @@
 
 kubernetes:
   - k8s-caps
+  - k8s-inotify

--- a/integration/kubernetes/k8s-inotify.bats
+++ b/integration/kubernetes/k8s-inotify.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	get_pod_config_dir
+}
+
+@test "configmap update works, and preserves symlinks" {
+        pod_name="inotify-configmap-testing"
+
+        # Create configmap for my deployment
+        kubectl apply -f "${pod_config_dir}"/inotify-configmap.yaml
+
+        # Create deployment that expects identity-certs
+        kubectl apply -f "${pod_config_dir}"/inotify-configmap-pod.yaml
+        kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+        # Update configmap
+        kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml
+
+        # Ideally we'd wait for the pod to complete...
+        sleep 120
+
+        # Verify we saw the update
+        result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")
+        echo $result | grep -vq Error
+
+        kubectl delete configmap cm
+}
+
+
+
+teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -31,6 +31,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-env.bats" \
 	"k8s-exec.bats" \
 	"k8s-expose-ip.bats" \
+        "k8s-inotify.bats" \
 	"k8s-job.bats" \
 	"k8s-limit-range.bats" \
 	"k8s-liveness-probes.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inotify-configmap-testing
+spec:
+  containers:
+  - name: c1
+    image: quay.io/kata-containers/fsnotify:latest
+    command: ["bash"]
+    args: ["-c", "inotifywait --timeout 120 -r /config/ && [[ -L /config/config.toml ]] && echo success" ]
+    resources:
+      requests:
+        cpu: 1
+        memory: 50Mi
+      limits:
+        cpu: 1
+        memory: 1024Mi
+    volumeMounts:
+      - name: config
+        mountPath: /config
+  runtimeClassName: kata
+  restartPolicy: Never
+  volumes:
+    - name: config
+      configMap:
+        name: cm

--- a/integration/kubernetes/runtimeclass_workloads/inotify-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-configmap.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+data:
+  config.toml: |-
+    foo original...
+kind: ConfigMap
+metadata:
+  name: cm

--- a/integration/kubernetes/runtimeclass_workloads/inotify-updated-configmap.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/inotify-updated-configmap.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2021 Apple Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v1
+data:
+  config.toml: |-
+    foo original...
+    ... updated
+kind: ConfigMap
+metadata:
+  name: cm

--- a/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   replicas: 1
   selector:
-    app: nginx
+    app: nginx-rc-test
   template:
     metadata:
       name: nginx
       labels:
-        app: nginx
+        app: nginx-rc-test
     spec:
       terminationGracePeriodSeconds: 0
       runtimeClassName: kata


### PR DESCRIPTION
This PR backports:
* kubernetes: add integration test for inotify workaround support (#4180)
  * ci: skip k8s-inotify on ppc64le (#4202)
* integration: containerd cri integration tests using containerd repo (#4198)
* k8s: improve the replication test (#4214) 