### PR TITLE
versions: Remove alpine reference

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -15,11 +15,6 @@ description: |
 docker_images:
   description: "Docker hub images used for testing"
 
-  alpine:
-    description: "Linux distribution built around busybox and musl libc"
-    url: "https://hub.docker.com/_/alpine/"
-    version: "3.7"
-
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"


### PR DESCRIPTION
This PR removes the alpine reference from the versions.yaml file
as this was used by docker integration tests which we do not longer
support in kata 2.0

Fixes #4418

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>