### PR TITLE
 openshift-ci: adapt scripts to test like OpenShift Sandboxed Containers - respin

### DIFF
--- a/.ci/openshift-ci/images/Dockerfile.installer
+++ b/.ci/openshift-ci/images/Dockerfile.installer
@@ -7,7 +7,7 @@
 #
 FROM registry.centos.org/centos:8
 
-RUN yum install -y rsync
+RUN yum install -y rsync dracut
 
 # Load the installation files.
 COPY ./_out ./_out

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -26,3 +26,4 @@ info "Run test suite: $suite"
 test_status='PASS'
 ${script_dir}/run_${suite}_test.sh || test_status='FAIL'
 info "Test suite: $suite: $test_status"
+[ "$test_status" == "PASS" ]

--- a/versions.yaml
+++ b/versions.yaml
@@ -86,4 +86,4 @@ externals:
 openshift-ci:
   dracut_kernel:
     description: "kernel that dracut should be pulling modules in the initramfs"
-    version: "4.18.0-305.19.1.el8_4.x86_64"
+    version: "4.18.0-348.2.1.el8_5.x86_64"


### PR DESCRIPTION
This is a respin of [openshift-ci: adapt scripts to test like OpenShift Sandboxed Containers](https://github.com/kata-containers/tests/pull/4164).

When I started working on the new job on OpenShift CI for OCP 4.10 I realized that the `centos:8` image had been updated to ship the EL 8.5 kernel, consequently kata's initrd now includes `4.18.0-348.2.1.el8_5.x86_64` modules. The OCP 4.10 worker nodes will be running with an EL 8.4 kernel, and that mismatch drives the Kata's VM to crash on boot. To solve that problem I added a code on the installer script to simply copy the host's kernel modules over the initrd in case of mismatch. This worked out on my test environment.

An alternative approach would be to use a buildroot which provides the EL 8.4 kernel but I couldn't find a suitable image, hence the solution I propose on that PR. 