### PR TITLE
integration/k8s: Allow for pod removal

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -109,3 +109,6 @@ do
 	bats "${K8S_TEST_ENTRY}"
 done
 popd
+
+# Allow for pod deletion before running `kubeadm reset`, potentially leaving pods behind
+waitForProcess 30 3 '[ -z "$(kubectl get pods)" ]'


### PR DESCRIPTION
After `kubeadm reset`, we frequently see remaining pods running. Use
waitForProcess with 30 seconds (a bit over the highest I've seen in the
wild) after running all tests to allow for the completion of pod
removal.

Fixes: #3998
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Respin of #4291