### PR TITLE
vagrant: Use the default distro with osbuilder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,8 +113,6 @@ EOF
     fedora.vm.provision "shell", inline: <<-SHELL
       source "#{guest_env_file}"
       cd "${GOPATH}/src/github.com/kata-containers/tests"
-      # Build the osbuilder with same distro as the host.
-      export osbuilder_distro="fedora"
       sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'
     SHELL
   end
@@ -132,8 +130,6 @@ EOF
     ubuntu.vm.provision "shell", inline: <<-SHELL
       source "#{guest_env_file}"
       cd "${GOPATH}/src/github.com/kata-containers/tests"
-      # Build the osbuilder with same distro as the host.
-      export osbuilder_distro="ubuntu"
       sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'
     SHELL
   end


### PR DESCRIPTION
Instead of using the same distro as the host, let's just use the default
one.

The reasoning behind this change is because support for some of the
distros used as rootfs has been removed.

Fixes: #4356
Depends-on: github.com/kata-containers/kata-containers#3420

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>