### PR TITLE
integration/k8s: Allow for pod removal

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -71,3 +71,6 @@ do
 	bats "${K8S_TEST_ENTRY}"
 done
 popd
+
+# Allow for pod deletion before running `kubeadm reset`, potentially leaving pods behind
+sleep 10


### PR DESCRIPTION
~Refactored the cleanup_env.sh so that it has a main() and added more~
~info() messages.~

~Fixes: #3998~
~Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>~
~Cherry-picked-by: Jakob Naucke <jakob.naucke@ibm.com>~

~@wainersm I think this commit from your #4279 will unblock s390x. If it does, it might be better to merge it already.~

---

~We check that after k8s cleanup, no Kata-related processes are left.~
~Give this a `waitForProcess` to allow for some tolerance.~

~Fixes: #3998~
~Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>~

---

After `kubeadm reset`, we frequently see remaining pods running. Sleep
10 seconds after running all tests to allow for the completion of pod
removal.

Fixes: #3998
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>