### PR TITLE
ci: Fix containerd install

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -84,7 +84,7 @@ install_from_static_tarball() {
 }
 
 # For 'CCv0' we are pulling in a branch of our confidential-containers fork of containerd with our custom code
-if [ -n ${containerd_branch} ]; then
+if [ -n "${containerd_branch}" ]; then
   install_from_branch
 else
   install_from_static_tarball || install_from_source


### PR DESCRIPTION
Correct the logic so that the if doesn't result in true
if containerd_branch is empty

Fixes: #4479
Signed-off-by: stevenhorsman <steven@uk.ibm.com>

This PR is partly to fix a minor bug, but also to check the CCv0 tests are working after we had to disable some checks in the earlier merge