### PR TITLE
stable-2.3: backports

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -24,7 +24,7 @@ export WORKSPACE=$(mktemp -d)
 QEMU_EFI_BUILD_PATH="${WORKSPACE}/Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd"
 
 PREFIX="${PREFIX:-/usr}"
-INSTALL_PATH="${DESTDIR:-}${PREFIX}/share/kata-containers/"
+INSTALL_PATH="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
 EFI_NAME="QEMU_EFI.fd"
 EFI_DEFAULT_DIR="/usr/share/qemu-efi-aarch64"
@@ -78,7 +78,10 @@ prepare_default_uefi()
 	else
 		local efi_url="https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd"
 		sudo mkdir -p "${EFI_DEFAULT_DIR}"
-		sudo curl -LO "${EFI_DEFAULT_DIR}/$efi_url"
+		pushd "${WORKSPACE}" || clean_up_and_die "fail to prepare default uefi."
+		curl -LO ${efi_url}
+		sudo install -o root -g root -m 644 QEMU_EFI.fd ${EFI_DEFAULT_DIR}
+		popd
 	fi
 }
 

--- a/integration/kubernetes/k8s-caps.bats
+++ b/integration/kubernetes/k8s-caps.bats
@@ -33,7 +33,15 @@ setup() {
         kubectl create -f "${pod_config_dir}/pod-caps.yaml"
         # Check pod creation
         kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
-        kubectl logs "$pod_name" | grep -q "$expected"
+
+        # Verify expected capabilities for the running container. Add retry to ensure
+        # that the container had time to execute:
+        wait_time=5
+        sleep_time=1
+        cmd="kubectl logs $pod_name | grep -q $expected"
+        waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+        # Verify expected capabilities from exec context:
         kubectl exec "$pod_name" -- sh -c "cat /proc/self/status" | grep -q "$expected"
 }
 


### PR DESCRIPTION
07a46826 ci: fix install_rom_aarch64.sh on non-ubuntu/debian os
209def11 k8s: ensure capability test container logs are available before checking
