### PR TITLE
stability: Kill _all_ containers

### DIFF
--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -137,12 +137,12 @@ go() {
 }
 
 kill_all_containers() {
-	present=$(sudo ctr c list -q | wc -l)
-	if ((${present})); then
-		sudo ctr tasks kill $(sudo ctr task ls -q)
-		sudo ctr tasks rm -f $(sudo ctr task list -q)
-		sudo ctr c rm $(sudo ctr c list -q)
-	fi
+	for container in $(sudo ctr containers list -q); do
+		sudo ctr tasks kill "$container"
+		# Give task a second to die if required
+		waitForProcess 1 1 "! (sudo ctr tasks list -q | grep -q $container)"
+		sudo ctr containers delete "$container"
+	done
 }
 
 count_mounts() {

--- a/integration/stability/soak_parallel_rm.sh
+++ b/integration/stability/soak_parallel_rm.sh
@@ -116,6 +116,7 @@ go() {
 	while true; do {
 		check_all_running
 
+		local i
 		for ((i=1; i<= ${MAX_CONTAINERS}; i++)); do
 			containers+=($(random_name))
 			sudo ctr run --runtime=${CTR_RUNTIME} -d ${nginx_image} ${containers[-1]} sh -c ${COMMAND}
@@ -187,6 +188,7 @@ init() {
 }
 
 spin() {
+	local i
 	for ((i=1; i<= ITERATIONS; i++)); do {
 		echo "Start iteration $i of $ITERATIONS"
 		#spin them up


### PR DESCRIPTION
In `soak_parallel_rm.sh`'s `kill_all_containers`, we run e.g. `ctr tasks
kill $(ctr tasks ls -q)`, wrongly assuming that `ctr tasks kill` can
kill multiple tasks in one go. Let's just kill and delete all tasks and
containers respectively.

Fixes: #4430
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>