### PR TITLE
Vagrantfile: Add support to Fedora 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Your workstation must be capable of running VMs with:
  * ~45GB and ~20GB of disk space for the VM images (Fedora and Ubuntu, respectively) on
    the Libvirt's storage pool
 
-Currently it supports the creation of *Fedora 32* and *Ubuntu 20.04* VM, as shown on the table
+Currently it supports the creation of *Fedora (32 and 35)* and *Ubuntu 20.04* VM, as shown on the table
 below. The `Vagrantfile` was tested on Fedora 33 and Ubuntu 20.04 hosts, and it is
 [known to fail](https://github.com/kata-containers/tests/issues/3942) the boot of Fedora VM on
 Ubuntu host. If you have the need of testing on a different guest or it fails to work

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,7 +99,28 @@ EOF
   config.vm.define "fedora", autostart: false do |fedora|
     fedora.vm.box = "generic/fedora32"
     # Fedora is required to reboot so that the change to cgroups v1
-    # and kernel arguments make effect.
+    # and kernel arguments take effect.
+    fedora.vm.provision "shell", reboot: true, inline: <<-SHELL
+      # Set the kernel parameter to use cgroups v1.
+      sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+      # Set iommu's kernel parameters for vfio tests.
+      source "#{guest_env_file}"
+      if [ "${CI_JOB}" == "VFIO" ]; then
+        grubby --update-kernel=ALL --args="intel_iommu=on iommu=pt"
+      fi
+    SHELL
+
+    fedora.vm.provision "shell", inline: <<-SHELL
+      source "#{guest_env_file}"
+      cd "${GOPATH}/src/github.com/kata-containers/tests"
+      sudo -E PATH=$PATH -H -u #{guest_user} bash -c '.ci/setup.sh'
+    SHELL
+  end
+
+  config.vm.define "fedora35", autostart: false do |fedora|
+    fedora.vm.box = "generic/fedora35"
+    # Fedora is required to reboot so that the change to cgroups v1
+    # and kernel arguments take effect.
     fedora.vm.provision "shell", reboot: true, inline: <<-SHELL
       # Set the kernel parameter to use cgroups v1.
       sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"


### PR DESCRIPTION
As some CI jobs will run on Fedora 35, it was added its support on
Vagrant so jobs can be ran locally.

Fixes #4373
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>