### PR TITLE
respin - [DNM] tracing: Move tracing test to different job

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -54,6 +54,8 @@ case "${CI_JOB}" in
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		echo "INFO: Running ksm test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
+		echo "INFO: Running tracing test"
+		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
 	"CRI_CONTAINERD_K8S_COMPLETE")
 		echo "INFO: Running e2e kubernetes tests"
@@ -62,8 +64,6 @@ case "${CI_JOB}" in
 	"CRI_CONTAINERD_K8S_MINIMAL")
 		echo "INFO: Running e2e kubernetes tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
-		echo "INFO: Running tracing test"
-		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -43,7 +43,7 @@ set -o errtrace
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../.ci/lib.sh"
 
-RUNTIME=${RUNTIME:-"io.containerd.kata.v2"}
+CTR_RUNTIME=${CTR_RUNTIME:-"io.containerd.kata.v2"}
 
 # Kata always uses this value
 EXPECTED_VSOCK_PORT="1024"
@@ -949,7 +949,7 @@ start_agent_in_kata_vm()
 		-s \"$KATA_TMUX_VM_SESSION\" \
 		\"sudo ctr run \
 			--snapshotter '$snapshotter' \
-			--runtime '${RUNTIME}' \
+			--runtime '${CTR_RUNTIME}' \
 			--rm \
 			-t '${CTR_IMAGE}' \
 			'$container_id' \


### PR DESCRIPTION
Since the current job that ran the tracing test is disabled, move it to
an existing job.

Fixes #4195

Signed-off-by: Chelsea Mafrica chelsea.e.mafrica@intel.com

Testing commits from #4196 in a new PR due to a CI failure saying trace forwarder doesn't exist. 