### PR TITLE
ci: Remove unused ci job flags for kata 2.0

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -101,14 +101,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	[ "${CI_JOB}" == "CRI_CONTAINERD_K8S" ] && export KUBERNETES="yes"
 	;;
-"CRI_CONTAINERD_K8S_MINIMAL")
-	init_ci_flags
-	export CRI_CONTAINERD="yes"
-	export CRI_RUNTIME="containerd"
-	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="yes"
-	export MINIMAL_K8S_E2E="true"
-	;;
 "CRIO_K8S")
 	init_ci_flags
 	export CRI_RUNTIME="crio"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -37,7 +37,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running QAT integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
-	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_INITRD")
+	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S")
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"
@@ -54,16 +54,6 @@ case "${CI_JOB}" in
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		echo "INFO: Running ksm test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
-		;;
-	"CRI_CONTAINERD_K8S_COMPLETE")
-		echo "INFO: Running e2e kubernetes tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
-		;;
-	"CRI_CONTAINERD_K8S_MINIMAL")
-		echo "INFO: Running e2e kubernetes tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
-		echo "INFO: Running tracing test"
-		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"
@@ -89,14 +79,6 @@ case "${CI_JOB}" in
 
 		echo "INFO: Running kubernetes tests with containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
-		;;
-	"CLOUD-HYPERVISOR-K8S-CONTAINERD-MINIMAL")
-		echo "INFO: Running e2e kubernetes tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
-		;;
-	"CLOUD-HYPERVISOR-K8S-CONTAINERD-FULL")
-		echo "INFO: Running complete e2e kubernetes tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes-e2e"
 		;;
 	"EXTERNAL_CRIO")
 		echo "INFO: Running tests on cri-o PR"


### PR DESCRIPTION
This PR removes unused ci job flags at the run.sh and ci_job_flags.sh
scripts as they are not being part of the baseline or PR CI jobs that
we have for kata 2.0

Fixes #4402

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>