### PR TITLE
k8s: add firecracker limitation issue link

### DIFF
--- a/integration/kubernetes/k8s-cpu-ns.bats
+++ b/integration/kubernetes/k8s-cpu-ns.bats
@@ -7,7 +7,6 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"

--- a/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/integration/kubernetes/k8s-credentials-secrets.bats
@@ -7,7 +7,6 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"

--- a/integration/kubernetes/k8s-projected-volume.bats
+++ b/integration/kubernetes/k8s-projected-volume.bats
@@ -7,7 +7,6 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"

--- a/integration/kubernetes/k8s-ro-volume.bats
+++ b/integration/kubernetes/k8s-ro-volume.bats
@@ -7,7 +7,6 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
-fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"

--- a/integration/kubernetes/k8s-volume.bats
+++ b/integration/kubernetes/k8s-volume.bats
@@ -9,7 +9,6 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="https://github.com/kata-containers/runtime/issues/1127"
-fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 
 setup() {
 	[ "${TEST_INITRD}" == "yes" ] && skip "test not working see: ${issue}"

--- a/integration/kubernetes/tests_common.sh
+++ b/integration/kubernetes/tests_common.sh
@@ -18,6 +18,9 @@ sleep_time=3
 # Note: try to keep timeout and wait_time equal.
 timeout=90s
 
+# issues that can't test yet.
+fc_limitations="https://github.com/kata-containers/documentation/issues/351"
+
 # Path to the kubeconfig file which is used by kubectl and other tools.
 # Note: the init script sets that variable but if you want to run the tests in
 # your own provisioned cluster and you know what you are doing then you should


### PR DESCRIPTION
In k8s-inotify.bats and k8s-nested-configmap-secret.bats,
the `fc_limitations` is used but not defined.

Fixes: #4361

Signed-off-by: bin <bin@hyper.sh>