### PR TITLE
workflows: Bump golang to 1.17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
According to https://endoflife.date/go golang 1.15 is not supported
anymore.  Let's remove it from out tests, add 1.17.x, and bump the
newest version known to work when building kata to 1.17.3.

This is the tests counterpart of kata-containers/kata-containers#3017,
which I simply forgot to open when dealing with the `kata-containers
repo.

Fixes: #4250 

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>