### PR TITLE
k8s: add more test cases in k8s-env.bats

### DIFF
--- a/integration/kubernetes/k8s-env.bats
+++ b/integration/kubernetes/k8s-env.bats
@@ -24,6 +24,13 @@ setup() {
 	# Print environment variables
 	cmd="printenv"
 	kubectl exec $pod_name -- sh -c $cmd | grep "MY_POD_NAME=$pod_name"
+	kubectl exec $pod_name -- sh -c $cmd | \
+		grep "HOST_IP=\([0-9]\+\(\.\|$\)\)\{4\}"
+	# Requested 32Mi of memory
+	kubectl exec $pod_name -- sh -c $cmd | \
+		grep "MEMORY_REQUESTS=$((1024 * 1024 * 32))"
+	# Memory limits allocated by the node
+	kubectl exec $pod_name -- sh -c $cmd | grep "MEMORY_LIMITS=[1-9]\+"
 }
 
 teardown() {

--- a/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -18,11 +18,29 @@ spec:
       - while true; do
           echo -en '\n';
           printenv MY_POD_NAME;
+          printenv HOST_IP;
+          printenv MEMORY_REQUESTS;
+          printenv MEMORY_LIMITS;
           sleep 1;
         done;
+      resources:
+        requests:
+          memory: "32Mi"
       env:
         - name: MY_POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: MEMORY_REQUESTS
+          valueFrom:
+            resourceFieldRef:
+              resource: requests.memory
+        - name: MEMORY_LIMITS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
   restartPolicy: Never


### PR DESCRIPTION
This increased the coverage of k8s-env.bats by adding cases where
different sources have their values loaded and exported in the container
environment.

Fixes #4323
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>