### PR TITLE
stable-2.3: backport adapt to centos stream

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -29,7 +29,8 @@ sudo -E dnf -y install epel-release
 # Enable priority to CentOS Base repo in order to
 # avoid perl updating issues
 for repo_file_path in /etc/yum.repos.d/CentOS-Base.repo \
-	/etc/yum.repos.d/CentOS-Linux-BaseOS.repo; do
+	/etc/yum.repos.d/CentOS-Linux-BaseOS.repo \
+	/etc/yum.repos.d/CentOS-Stream-BaseOS.repo; do
 	if [ -f "$repo_file_path" ]; then
 		repo_file="$repo_file_path"
 		break


### PR DESCRIPTION
backport of https://github.com/kata-containers/tests/pull/4300 so that centos stream jobs will work also on stable