### PR TITLE
clh: Use kata-containers' static build script

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -15,63 +15,15 @@ readonly script_dir=$(dirname $(readlink -f "$0"))
 cidir=$(dirname "$0")
 arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
-# Where real kata build script exist, via docker build to avoid install all deps
-latest_build_url="${jenkins_url}/job/cloud-hypervisor-nightly-$(uname -m)/${cached_artifacts_path}"
-clh_bin_name="cloud-hypervisor"
-clh_install_path="/usr/bin/${clh_bin_name}"
-cloud_hypervisor_repo=$(get_version "assets.hypervisor.cloud_hypervisor.url")
-go_cloud_hypervisor_repo=${cloud_hypervisor_repo/https:\/\//}
-
-install_clh() {
-	[ -n "$cloud_hypervisor_repo" ] || die "failed to get cloud_hypervisor repo"
-	export cloud_hypervisor_repo
-
-	# Get version for cloud_hypervisor from runtime/versions.yaml
-	cloud_hypervisor_version=$(get_version "assets.hypervisor.cloud_hypervisor.version")
-	[ -n "$cloud_hypervisor_version" ] || die "failed to get cloud_hypervisor version"
-	export cloud_hypervisor_version
-
-	# Get cloud_hypervisor repo
-	go get -d "${go_cloud_hypervisor_repo}" || true
-	# This may be downloaded before if there was a depends-on in PR, but 'go get' wont make any problem here
-	clone_katacontainers_repo
-	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
-	# packaging build script expects run in the hypervisor repo parent directory
-	# It will find the hypervisor repo and checkout to the version exported above
-	"${katacontainers_repo_dir}/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh"
-	sudo install -D "cloud-hypervisor/${clh_bin_name}"  "${clh_install_path}"
-	popd
-}
-
-install_prebuilt_clh() {
-	local checksum_file="sha256sum-cloud-hypervisor"
-	go get -d "${go_cloud_hypervisor_repo}" || true
-	pushd  $(dirname "${GOPATH}/src/${go_cloud_hypervisor_repo}")
-
-	curl -fsOL --progress-bar "${latest_build_url}/${clh_bin_name}" || return 1
-	curl -fsOL "${latest_build_url}/${checksum_file}" || return 1
-
-	info "Verify download checksum"
-	sudo sha256sum -c "${checksum_file}" || return 1
-
-	info "installing ${clh_bin_name}" "${clh_install_path}"
-	sudo install -D ${clh_bin_name} "${clh_install_path}"
-	popd
-}
 
 main() {
-	current_cloud_hypervisor_version=$(get_version "assets.hypervisor.cloud_hypervisor.version")
-	cached_cloud_hypervisor_version=$(curl -sfL "${latest_build_url}/latest") || cached_cloud_hypervisor_version="none"
-	info "current cloud hypervisor : ${current_cloud_hypervisor_version}"
-	info "cached cloud hypervisor  : ${cached_cloud_hypervisor_version}"
-	if [ "$cached_cloud_hypervisor_version" == "$current_cloud_hypervisor_version" ] && [ "$arch" == "x86_64" ]; then
-		if ! install_prebuilt_clh; then
-			info "failed to install cached cloud hypervisor, trying to build from source"
-			install_clh
-		fi
-	else
-		install_clh
-	fi
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH make cloud-hypervisor-tarball
+	sudo tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
+	popd
 }
 
 main "$@"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -85,6 +85,7 @@ case "${KATA_HYPERVISOR}" in
 		;;
 	"cloud-hypervisor")
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-clh.toml"
+		sudo sed -i 's|/usr/bin/cloud-hypervisor|/opt/kata/bin/cloud-hypervisor|g' "${runtime_config_path}"
 		;;
 	"firecracker")
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"

--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -138,6 +138,7 @@ ${environment}
     export PATH=\${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:\${PATH}
     export GOROOT="/usr/local/go"
     export KUBERNETES="no"
+    export USE_DOCKER="true"
     export ghprbPullId
     export ghprbTargetBranch
 


### PR DESCRIPTION
Let's avoid code duplication and re-use here the very same script that's
used to build the kata-deploy binaries.

By doing this we:
* Reduce code duplication / complexity;
* Test the same build scripts used for kata-deploy on every single CI
  job;

Fixes: #4462

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>