### PR TITLE
ci: Remove some jenkins_job_build.sh cruft

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -36,8 +36,6 @@ export kata_repo="$1"
 
 echo "Setup env for kata repository: $kata_repo"
 
-[ -z "$kata_repo" ] && echo >&2 "kata repo no provided" && exit 1
-
 tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 katacontainers_repo="${katacontainers_repo:-github.com/kata-containers/kata-containers}"
 
@@ -128,8 +126,6 @@ fi
 "${GOPATH}/src/${tests_repo}/.ci/resolve-kata-dependencies.sh"
 
 # Check if we can fastpath return/skip the CI
-# Specifically do this **after** we have potentially done the static
-# checks, as we always want to run those.
 # Work around the 'set -e' dying if the check fails by using a bash
 # '{ group command }' to encapsulate.
 {


### PR DESCRIPTION
- Remove error message about missing spec of the Kata containers
  repository. nounset takes care of this.
- Remove comment about running fast return check before static checks.
  We have stopped doing this and there is no need to because we run the
  static checks `--only-arch` and other checks are run in GHA.

Fixes: #4471
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>