### PR TITLE
metrics: Update blogbench limits for qemu

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -55,7 +55,7 @@ description = "measure container average of blogbench write"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
-midval = 975.0
+midval = 907.0
 minpercent = 10.0
 maxpercent = 10.0
 
@@ -68,7 +68,7 @@ description = "measure container average of blogbench read"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .read.Result"
 checktype = "mean"
-midval = 55808.66
+midval = 55011.88
 minpercent = 10.0
 maxpercent = 10.0
 


### PR DESCRIPTION
This PR updates the blogbench limits for qemu in order to avoid
random failures related with them for the metrics CI. This seems
to be related that we changed the baremetal for the metrics CI.

Fixes #4498

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>