### PR TITLE
tests: update API version of RuntimeClass resource

### DIFF
--- a/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/kata-runtimeclass.yaml
@@ -1,5 +1,5 @@
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
   name: kata
 handler: kata


### PR DESCRIPTION
RuntimeClass' API version of node.k8s.io/v1beta1 is deprecated,
should be updated to node.k8s.io/v1.

Fixes: #4243

Signed-off-by: bin <bin@hyper.sh>

Now in CI logs:

> 14:30:53 Create kata RuntimeClass resource
14:30:53 Warning: node.k8s.io/v1beta1 RuntimeClass is deprecated in v1.22+, unavailable in v1.25+
14:30:53 runtimeclass.node.k8s.io/kata created

