### PR TITLE
metrics: Remove unused code for run metrics script

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -78,28 +78,9 @@ check() {
 		sudo make install
 		popd
 
-		# FIXME - we need to document the whole metrics CI setup, and the ways it
-		# can be configured and adapted. See:
-		# https://github.com/kata-containers/ci/issues/58
-		#
-		# If we are running on a (transient) cloud machine then we cannot
-		# tie the name of the expected results config file to the machine name - but
-		# we can expect the cloud image to have a default named file in the correct
-		# place.
-		if [ -n "${METRICS_CI_CLOUD}" ]; then
-			local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DEFDIR}/checkmetrics-json.toml"
-
-			# If we don't have a machine specific file in place, then copy
-			# over the default cloud density file.
-			if [ ! -f ${CM_BASE_FILE} ]; then
-				sudo mkdir -p ${CHECKMETRICS_CONFIG_DEFDIR}
-				sudo cp ${CM_DEFAULT_DENSITY_CONFIG} ${CM_BASE_FILE}
-			fi
-		else
-			# For bare metal repeatable machines, the config file name is tied
-			# to the uname of the machine.
-			local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DIR}/checkmetrics-json-${KATA_HYPERVISOR}-$(uname -n).toml"
-		fi
+		# For bare metal repeatable machines, the config file name is tied
+		# to the uname of the machine.
+		local CM_BASE_FILE="${CHECKMETRICS_CONFIG_DIR}/checkmetrics-json-${KATA_HYPERVISOR}-$(uname -n).toml"
 
 		checkmetrics --debug --percentage --basefile ${CM_BASE_FILE} --metricsdir ${RESULTS_DIR}
 		cm_result=$?


### PR DESCRIPTION
This PR removes unused code that belonged to kata 1.x metrics CI and
it is not longer being used for kata 2.x metrics CI for PR or
baseline.

Fixes #4492

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>