### PR TITLE
tests: Remove ctr runtime duplicate definition

### DIFF
--- a/integration/agent/agent_test.sh
+++ b/integration/agent/agent_test.sh
@@ -20,7 +20,6 @@ dir_path=$(dirname "$0")
 source "${dir_path}/../../lib/common.bash"
 source "${dir_path}/../../metrics/lib/common.bash"
 
-CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 CONTAINER_NAME="${CONTAINER_NAME:-test}"
 IMAGE="${IMAGE:-quay.io/library/busybox:latest}"
 


### PR DESCRIPTION
This PR removes the ctr runtime variable as it is already defined
at the metrics/lib/common.sh which this script is making reference
in order to avoid a double definition.

Fixes #4426

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>