### PR TITLE
k8s: check $number_cpus before using it

### DIFF
--- a/integration/kubernetes/k8s-number-cpus.bats
+++ b/integration/kubernetes/k8s-number-cpus.bats
@@ -31,9 +31,11 @@ setup() {
 		# Get number of cpus
 		number_cpus=$(kubectl exec pod/"$pod_name" -c "$container_name" \
 			-- sh -c "$num_cpus_cmd")
-		# Verify number of cpus
-		[ "$number_cpus" -le "$max_number_cpus" ]
-		[ "$number_cpus" -eq "$max_number_cpus" ] && break
+		if [[ "$number_cpus" =~ ^[0-9]+$ ]]; then
+			# Verify number of cpus
+			[ "$number_cpus" -le "$max_number_cpus" ]
+			[ "$number_cpus" -eq "$max_number_cpus" ] && break
+		fi
 		sleep 1
 	done
 }


### PR DESCRIPTION
In integration/kubernetes/k8s-number-cpus.bats the number of cpus in
the pod is stored in $number_cpus which is afterwards used to compare
with the maximum allowed. But $number_cpus can be empty sometimes, so
here is added a checking before using it.

Fixes #4328
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>