### PR TITLE
static-checks: Remove `git ls-remote` check

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -773,12 +773,6 @@ static_check_docs()
 		# Google APIs typically require an auth token.
 		echo "$url"|grep -q 'https://www.googleapis.com' && continue
 
-		# Git repo URL check
-		if echo "$url"|grep -q '^https.*git'
-		then
-			timeout "${KATA_NET_TIMEOUT}" git ls-remote "$url" > /dev/null 2>&1 && continue
-		fi
-
 		# Check the URL, saving it if invalid
 		#
 		# Each URL is checked in a separate process as each unique URL


### PR DESCRIPTION
is no longer needed and incompatible e.g. with a link to a GitHub
namespace

Fixes: #4301
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>