### PR TITLE
ci: Run static checks --only-arch

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -158,7 +158,7 @@ if [ "${METRICS_CI}" = "false" ]; then
 		specific_branch=""
 		# If not a PR, we are testing on stable or master branch.
 		[ -z "$pr_number" ] && specific_branch="true"
-		"${ci_dir_name}/static-checks.sh" "$kata_repo" "$specific_branch"
+		"${ci_dir_name}/static-checks.sh" --only-arch "$kata_repo" "$specific_branch"
 	fi
 fi
 


### PR DESCRIPTION
avoid rate limiting, other checks still run on GHA

Fixes: #4369
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @Amulyam24
Forward port of #4370