### PR TITLE
ci: crio: Bump CRI-O latest release

### DIFF
--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -36,7 +36,7 @@ export CI_JOB="EXTERNAL_CRIO"
 export INSTALL_KATA="yes"
 export GO111MODULE=auto
 
-latest_release="1.22"
+latest_release="1.23"
 
 sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]


### PR DESCRIPTION
CRI-O latest release is now 1.23, and we should be testing against the
same version of Kubernetes.

Fixes: #4382

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>