### PR TITLE
Backport ci: Always install newest Rust version

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -174,8 +174,8 @@ popd
 # Run unit tests on non x86_64
 if [ "$arch" != "x86_64" ]; then
 	echo "Running unit tests"
-	cargo_env="$HOME/.cargo/env"
-	[ -e "${cargo_env}" ] || "${ci_dir_name}/install_rust.sh" && source "${cargo_env}"
+	sudo chown -R "$USER" "$HOME/.cargo" || true
+	"$ci_dir_name/install_rust.sh" && source "$HOME/.cargo/env"
 	pushd "${GOPATH}/src/${katacontainers_repo}"
 	echo "Installing libseccomp library from sources"
 	libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -765,14 +765,7 @@ setup()
 		exit 0
 	}
 
-	# Ensure rust commands are found
-	local cargo="$HOME/.cargo"
-	[ -d "$cargo" ] && sudo chown -R "${USER}:" \
-		"$cargo" \
-		"$kata_repo_dir"
-
-	local file="${cargo}/env"
-	[ -e "$file" ] || "${SCRIPT_PATH}/../.ci/install_rust.sh" && source "$file"
+	"${SCRIPT_PATH}/../.ci/install_rust.sh" && source "$HOME/.cargo/env"
 
 	trap cleanup EXIT
 


### PR DESCRIPTION
In the unit tests and the agent shutdown test, we install Rust iff it
isn't installed. On CI instances that are not reinstated for every job
(e.g. ARM & s390x), this leads to Rust never getting updated (1.47 at
the moment). The Rust installation script already does what we should
do: It installs the required version of Rust unless it is already
installed. Use that without checks.

Fixes: #4179
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Backport of #4288