### PR TITLE
ci: make it possible to use multiple test files

### DIFF
--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -79,21 +79,23 @@ else
 fi
 
 for batsfile in ${bats_files_list[@]}; do
-    testfile=${batsfile%.*}_kata_integration_tests.bats
-    cp ${batsfile} ${testfile}
-    for testName in "${!skipCRIOTests[@]}"
+    testfile=${batsfile}_kata_integration_tests.bats
+    cp ${batsfile}.bats ${testfile}
+    declare -n skip_list=${batsfile}_skipCRIOTests
+    for testName in "${!skip_list[@]}"
     do
         echo "Skipping $testName in $testfile"
-        sed -i '/'${testName}'/a skip \"'${skipCRIOTests[$testName]}'\"' "${testfile}"
+        sed -i '/'${testName}'/a skip \"'${skip_list[$testName]}'\"' "${testfile}"
     done
 
     # selectively skip tests depending on the version of cri-o we're testing with
     if [ "$CRIO_VERSION" != "main" ]; then
-        for testName in "${!fixedInCrioVersion[@]}"
+	declare -n skip_list=${batsfile}_fixedInCrioVersion
+        for testName in "${!skip_list[@]}"
         do
-            if [ "$(echo -e "$CRIO_VERSION\n${fixedInCrioVersion[$testName]}" | sort -V | head -n1)" != "${fixedInCrioVersion[$testName]}" ]; then
+            if [ "$(echo -e "$CRIO_VERSION\n${skip_list[$testName]}" | sort -V | head -n1)" != "${skip_list[$testName]}" ]; then
                 echo "Skipping $testName in $testfile for cri-o v$CRIO_VERSION"
-                sed -i '/'${testName}'/a skip \"- fixed in cri-o v'${fixedInCrioVersion[$testName]}'\"' "${testfile}"
+                sed -i '/'${testName}'/a skip \"- fixed in cri-o v'${skip_list[$testName]}'\"' "${testfile}"
             fi
         done
     fi

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -72,8 +72,8 @@ pushd "${crio_repository_path}/test/"
 
 CRIO_VERSION=$(echo ${PULL_BASE_REF} | cut -d'-' -f 2)
 if [ -z "$CRIO_VERSION" ]; then
-    echo "Unknown version of cri-o - skipping more tests"
     CRIO_VERSION="1.21"
+    echo "Unknown version of cri-o - assuming v$CRIO_VERSION to skip more tests"
 else
     echo GOT CRIO VERSION $CRIO_VERSION
 fi

--- a/integration/cri-o/cri-o.sh
+++ b/integration/cri-o/cri-o.sh
@@ -80,8 +80,9 @@ fi
 
 for batsfile in ${bats_files_list[@]}; do
     testfile=${batsfile}_kata_integration_tests.bats
+    [ ! -f ${batsfile}.bats ] && continue
     cp ${batsfile}.bats ${testfile}
-    declare -n skip_list=${batsfile}_skipCRIOTests
+    declare -n skip_list=${batsfile//-}_skipCRIOTests
     for testName in "${!skip_list[@]}"
     do
         echo "Skipping $testName in $testfile"
@@ -90,7 +91,7 @@ for batsfile in ${bats_files_list[@]}; do
 
     # selectively skip tests depending on the version of cri-o we're testing with
     if [ "$CRIO_VERSION" != "main" ]; then
-	declare -n skip_list=${batsfile}_fixedInCrioVersion
+        declare -n skip_list=${batsfile//-}_fixedInCrioVersion
         for testName in "${!skip_list[@]}"
         do
             if [ "$(echo -e "$CRIO_VERSION\n${skip_list[$testName]}" | sort -V | head -n1)" != "${skip_list[$testName]}" ]; then

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -5,6 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# TODO: the list of files is hardcoded for now, as we don't have listed all tests
+# that need to be skipped, but ultimately we will want to use *.bats
+declare -a bats_files_list=("ctr.bats")
+
 # Currently these are the CRI-O tests that are not working
 
 declare -A skipCRIOTests=(

--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -7,11 +7,18 @@
 
 # TODO: the list of files is hardcoded for now, as we don't have listed all tests
 # that need to be skipped, but ultimately we will want to use *.bats
-declare -a bats_files_list=("ctr.bats")
+# The file name is provided without its ".bats" extension for easier processing.
+declare -a bats_files_list=("ctr")
 
-# Currently these are the CRI-O tests that are not working
+# We keep two lists for each bats file.
+# - [name]_skipCRIOTests for tests that we need to skip because of failures
+# - [name]_fixedInCrioVersion for tests that we need to skip when running
+#   with a version of cri-o that doesn't have the fix
+#
+# In both case, [name] is the basename of the bats file containing the tests.
 
-declare -A skipCRIOTests=(
+
+declare -A ctr_skipCRIOTests=(
 ['test "ctr logging"']='This is not working'
 ['test "ctr journald logging"']='Not implemented'
 ['test "ctr logging \[tty=true\]"']='FIXME: See https://github.com/kata-containers/tests/issues/4069'
@@ -36,7 +43,7 @@ declare -A skipCRIOTests=(
 # The following lists tests that should be skipped in specific cri-o versions.
 # When adding a test here, you need to provide the version of cri-o where the
 # bug was fixed. The script will skip this test in all previous versions.
-declare -A fixedInCrioVersion=(
+declare -A ctr_fixedInCrioVersion=(
 ['test "privileged ctr device add"']="1.22"
 ['test "privileged ctr -- check for rw mounts"']="1.22"
 ['test "ctr execsync"']="1.22"


### PR DESCRIPTION
The cri-o integration test script is focusing on ctr.bats only.
This commit makes it possible to define a list of validated test files
that we want to use during testing.

Fixes: #4433

Signed-off-by: Julien Ropé <jrope@redhat.com>