### PR TITLE
ci: Make building skopeo not default

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -50,7 +50,7 @@ build_rust_image() {
 			fi
 			distro="${osbuilder_distro:-ubuntu}"
 			if [ ${CCV0} == "yes" ]; then
-				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" SKOPEO_UMOCI=yes make -e "image"
+				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" UMOCI=yes make -e "image"
 			else
 				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
 					make -e "${target_image}"


### PR DESCRIPTION
Change the default CCv0 install image to build and add just umoci

Fixes: #4245
Depends-on: github.com/kata-containers/kata-containers#3171

Signed-off-by: stevenhorsman <steven@uk.ibm.com>