### PR TITLE
ci: install podman-docker when using podman

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -62,6 +62,8 @@ install_container_engine() {
 		sudo dnf install -y runc
 		# Try reinstalling to fix CNI configuration, allow erasing incompatible containerd
 		sudo dnf reinstall -y podman || sudo dnf install -y --allowerasing podman
+		# Install docker-podman, so scripts from outside our repo which are not aware of podman don't break
+		sudo dnf -y install podman-docker
 		return
 	fi
 


### PR DESCRIPTION
When using podman we need to also install `podman-docker`, as that
provides a compatibility layer which is very much needed as outside
scripts (as in, scripts from our dependencies) may not be aware of
`podman`.

Fixes: #4552
Depends-on: github.com/kata-containers/kata-containers#3664

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>