### PR TITLE
ci: Use tests directory for setting 9p

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -172,7 +172,7 @@ popd
 "${ci_dir_name}/setup.sh"
 
 # Use virtio-9p on s390x -- https://github.com/kata-containers/tests/issues/3998 for tracking
-[ "$arch" = s390x ] && sudo -E "${cidir}/set_kata_config.sh" shared_fs virtio-9p
+[ "$arch" = s390x ] && sudo -E "${GOPATH}/src/${tests_repo}/${cidir}/set_kata_config.sh" shared_fs virtio-9p
 
 # Run unit tests on non x86_64
 if [[ "$arch" == "s390x" || "$arch" == "aarch64" ]]; then


### PR DESCRIPTION
`.ci/` will only be a valid path when we're running on `tests`. Specify
explicitly so that it also works in the main repository.

Fixes: #4416
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>