### PR TITLE
Makefile: Remove unused podman tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,6 @@ endif
 # The time limit in seconds for each test
 TIMEOUT := 120
 
-PODMAN_DEPENDENCY = podman
-ifeq (${CI}, true)
-        ifneq (${TEST_CGROUPSV2}, true)
-                PODMAN_DEPENDENCY =
-        endif
-endif
-
 # union for 'make test'
 UNION := kubernetes
 


### PR DESCRIPTION
This PR removes part of how we were running podman integration tests
for kata 1.x, currently for kata 2.0 we do not have podman integration
tests running or even existing in our test repository, this PR makes
cleaner the Makefile.

Fixes #4352

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>