### PR TITLE
ci: do not drop merge commits when rebasing

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -74,7 +74,7 @@ if [ "${repo_to_test}" == "${tests_repo}" ]; then
 		pr_branch="PR_${pr_number}"
 		git fetch origin "pull/${pr_number}/head:${pr_branch}"
 		git checkout "${pr_branch}"
-		git rebase "origin/${ghprbTargetBranch}"
+		git rebase --rebase-merges "origin/${ghprbTargetBranch}"
 	fi
 fi
 


### PR DESCRIPTION
As "by default, a rebase will simply drop merge commits from the todo
list, and put the rebased commits into a single, linear branch", let's
ensure we pass `--rebase-merges` to `git rebase`.

Reference: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt--r

Fixes: #4329

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>