### PR TITLE
spell: Fix hypervisor entry in dictionary

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -42,7 +42,7 @@ HugePage/AB
 hugepage/AB
 Hyp
 hypercall/A
-hypervisor/A
+hypervisor/AB
 implementer/A
 implementor/A
 iodepth/A


### PR DESCRIPTION
Correct the custom spelling dictionary for the word "hypervisor". It
already allowed:

- > hypervisors

  (rule "A")

... but disallowed erroneously the following:

- > hypervisor's

  (rule "B")

Fixes: #4274.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>