### PR TITLE
versions: Remove elasticsearch

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -20,11 +20,6 @@ docker_images:
     url: "https://hub.docker.com/_/alpine/"
     version: "3.7"
 
-  elasticsearch:
-    description: "RESTful search and analytics engine"
-    url: "https://hub.docker.com/_/elasticsearch/"
-    version: "6.4.0"
-
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"


### PR DESCRIPTION
This PR removes elasticsearch from versions.yaml as this was used
for the docker integration tests that are not longer being part
of kata 2.0

Fixes #4398

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>