### PR TITLE
k8s: fix a problem on flannel installation

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -134,6 +134,24 @@ configure_network() {
 	fi
 	info "Use configuration file from ${network_plugin_config}"
 	kubectl apply -f "$network_plugin_config"
+
+	if [ -n "${flannel_version:-}" ]; then
+		local list_pods="kubectl get -n kube-system --selector app=flannel pods"
+		info "Wait for Flannel pods to show up"
+		waitForProcess "30" "10" \
+			"[ \$($list_pods 2>/dev/null | wc -l) -gt 0 ]"
+		local flannel_p
+		for flannel_p in $($list_pods \
+			-o jsonpath='{.items[*].metadata.name}'); do
+			info "Wait for pod $flannel_p be ready"
+			if ! kubectl wait -n kube-system --for=condition=Ready \
+				"pod/$flannel_p"; then
+				info "Flannel pod $flannel_p failed to start"
+				echo "[DEBUG] Pod ${flannel_p}:" 1>&2
+				kubectl describe -n kube-system "pod/$flannel_p"
+			fi
+		done
+	fi
 }
 
 # Save the current iptables configuration.

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -124,6 +124,7 @@ cleanup_cni_configuration() {
 #
 configure_network() {
 	local network_plugin_config="${1:-}"
+	local issue="https://github.com/kata-containers/tests/issues/4381"
 
 	if [ -z "${network_plugin_config}" ]; then
 		# default network plugin should be flannel, and its config file is taken from k8s 1.12 documentation
@@ -136,6 +137,14 @@ configure_network() {
 	kubectl apply -f "$network_plugin_config"
 
 	if [ -n "${flannel_version:-}" ]; then
+		# There is an issue hitting some CI jobs due to a bug on CRI-O that
+		# sometimes doesn't realize a new CNI configuration was installed.
+		# Here we try a simple workaround which consist of rebooting the
+		# CRI-O service.
+		if [ "${CRI_RUNTIME:-}" = "crio" ]; then
+			info "Restart the CRI-O service due to $issue"
+			sudo systemctl restart crio
+		fi
 		local list_pods="kubectl get -n kube-system --selector app=flannel pods"
 		info "Wait for Flannel pods to show up"
 		waitForProcess "30" "10" \


### PR DESCRIPTION
Tentative to fix a problem with CRI-O. Apparently it can sometimes not realize a new CNI configuration was installed as a result the deployed flannel pods fail to start up. 

Fixes #4381
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>