### PR TITLE
spell-checker: Add new words for DinD docs

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -7,6 +7,7 @@
 ACPI/AB
 ACS/AB
 API/AB
+AUFS # Another Union FS
 AWS/AB
 BDF/AB
 CFS/AB
@@ -17,6 +18,8 @@ CPUID/AB
 CRI/AB
 CVE/AB
 DAX/AB
+DinD/B # Docker in Docker
+dind/B
 DMA/AB
 DPDK/AB
 FaaS/AB
@@ -40,12 +43,14 @@ KVM/AB
 LTS/AB
 MACVTAP/AB
 mem/B	# For terms like "virtio-mem"
+memdisk/B
 MDEV/AB
 NEMU/AB
 NIC/AB
 NVDIMM/AB
 OCI/AB
 OVMF/AB
+OverlayFS/B
 PCDIMM/AB
 PCI/AB
 PCIe/AB

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -27,6 +27,7 @@ deploy
 dialer
 dialog/A
 distro/AB
+emptydir/A
 enablement/AB
 entrypoint/AB
 ethernet
@@ -55,6 +56,7 @@ linter/AB
 logfile/A
 Longterm
 longterm
+loopback
 memcpy/A
 mergeable
 metadata


### PR DESCRIPTION
Let's add a few new words to our dictionary so the DinD documentation
can be merged on the kata-containers side.

The words needed are:
- AUFS
- DinD
- dind
- emptydir
- loopback
- memdisk
- OverlayFS

Fixes: #4229

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>