### PR TITLE
ci: Improve `--rebase-merges` compatibility

### DIFF
--- a/.ci/ci_entry_point.sh
+++ b/.ci/ci_entry_point.sh
@@ -77,7 +77,8 @@ if [ "${repo_to_test}" == "${tests_repo}" ]; then
 		git fetch origin "pull/${pr_number}/head:${pr_branch}"
 		git checkout "${pr_branch}"
 		rebase_merge_flag="--rebase-merges"
-		if [[ ${ID} == "ubuntu" && ${VERSION_ID} == "18.04" ]]; then
+		has_rebase_merges=$(git rebase --help 2>&1|grep -- --rebase-merges || true)
+		if [ -z "${has_rebase_merges}" ]; then
 			rebase_merge_flag="--preserve-merges"
 		fi
 		git rebase "${rebase_merge_flag}" "origin/${ghprbTargetBranch}"


### PR DESCRIPTION
- Improve the logic to support distros other than Ubuntu 18.04

Fixes: #4344
Signed-off-by: stevenhorsman <steven@uk.ibm.com>