### PR TITLE
ci: Remove unused variable at install kata script

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -15,7 +15,6 @@ source /etc/os-release || source /usr/lib/os-release
 source "${cidir}/lib.sh"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 experimental_qemu="${experimental_qemu:-false}"
-TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
 
 echo "Install Kata Containers Image"
 echo "rust image is default for Kata 2.0"


### PR DESCRIPTION
This PR removes a variable that is not longer being used for
the install kata script for kata 2.0

Fixes #4371

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>