### PR TITLE
integration/kubernetes: volume tests for nested configmap and secret

### DIFF
--- a/integration/kubernetes/k8s-nested-configmap-secret.bats
+++ b/integration/kubernetes/k8s-nested-configmap-secret.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	
+	export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+	get_pod_config_dir
+
+	pod_name="nested-configmap-secret-pod"
+}
+
+@test "Nested mount of a secret volume in a configmap volume for a pod" {
+	# Creates a configmap, secret and pod that mounts the secret inside the configmap
+	kubectl create -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+	# Check config/secret value are correct
+	[ "myconfig" == $(kubectl exec $pod_name -- cat /config/config_key) ]
+	[ "mysecret" == $(kubectl exec $pod_name -- cat /config/secret/secret_key) ]
+}
+
+teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	# Delete the configmap, secret, and pod used for testing
+	kubectl delete -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -36,6 +36,7 @@ K8S_TEST_UNION=("k8s-attach-handlers.bats" \
 	"k8s-limit-range.bats" \
 	"k8s-liveness-probes.bats" \
 	"k8s-memory.bats" \
+	"k8s-nested-configmap-secret.bats" \
 	"k8s-number-cpus.bats" \
 	"k8s-oom.bats" \
 	"k8s-optional-empty-configmap.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2021 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config_key: myconfig
+---
+apiVersion: v1
+data:
+  secret_key: bXlzZWNyZXQ= #mysecret
+kind: Secret
+metadata:
+  name: secret
+type: Opaque
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nested-configmap-secret-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+    - name: test-container
+      image: quay.io/prometheus/busybox:latest
+      command: ["tail", "-f", "/dev/null"]
+      volumeMounts:
+        - mountPath: /config
+          name: config
+        - mountPath: /config/secret
+          name: secret
+  volumes:
+    - name: secret
+      secret:
+        secretName: secret
+    - name: config
+      configMap:
+        name: config
+  restartPolicy: Never


### PR DESCRIPTION
This test makes sure that pods that mount a secret volumes inside of configmap volume will work correctly.

Fixes: #4239

Signed-off-by: Simon Kaegi <simon.kaegi@gmail.com>