### PR TITLE
ci: Add ignore_depends_on label

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -15,11 +15,11 @@ QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
 QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 
 build_and_install_qemu() {
-        PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+        PACKAGING_DIR="${katacontainers_repo_dir}/tools/packaging"
         QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
 	clone_qemu_repo
-	clone_kata_repo
+	clone_katacontainers_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
         git fetch

--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -122,7 +122,7 @@ can_we_skip() {
 
 	# Use just the repo name itself. The YAML does not like having the full
 	# repo path in it.
-	local repo="${kata_repo##*/}"
+	local repo="${katacontainers_repo##*/}"
 
 	if [ -n "$repo" ]; then
 		# Get our repo specific patterns

--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -81,8 +81,8 @@ tests_repo="${kata_github}/tests"
 tests_repo_dir="${GOPATH}/src/${tests_repo}"
 
 # Kata Containers repository
-kata_repo="${kata_github}/kata-containers"
-kata_repo_dir="${GOPATH}/src/${kata_repo}"
+katacontainers_repo="${kata_github}/kata-containers"
+katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
 
 # Print system info and env variables in case we need to debug
 uname -a
@@ -97,8 +97,8 @@ mkdir -p $(dirname "${tests_repo_dir}")
 source ${tests_repo_dir}/.ci/ci_job_flags.sh
 
 # Clone the kata-containers repository
-mkdir -p $(dirname "${kata_repo_dir}")
-[ -d "${kata_repo_dir}" ] || git clone "https://${kata_repo}.git" "${kata_repo_dir}"
+mkdir -p $(dirname "${katacontainers_repo_dir}")
+[ -d "${katacontainers_repo_dir}" ] || git clone "https://${katacontainers_repo}.git" "${katacontainers_repo_dir}"
 
 # Clone the crio repository
 mkdir -p $(dirname "${crio_repo_dir}")
@@ -116,7 +116,7 @@ if [ "${pr_number}" != "NONE" ]; then
 fi
 
 # Edit critools & kubernetes versions
-cd "${kata_repo_dir}"
+cd "${katacontainers_repo_dir}"
 
 # Install yq
 ${GOPATH}/src/${tests_repo}/.ci/install_yq.sh

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -34,11 +34,11 @@ install_clh() {
 	# Get cloud_hypervisor repo
 	go get -d "${go_cloud_hypervisor_repo}" || true
 	# This may be downloaded before if there was a depends-on in PR, but 'go get' wont make any problem here
-	clone_kata_repo
+	clone_katacontainers_repo
 	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
 	# packaging build script expects run in the hypervisor repo parent directory
 	# It will find the hypervisor repo and checkout to the version exported above
-	"${kata_repo_dir}/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh"
+	"${katacontainers_repo_dir}/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh"
 	sudo install -D "cloud-hypervisor/${clh_bin_name}"  "${clh_install_path}"
 	popd
 }

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -19,7 +19,7 @@ latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-vanilla-$(arch)-
 PREFIX="${PREFIX:-/usr}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
-kernel_packaging_dir="${kata_repo_dir}/tools/packaging/kernel"
+kernel_packaging_dir="${katacontainers_repo_dir}/tools/packaging/kernel"
 readonly tmp_dir="$(mktemp -d -t install-kata-XXXXXXXXXXX)"
 
 exit_handler() {
@@ -67,7 +67,7 @@ install_prebuilt_kernel() {
 }
 
 main() {
-	clone_kata_repo
+	clone_katacontainers_repo
 	kernel_version=$(get_version "assets.kernel.version")
 	kernel_version=${kernel_version#v}
 	kata_config_version=$(cat "${kernel_packaging_dir}/kata_config_version")

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -23,7 +23,7 @@ QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
 # Remove 'https://' from the repo url to be able to git clone the repo
 QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
 QEMU_ARCH=$(${cidir}/kata-arch.sh -d)
-PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+PACKAGING_DIR="${katacontainers_repo_dir}/tools/packaging"
 ARCH=$("${cidir}"/kata-arch.sh -d)
 QEMU_TAR="kata-static-qemu.tar.gz"
 qemu_latest_build_url="${jenkins_url}/job/kata-containers-2.0-qemu-$(uname -m)/${cached_artifacts_path}"
@@ -96,7 +96,7 @@ build_and_install_qemu() {
 
 	mkdir -p "${GOPATH}/src"
 
-	clone_kata_repo
+	clone_katacontainers_repo
 	clone_qemu_repo
 
 	pushd "${GOPATH}/src/${QEMU_REPO}"

--- a/.ci/install_qemu_experimental.sh
+++ b/.ci/install_qemu_experimental.sh
@@ -18,7 +18,7 @@ source /etc/os-release || source /usr/lib/os-release
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_TAG=$(get_version "assets.hypervisor.qemu-experimental.version")
-PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+PACKAGING_DIR="${katacontainers_repo_dir}/tools/packaging"
 QEMU_TAR="kata-static-qemu-experimental.tar.gz"
 arch=$("${cidir}"/kata-arch.sh -d)
 qemu_experimental_latest_build_url="${jenkins_url}/job/qemu-experimental-nightly-$(uname -m)/${cached_artifacts_path}"
@@ -54,7 +54,7 @@ build_and_install_static_experimental_qemu() {
 
 build_experimental_qemu() {
 	mkdir -p "${GOPATH}/src"
-	clone_kata_repo
+	clone_katacontainers_repo
 	"${PACKAGING_DIR}/static-build/qemu/build-static-qemu-experimental.sh"
 	sudo mkdir -p "${KATA_TESTS_CACHEDIR}"
 	sudo mv "${QEMU_TAR}" "${KATA_TESTS_CACHEDIR}"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -14,7 +14,7 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
-KATA_REPO=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
+KATACONTAINERS_REPO=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
 MACHINETYPE="${MACHINETYPE:-q35}"
@@ -44,7 +44,7 @@ export SHAREDIR=${PREFIX}/share
 OPENSHIFT_CI="${OPENSHIFT_CI:-false}"
 
 runtime_config_path="${SYSCONFDIR}/kata-containers/configuration.toml"
-runtime_src_path="${GOPATH}/src/${KATA_REPO}/src/runtime"
+runtime_src_path="${GOPATH}/src/${KATACONTAINERS_REPO}/src/runtime"
 
 PKGDEFAULTSDIR="${DESTDIR}${SHAREDIR}/defaults/kata-containers"
 NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
@@ -52,7 +52,7 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 
 build_install_shim_v2(){
 	if [ ! -d "$runtime_src_path" ]; then
-		go get "$KATA_REPO"
+		go get "$KATACONTAINERS_REPO"
 	fi
 	pushd "$runtime_src_path"
 	make

--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -225,8 +225,8 @@ test_snap_build() {
 	if [[ "${ID}" == "ubuntu" && "$(uname -m)" != "x86_64" ]]; then
 		echo "Test snap build"
 		sudo apt install -y snapcraft
-		[ ! -d "${kata_repo_dir}" ] && go get -d "${kata_repo}" || true
-		pushd "${kata_repo_dir}"
+		[ ! -d "${katacontainers_repo_dir}" ] && go get -d "${katacontainers_repo}" || true
+		pushd "${katacontainers_repo_dir}"
 		sudo snapcraft -d snap --destructive-mode
 		# PREFIX is changed in snap build, change it back
 		PREFIX=

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -10,8 +10,8 @@ export KATA_KSM_THROTTLER=${KATA_KSM_THROTTLER:-no}
 export KATA_QEMU_DESTDIR=${KATA_QEMU_DESTDIR:-"/usr"}
 export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
-export kata_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
-export kata_repo_dir="${GOPATH}/src/${kata_repo}"
+export katacontainers_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
+export katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
 export kata_default_branch="${kata_default_branch:-main}"
 export CI_JOB="${CI_JOB:-}"
 
@@ -94,12 +94,12 @@ registry_server_teardown() {
 	fi
 }
 
-# Clone repo only if $kata_repo_dir is empty
-# Otherwise, we assume $kata_repo is cloned and in correct branch, e.g. a PR or local change
-clone_kata_repo() {
-	if [ ! -d "${kata_repo_dir}" ]; then
-		go get -d "${kata_repo}" || true
-		pushd "${kata_repo_dir}"
+# Clone repo only if $katacontainers_repo_dir is empty
+# Otherwise, we assume $katacontainers_repo is cloned and in correct branch, e.g. a PR or local change
+clone_katacontainers_repo() {
+	if [ ! -d "${katacontainers_repo_dir}" ]; then
+		go get -d "${katacontainers_repo}" || true
+		pushd "${katacontainers_repo_dir}"
 		# Checkout to default branch
 		git checkout "${kata_default_branch}"
 		popd
@@ -165,11 +165,11 @@ function get_dep_from_yaml_db(){
 
 function get_version(){
 	dependency="$1"
-	versions_file="${kata_repo_dir}/versions.yaml"
-	if [ ! -d "${kata_repo_dir}" ]; then
-		mkdir -p "$(dirname ${kata_repo_dir})"
-		git clone --quiet https://${kata_repo}.git "${kata_repo_dir}"
-		( cd "${kata_repo_dir}" && git checkout "$kata_default_branch" >&2 )
+	versions_file="${katacontainers_repo_dir}/versions.yaml"
+	if [ ! -d "${katacontainers_repo_dir}" ]; then
+		mkdir -p "$(dirname ${katacontainers_repo_dir})"
+		git clone --quiet https://${katacontainers_repo}.git "${katacontainers_repo_dir}"
+		( cd "${katacontainers_repo_dir}" && git checkout "$kata_default_branch" >&2 )
 	fi
 	get_dep_from_yaml_db "${versions_file}" "${dependency}"
 }
@@ -495,7 +495,7 @@ sha256sum_from_files() {
 # those that seems sufficient to detect changes. For example, this script is
 # sourced by many others but it is not considered.
 calc_qemu_files_sha256sum() {
-	local pkg_dir="${kata_repo_dir}/tools/packaging"
+	local pkg_dir="${katacontainers_repo_dir}/tools/packaging"
 	local files="${pkg_dir}/qemu \
 		${pkg_dir}/static-build/qemu \
 		${pkg_dir}/static-build/qemu.blacklist \

--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -73,7 +73,7 @@ sandboxed_containers_image_configs() {
 	# Unlike the kernel installed by the .ci/install_kata_kernel.sh script,
 	# the host kernel doesn't have the needed modules built static. Thus,
 	# we need to package them as loadable modules into the guest image.
-	cp -r "${kata_repo_dir}/tools/osbuilder/dracut/dracut.conf.d"/* \
+	cp -r "${katacontainers_repo_dir}/tools/osbuilder/dracut/dracut.conf.d"/* \
 		"${DRACUT_CONF_DIR}"
 	cat <<-EOF >> "${DRACUT_CONF_DIR}/10-drivers.conf"
 	drivers+="irqbypass "

--- a/.ci/openshift-ci/qemu-build-pre.sh
+++ b/.ci/openshift-ci/qemu-build-pre.sh
@@ -13,7 +13,7 @@ set -e
 export GOPATH="${GOPATH:-/go}"
 script_dir="$(realpath $(dirname $0))"
 source "${script_dir}/../lib.sh"
-pkg_dir="${kata_repo_dir}/tools/packaging"
+pkg_dir="${katacontainers_repo_dir}/tools/packaging"
 
 kata_version=${kata_version:-}
 prefix=${PREFIX:-/opt/kata}

--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -18,12 +18,12 @@ build_and_install_qemu() {
         QEMU_REPO_URL=$(get_version "assets.hypervisor.qemu.url")
         # Remove 'https://' from the repo url to be able to clone the repo using 'go get'
         QEMU_REPO=${QEMU_REPO_URL/https:\/\//}
-        PACKAGING_DIR="${kata_repo_dir}/tools/packaging"
+        PACKAGING_DIR="${katacontainers_repo_dir}/tools/packaging"
         QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
         git clone --branch "$CURRENT_QEMU_TAG" --depth 1 "$QEMU_REPO_URL" "${GOPATH}/src/${QEMU_REPO}"
 
-        clone_kata_repo
+        clone_katacontainers_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
         git fetch

--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -9,10 +9,6 @@ set -o errexit
 set -o pipefail
 set -o errtrace
 
-# Repositories needed for building the kata containers project.
-katacontainers_repo="${katacontainers_repo:-github.com/kata-containers/kata-containers}"
-tests_repo="${tests_repo:-github.com/kata-containers/tests}"
-
 branch=${branch:-}
 pr_branch=${pr_branch:-}
 pr_number=${pr_number:-}

--- a/.ci/resolve-kata-dependencies.sh
+++ b/.ci/resolve-kata-dependencies.sh
@@ -6,7 +6,6 @@
 #
 
 set -o errexit
-set -o nounset
 set -o pipefail
 set -o errtrace
 
@@ -18,6 +17,13 @@ branch=${branch:-}
 pr_branch=${pr_branch:-}
 pr_number=${pr_number:-}
 kata_repo=${kata_repo:-}
+
+# Name of the label, that if set on a PR, will ignore depends-on lines in commits
+ignore_depends_on_label="ignore-depends-on"
+
+script_name="${0##*/}"
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
 
 apply_depends_on() {
 	# kata_repo variable is set by the jenkins_job_build.sh
@@ -108,9 +114,107 @@ clone_repos() {
 	done
 }
 
-main() {
-	clone_repos
-	apply_depends_on
+# Check if we have the 'magic label' that ignored depends-on messages in commits
+# Returns on stdout as string:
+#  0 - No label found,
+#  1 - Label found - should ignore 'Depends-on' messages
+check_ignore_depends_label() {
+	local label="${ignore_depends_on_label}"
+
+	local result=$(check_label "$label")
+	if [ "$result" -eq 1 ]; then
+		local_info "Ignoring all 'Depends-on' labels"
+		echo "1"
+		return 0
+	fi
+
+	local_info "No ignore_depends_on label found"
+	echo "0"
+	return 0
 }
 
-main
+testCheckIgnoreDependsOnLabel() {
+	local result=""
+
+	result=$(unset ghprbGhRepository; check_ignore_depends_label)
+	assertEquals "0" "$result"
+
+	result=$(unset ghprbPullId; check_ignore_depends_label)
+	assertEquals "0" "$result"
+
+	result=$(unset ghprbGhRepository ghprbPullId; check_ignore_depends_label)
+	assertEquals "0" "$result"
+
+	result=$(ghprbGhRepository="repo"; \
+		ghprbPullId=123; \
+		ignore_depends_on_label=""; \
+		check_ignore_depends_label)
+	assertEquals "0" "$result"
+
+	# Pretend label not found
+	result=$(is_label_set() { echo "0"; return 0; }; \
+	                ghprbGhRepository="repo"; \
+	                ghprbPullId=123; \
+	                check_ignore_depends_label "label")
+	assertEquals "0" "$result"
+
+	# Pretend label found
+	result=$(is_label_set() { echo "1"; return 0; }; \
+	                ghprbGhRepository="repo"; \
+	                ghprbPullId=123; \
+	                check_ignore_depends_label "label")
+	assertEquals "1" "$result"
+}
+
+# Run our self tests. Tests are written using the
+# github.com/kward/shunit2 library, and are encoded into functions starting
+# with the string 'test'.
+self_test() {
+	local shunit2_path="github.com/kward/shunit2"
+	local_info "Running self tests"
+
+	local_info "Go get unit test framework from ${shunit2_path}"
+	go get -d "${shunit2_path}" || true
+	local_info "Run the unit tests"
+	# Sourcing the `shunit2` file automatically runs the unit tests in this file.
+	. "${GOPATH}/src/${shunit2_path}/shunit2"
+	# shunit2 call does not return - it exits with its return code.
+}
+
+help()
+{
+	cat <<EOF
+Usage: ${script_name} [test]
+
+Passing the argument 'test' to this script will cause it to only
+run its self tests.
+EOF
+
+	exit 0
+}
+
+main() {
+
+	# Some of our sub-funcs return their results on stdout, but we also want them to be
+	# able to log INFO messages. But, we don't want those going to stderr, as that may
+	# be seen by some CIs as an actual error. Create another file descriptor, mapped
+	# back to stdout, for us to send INFO messages to...
+	exec 5>&1
+
+	if [ "$1" == "test" ]; then
+		self_test
+		# self_test func does not return
+	fi
+
+	[ $# -gt 0 ] && help
+
+	clone_repos
+	local result=$(check_ignore_depends_label)
+	if [ "${result}" -eq 1 ]; then
+		local_info "Not applying depends on due to '${ignore_depends_on_label}' label"
+	else
+		apply_depends_on
+	fi
+}
+
+main "$@"

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -194,12 +194,12 @@ profile="${profile:-${default_profile}}"
 #-------------------------------------------------------------------------------
 
 export GOPATH=${GOPATH:-${HOME}/go}
-kata_repo_dir="$GOPATH/src/github.com/kata-containers/kata-containers"
-agent_dir="${kata_repo_dir}/src/agent"
+katacontainers_repo_dir="$GOPATH/src/github.com/kata-containers/kata-containers"
+agent_dir="${katacontainers_repo_dir}/src/agent"
 agent_binary="${agent_dir}/target/${triple}/${profile}/${agent_binary_name}"
 
-agent_ctl_dir="${kata_repo_dir}/tools/agent-ctl"
-forwarder_dir="${kata_repo_dir}/src/trace-forwarder"
+agent_ctl_dir="${katacontainers_repo_dir}/src/tools/agent-ctl"
+forwarder_dir="${katacontainers_repo_dir}/src/tools/trace-forwarder"
 
 # Maximum debug level
 default_agent_log_level="trace"
@@ -984,7 +984,7 @@ run_agent_ctl()
 	# since that uses a different build profile compared to the agent.
 	command -v "$agent_ctl_binary_name" &>/dev/null || \
 		(cd "$agent_ctl_dir" && \
-			sudo chown -R "${USER}:" "${kata_repo_dir}" && \
+			sudo chown -R "${USER}:" "${katacontainers_repo_dir}" && \
 			cargo install --path .)
 
 	local agent_ctl_path


### PR DESCRIPTION
- Add logic to resolve-kata-dependencies.sh to skip
depends-on processing if ignore_depends_on label
is present
- Refactor common code and tests from ci-fast-return.sh
into lib.sh

Fixes: #4360
Signed-off-by: stevenhorsman <steven@uk.ibm.com>