### PR TITLE
ci: Switch to virtio-9p on s390x

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -171,6 +171,9 @@ popd
 
 "${ci_dir_name}/setup.sh"
 
+# Use virtio-9p on s390x -- https://github.com/kata-containers/tests/issues/3998 for tracking
+[ "$arch" = s390x ] && sudo -E "${GOPATH}/src/${tests_repo}/${cidir}/set_kata_config.sh" shared_fs virtio-9p
+
 # Run unit tests on non x86_64
 if [[ "$arch" == "s390x" || "$arch" == "aarch64" ]]; then
 	echo "Running unit tests"


### PR DESCRIPTION
until leftover shims under virtio-fs (#3998) are resolved.

Fixes: #4406
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Backport of #4407 (e: including #4417). Sad but better than making failures the norm.