### PR TITLE
versions: Remove kibana information

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -25,11 +25,6 @@ docker_images:
     url: "https://hub.docker.com/_/elasticsearch/"
     version: "6.4.0"
 
-  kibana:
-    description: "Open source analytics and visualization platform"
-    url: "https://hub.docker.com/_/kibana/"
-    version: "6.4.0"
-
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"


### PR DESCRIPTION
This PR removes kibana from versions.yaml as this was used for
docker integration tests that we do not longer have in kata 2.0

Fixes #4377

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>