### PR TITLE
static-checks: Check for the `force-skip-ci` label on each step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
 name: Static checks
 jobs:
   test:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x]
@@ -25,10 +24,12 @@ jobs:
       TRAVIS_PULL_REQUEST_SHA : ${{ github.event.pull_request.head.sha }}
     steps:
     - name: Install Go
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
     - name: Setup GOPATH
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         gopath_org=$(go env GOPATH)/src/github.com/kata-containers/
         mkdir -p ${gopath_org}
@@ -38,20 +39,25 @@ jobs:
         echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
         echo "TRAVIS: ${TRAVIS}"
     - name: Set env
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Checkout code
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
         path: ./src/github.com/${{ github.repository }}
     - name: Setup travis references
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         echo "TRAVIS_BRANCH=${TRAVIS_BRANCH:-$(echo $GITHUB_REF | awk 'BEGIN { FS = \"/\" } ; { print $3 }')}" 
     - name: Install dependencies
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         cd ${GOPATH}/src/github.com/kata-containers/tests && ./.ci/setup.sh
     - name: Static checks
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         cd ${GOPATH}/src/github.com/kata-containers/tests && ./.ci/static-checks.sh github.com/kata-containers/tests


### PR DESCRIPTION
This is not the most beautiful solution, but that's what I've already
been doing as part of the `kata-containers` repo since
kata-containers/kata-containers#2361.

We do that othewise some of the checks won't even start, making any PR
using the `force-skip-ci` label not mergeable.

Fixes: #4253

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>