### PR TITLE
tests: temporarily disable hugepage sandbox cgroup only case

### DIFF
--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -37,6 +37,8 @@ setup() {
 
 
 @test "Hugepages and sandbox cgroup" {
+	skip "test not working see: https://github.com/kata-containers/tests/issues/4474"
+
 	# Enable sandbox_cgroup_only
 	# And set default memory to a low value that is not smaller then container's request
 	sed -i 's/sandbox_cgroup_only=false/sandbox_cgroup_only=true/g' ${RUNTIME_CONFIG_PATH}


### PR DESCRIPTION
There are too many errors with this case, temporarily disable
it and enable again after the issue fixed.

Fixes: #4474

Signed-off-by: bin <bin@hyper.sh>