### PR TITLE
ci/static-checks: Treat Dockerfile.template

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1229,7 +1229,7 @@ static_check_dockerfiles()
 		# dockerfile. Some of our dockerfiles are actually templates
 		# with special syntax, thus the linter might fail to build
 		# the AST. Here we handle Dockerfile templates.
-		if [[ "$file" =~ Dockerfile.*.in$ ]]; then
+		if [[ "$file" =~ Dockerfile.*\.(in|template)$ ]]; then
 			# In our templates, text with marker as @SOME_NAME@ is
 			# replaceable. Usually it is used to replace in a
 			# FROM command (e.g. `FROM @UBUNTU_REGISTRY@/ubuntu`)


### PR DESCRIPTION
besides Dockerfile.in for replacing `@...@` placeholders, so that
hadolint can run the checks.
Also fix the regex to actually require a period.

Fixes: #4465
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

"Can't we rename `Dockerfile.template`?" No, because that generates `Dockerfile.in`s in itself.