### PR TITLE
ci: exclude the SPDX-License check for some proto files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -510,8 +510,8 @@ static_check_license_headers()
 			--exclude="*.diff" \
 			--exclude="tools/packaging/static-build/qemu.blacklist" \
 			--exclude="tools/packaging/qemu/default-configs/*" \
-			--exclude="src/agent/protocols/protos/gogo/*" \
-			--exclude="src/agent/protocols/protos/google/*" \
+			--exclude="src/libs/protocols/protos/gogo/*.proto" \
+			--exclude="src/libs/protocols/protos/google/*.proto" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
Since we'd plan to move the protocols crate to upper libs
directory, thus rename the excluded spdx license checking
files.

Fixes: [#3348](https://github.com/kata-containers/kata-containers/issues/3348)

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>