### PR TITLE
ci: fix CI entry point for cri-o PRs

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -183,6 +183,7 @@ case "${CI_JOB}" in
 "EXTERNAL_CRIO")
 	init_ci_flags
 	export CRIO="yes"
+	export CRI_RUNTIME="crio"
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	export TEST_CRIO="true"


### PR DESCRIPTION
A flag was missing, making the script try to test with containerd
rather than cri-o.

Fixes: #4103

Signed-off-by: Julien Ropé <jrope@redhat.com>