### PR TITLE
kubernetes: strengthen the init.sh and misc refactors

### DIFF
--- a/.ci/aarch64/kubernetes/init.sh
+++ b/.ci/aarch64/kubernetes/init.sh
@@ -8,8 +8,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
+
 network_plugin_config_file="${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/kube-flannel.yml"
 
+flannel_url="$(get_test_version "externals.flannel.kube-flannel_url")"
 curl -fsL $flannel_url -o $network_plugin_config_file
 
 memory_resource="spec.template.spec.containers[*].resources.*.memory"

--- a/.ci/ppc64le/kubernetes/init.sh
+++ b/.ci/ppc64le/kubernetes/init.sh
@@ -8,8 +8,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
+
 network_plugin_config_file="${SCRIPT_PATH}/../../.ci/${arch}/kubernetes/kube-flannel.yml"
 
+flannel_url="$(get_test_version "externals.flannel.kube-flannel_url")"
 curl -fsL $flannel_url -o $network_plugin_config_file
 
 memory_resource="spec.template.spec.containers[*].resources.*.memory"

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -24,7 +24,7 @@ main () {
 		cri_runtime_socket="/var/run/crio/crio.sock"
 		;;
 	*)
-		echo "Runtime ${CRI_RUNTIME} not supported"
+		die "Runtime ${CRI_RUNTIME} not supported"
 		;;
 	esac
 
@@ -41,7 +41,7 @@ main () {
 
 	info "Remove network devices"
 	for dev in cni0 flannel.1; do
-		echo "remove device: $dev"
+		info "remove device: $dev"
 		sudo ip link set dev "$dev" down || true
 		sudo ip link del "$dev" || true
 	done

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -10,41 +10,52 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
-cri_runtime="${CRI_RUNTIME:-crio}"
-
-case "${cri_runtime}" in
-containerd)
-	cri_runtime_socket="/run/containerd/containerd.sock"
-	;;
-crio)
-	cri_runtime_socket="/var/run/crio/crio.sock"
-	;;
-*)
-	echo "Runtime ${cri_runtime} not supported"
-	;;
-esac
-
-export KUBECONFIG="$HOME/.kube/config"
-sudo -E kubeadm reset -f --cri-socket="${cri_runtime_socket}"
-
-[ "${container_engine}" == "docker" ] && restart_docker_service
-registry_server_teardown
-
-sudo systemctl stop "${cri_runtime}"
-
-sudo ip link set dev cni0 down || true
-sudo ip link set dev flannel.1 down || true
-sudo ip link del cni0 || true
-sudo ip link del flannel.1 || true
-
-# if CI run in bare-metal, we need a set of extra clean
 BAREMETAL="${BAREMETAL:-false}"
-if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
-	bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
-fi
+CRI_RUNTIME="${CRI_RUNTIME:-crio}"
 
-# Check no kata processes are left behind after reseting kubernetes
-check_processes
+main () {
+	local cri_runtime_socket=""
 
-# Checks that pods were not left
-check_pods
+	case "${CRI_RUNTIME}" in
+	containerd)
+		cri_runtime_socket="/run/containerd/containerd.sock"
+		;;
+	crio)
+		cri_runtime_socket="/var/run/crio/crio.sock"
+		;;
+	*)
+		echo "Runtime ${CRI_RUNTIME} not supported"
+		;;
+	esac
+
+	info "Reset Kubernetes"
+	export KUBECONFIG="$HOME/.kube/config"
+	sudo -E kubeadm reset -f --cri-socket="${cri_runtime_socket}"
+
+	info "Teardown the registry server"
+	[ "${container_engine}" == "docker" ] && restart_docker_service
+	registry_server_teardown
+
+	info "Stop ${CRI_RUNTIME} service"
+	sudo systemctl stop "${CRI_RUNTIME}"
+
+	info "Remove network devices"
+	for dev in cni0 flannel.1; do
+		echo "remove device: $dev"
+		sudo ip link set dev "$dev" down || true
+		sudo ip link del "$dev" || true
+	done
+
+	# if CI run in bare-metal, we need a set of extra clean
+	if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
+		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
+	fi
+
+	info "Check no kata processes are left behind after reseting kubernetes"
+	check_processes
+
+	info "Checks that pods were not left"
+	check_pods
+}
+
+main $@

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -57,7 +57,7 @@ wait_pods_ready()
 		running_pattern="${pod_entry}.*1/1.*Running"
 		if ! waitForProcess "$system_pod_wait_time" "$sleep_time" \
 			"$pods_status | grep "${running_pattern}""; then
-			echo "Some expected Pods aren't running after ${system_pod_wait_time} seconds." 1>&2
+			info "Some expected Pods aren't running after ${system_pod_wait_time} seconds." 1>&2
 			${pods_status} 1>&2
 			# Print debug information for the problematic pods.
 			for pod in $(kubectl get pods --all-namespaces \
@@ -129,10 +129,10 @@ configure_network() {
 		# default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation
 		local flannel_version="$(get_test_version "externals.flannel.version")"
 		local flannel_url="$(get_test_version "externals.flannel.kube-flannel_url")"
-		echo "Use flannel ${flannel_version}"
+		info "Use flannel ${flannel_version}"
 		network_plugin_config="$flannel_url"
 	fi
-	echo "Use configuration file from ${network_plugin_config}"
+	info "Use configuration file from ${network_plugin_config}"
 	kubectl apply -f "$network_plugin_config"
 }
 
@@ -170,7 +170,7 @@ start_kubernetes() {
 	local cgroup_driver="$3"
 	local kubeadm_config_template="${SCRIPT_PATH}/kubeadm/config.yaml"
 
-	echo "Init cluster using ${cri_socket_path}"
+	info "Init cluster using ${cri_socket_path}"
 
 	# This should be global otherwise the clean up fails.
 	kubeadm_config_file="$(mktemp --tmpdir kubeadm_config.XXXXXX.yaml)"
@@ -200,7 +200,7 @@ start_kubernetes() {
 
 	# enable debug log for kubelet
 	sudo sed -i 's/.$/ --v=4"/' /var/lib/kubelet/kubeadm-flags.env
-	echo "Kubelet options:"
+	info "Kubelet options:"
 	sudo cat /var/lib/kubelet/kubeadm-flags.env
 	sudo systemctl daemon-reload && sudo systemctl restart kubelet
 
@@ -238,7 +238,7 @@ start_cri_runtime_service() {
 		#when the test runs two times in the CI, the second time crio takes some time to be ready
 		sleep "${wait_time_cri_socket_check}"
 		[ -e "${socket_path}" ] && break
-		echo "Waiting for cri socket ${socket_path} (try ${i})"
+		info "Waiting for cri socket ${socket_path} (try ${i})"
 	done
 
 	sudo systemctl status "${cri}" --no-pager || \
@@ -261,7 +261,7 @@ main() {
 		cgroup_driver="systemd"
 		;;
 	*)
-		echo "Runtime ${CRI_RUNTIME} not supported"
+		die "Runtime ${CRI_RUNTIME} not supported"
 		;;
 	esac
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -60,6 +60,8 @@ externals:
   flannel:
     url: "https://github.com/coreos/flannel"
     version: "v0.14.0"
+    # yamllint disable-line rule:line-length
+    kube-flannel_url: "https://raw.githubusercontent.com/coreos/flannel/v0.14.0/Documentation/kube-flannel.yml"
 
   xurls:
     description: |


### PR DESCRIPTION
The main goal of this PR is to address the improvements listed in #4247 for the initialization script of the kubernetes integration tests.

The highlights are:
 * now the initialization is retried in case of fail
 * added debug information to `wait_for_pods()` as in my experience that method drive to many CI jobs to fail and we don't know what happened
 * More `info()` calls to help debugability

Along the way I refactored some scripts to improve maintainability and ease reviews.