### PR TITLE
ci: "local" can only be used in functions

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -76,7 +76,7 @@ if [ "${repo_to_test}" == "${tests_repo}" ]; then
 		pr_branch="PR_${pr_number}"
 		git fetch origin "pull/${pr_number}/head:${pr_branch}"
 		git checkout "${pr_branch}"
-		local rebase_merge_flag="--rebase-merges"
+		rebase_merge_flag="--rebase-merges"
 		if [[ ${ID} == "ubuntu" && ${VERSION_ID} == "18.04" ]]; then
 			rebase_merge_flag="--preserve-merges"
 		fi


### PR DESCRIPTION
Sorry for the breakage, again, but it seems I've overlooked and used
"local" outside of a function, causing a breakage while trying to fix a
breakage. /o\

```
++ echo 'Failed at /tmp/jenkins/workspace/kata-containers-2.0-ubuntu-PR-x86_64-clh-crio-tests-repo/ci_entry_point.sh +79: local rebase_merge_flag="--rebase-merges"'
Failed at /tmp/jenkins/workspace/kata-containers-2.0-ubuntu-PR-x86_64-clh-crio-tests-repo/ci_entry_point.sh +79: local rebase_merge_flag="--rebase-merges"
++ exit 1
```

3rd time's the charm!

Fixes: #4334

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>