### PR TITLE
tests: Removed unused e2e k8s tests flags

### DIFF
--- a/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
+++ b/integration/kubernetes/e2e_conformance/e2e_k8s_jobs.yaml
@@ -7,10 +7,6 @@
 jobs:
   CRI_CONTAINERD_K8S_MINIMAL:
     passed: 12
-  CRI_CONTAINERD_K8S_COMPLETE:
-    passed: 269
-  CLOUD-HYPERVISOR-K8S-E2E-CONTAINERD-FULL:
-    passed: 274
   minimal:
     focus:
       - ConfigMap should be consumable from pods in volume


### PR DESCRIPTION
This PR removes unused e2e k8s tests filter flags as they are not part
of the current baseline and PR CIs for kata 2.0

Fixes #4410

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>