### PR TITLE
stable-2.3 | integration/containerd: Do not override config

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -55,11 +55,13 @@ readonly CONTAINERD_CONFIG_FILE="${tmp_dir}/test-containerd-config"
 readonly default_containerd_config="/etc/containerd/config.toml"
 readonly default_containerd_config_backup="$CONTAINERD_CONFIG_FILE.backup"
 readonly kata_config="/etc/kata-containers/configuration.toml"
+readonly kata_config_backup="$kata_config.backup"
 readonly default_kata_config="/usr/share/defaults/kata-containers/configuration.toml"
 
 ci_config() {
 	sudo mkdir -p $(dirname "${kata_config}")
-	sudo cp "${default_kata_config}" "${kata_config}"
+	[ -f "$kata_config" ] && sudo cp "$kata_config" "$kata_config_backup" || \
+		sudo cp "$default_kata_config" "$kata_config"
 
 	source /etc/os-release || source /usr/lib/os-release
 	ID=${ID:-""}
@@ -81,7 +83,6 @@ ci_config() {
 
 	echo "enable debug for kata-runtime"
 	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${kata_config}
-	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${default_kata_config}
 }
 
 ci_cleanup() {
@@ -98,15 +99,8 @@ ci_cleanup() {
 		sudo cp "$default_containerd_config_backup" "$default_containerd_config"
 	fi
 
-	ID=${ID:-""}
-	if [ "$ID" == ubuntu ]; then
-		if [ -n "${SNAP_CI}" ]; then
-			# restore default configuration
-			sudo cp "${default_kata_config}" "${kata_config}"
-		elif [ -n "${CI}" ] ;then
-			[ -f "${kata_config}" ] && sudo rm "${kata_config}"
-		fi
-	fi
+	[ -f "$kata_config_backup" ] && sudo mv "$kata_config_backup" "$kata_config" || \
+		sudo rm -f "$kata_config"
 }
 
 create_containerd_config() {


### PR DESCRIPTION
Instead of blindly copying the default Kata config, use the existing if
it is available, and restore it afterwards; as there might be important
changes, e.g. #4407.

Also, do not change the default config.

Fixes: #4435
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Backport of #4436.