### PR TITLE
integration: add the agent namespace test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ vfio:
 	bash -f functional/vfio/run.sh -s false -p qemu -m q35 -i image
 	bash -f functional/vfio/run.sh -s true -p qemu -m q35 -i image
 
+agent: bash -f integration/agent/agent_test.sh
+
 help:
 	@echo Subsets of the tests can be run using the following specific make targets:
 	@echo " $(UNION)" | sed 's/ /\n\t/g'
@@ -152,4 +154,5 @@ help:
 	tracing \
 	vcpus \
 	vfio \
-	pmem
+	pmem \
+	agent

--- a/integration/agent/agent_test.sh
+++ b/integration/agent/agent_test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This will run a containers and then check
+# whether the kata-agent threads namespaces
+# were changed during create container processes.
+
+set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[ -n "$BASH_VERSION" ] && set -o errtrace
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+dir_path=$(dirname "$0")
+source "${dir_path}/../../lib/common.bash"
+source "${dir_path}/../../metrics/lib/common.bash"
+
+CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
+CONTAINER_NAME="${CONTAINER_NAME:-test}"
+IMAGE="${IMAGE:-quay.io/library/busybox:latest}"
+
+setup() {
+        restart_containerd_service
+        check_processes
+}
+
+test_agent() {
+	sudo ctr image pull "${IMAGE}"
+        [ $? != 0 ] && die "Unable to get image $IMAGE"
+        sudo ctr run --runtime="${CTR_RUNTIME}" -d --privileged --rm --mount type=bind,src=/proc,dst=/proc,options=rbind:ro "${IMAGE}" "${CONTAINER_NAME}" sh -c "tail -f /dev/null" || die "Test failed"
+
+	sudo ctr t exec --exec-id test ${CONTAINER_NAME} sh -c 'ps -ef | grep kata-agent | grep -v grep'
+
+	agent_pid=$(sudo ctr t exec --exec-id test ${CONTAINER_NAME} sh -c 'ps -ef | grep kata-agent | grep -v grep' | awk '{print $1}')
+	agent_tasks=$(sudo ctr t exec --exec-id test ${CONTAINER_NAME} sh -c "ls /proc/$agent_pid/task")
+
+	ns="cgroup ipc mnt net pid user uts"
+
+	for t in $agent_tasks; do
+		for i in $ns; do 
+			agent_namespace=$(sudo ctr t exec --exec-id test ${CONTAINER_NAME} sh -c "ls -al /proc/$t/ns/$i" | awk '{print $NF}')
+			root_namespace=$(sudo ctr t exec --exec-id test ${CONTAINER_NAME} sh -c "ls -al /proc/1/ns/$i" | awk '{print $NF}')
+
+    			[ "$agent_namespace" == "$root_namespace" ] || die "the agent's namespace $agent_namespace isn't equal to $root_namespace"
+		done
+	done	
+}
+
+teardown() {
+        clean_env_ctr
+        check_processes
+}
+
+trap teardown EXIT
+
+echo "Running setup"
+setup
+
+echo "Running stability integration tests with agent"
+test_agent


### PR DESCRIPTION
Since the kata agent would change some of its threads
namespaces during creating the container's process,
thus this test would to check whether those changes
were recovered.

Fixes: #4340
Depeneds-on: https://github.com/kata-containers/kata-containers/pull/3370

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>