### PR TITLE
kubernetes: bring up kubelet with '--v 4' by default and misc improvement

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -169,8 +169,8 @@ start_kubernetes() {
 	local cri_socket_path="$2"
 	local cgroup_driver="$3"
 	local kubeadm_config_template="${SCRIPT_PATH}/kubeadm/config.yaml"
-	local kubelet_restart_wait="120"
-	local kubelet_restart_sleep="10"
+	local kubelet_wait="240"
+	local kubelet_sleep="10"
 
 	info "Init cluster using ${cri_socket_path}"
 
@@ -200,14 +200,8 @@ start_kubernetes() {
 	sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
 	export KUBECONFIG="$HOME/.kube/config"
 
-	# enable debug log for kubelet
-	sudo sed -i 's/.$/ --v=4"/' /var/lib/kubelet/kubeadm-flags.env
-	info "Restart Kubelet with options:"
-	sudo cat /var/lib/kubelet/kubeadm-flags.env
-	sudo systemctl daemon-reload && sudo systemctl restart kubelet
-
-	info "Probing kubelet"
-	waitForProcess "$kubelet_restart_wait" "$kubelet_restart_sleep" \
+	info "Probing kubelet (timeout=${kubelet_wait}s)"
+	waitForProcess "$kubelet_wait" "$kubelet_sleep" \
 		"kubectl get nodes"
 }
 

--- a/integration/kubernetes/kubeadm/config.yaml
+++ b/integration/kubernetes/kubeadm/config.yaml
@@ -4,6 +4,7 @@ nodeRegistration:
   criSocket: CRI_RUNTIME_SOCKET
   kubeletExtraArgs:
     allowed-unsafe-sysctls: kernel.msg*,kernel.shm.*,net.*
+    v: "4"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -15,6 +15,7 @@ source "${cidir}/lib.sh"
 arch="$(uname -m)"
 
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+K8S_TEST_DEBUG="${K8S_TEST_DEBUG:-false}"
 
 if [ -n "${K8S_TEST_UNION:-}" ]; then
 	K8S_TEST_UNION=($K8S_TEST_UNION)
@@ -59,9 +60,21 @@ else
 	"k8s-hugepages.bats")
 fi
 
+cleanup() {
+	if [ ${K8S_TEST_DEBUG} == "true" ]; then
+		info "Running on debug mode so skip the cleanup routine"
+		info "You can access kubernetes with:\n\tkubectl <command>"
+		info "Run the cleanup routine when you are done debugging:\n\t${kubernetes_dir}/cleanup_env.sh"
+		return
+	fi
+
+	info "Run the cleanup routine"
+	${kubernetes_dir}/cleanup_env.sh
+}
+
 # Using trap to ensure the cleanup occurs when the script exists.
 trap_on_exit() {
-	trap '${kubernetes_dir}/cleanup_env.sh' EXIT
+	trap 'cleanup' EXIT
 }
 
 # we may need to skip a few test cases when running on non-x86_64 arch


### PR DESCRIPTION
The primary goal of this pull request is to fix #4290 which has hurt badly our baseline jobs. My previous attempt to solve that problem (076f6273573c45b9af046a309b877e4467441ec9) didn't work out. With the approach I am proposing here I ran 50x in my local machine without a single failure (at least not related with that problem); but let's see how it behaves on Jenkins.

While here I am sending a change that allow the developer to keep kubernetes running after the tests execution. I need this for debugging and developing tests and I believe others will be benefited too.