### PR TITLE
metrics: Update boot time for qemu

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -16,8 +16,8 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.67
-minpercent = 20.0
+midval = 0.60
+minpercent = 10.0
 maxpercent = 10.0
 
 [[metric]]


### PR DESCRIPTION
This PR updates the boot time for qemu for the metrics CI, this
is related with the issue that we recently changed the baremetal
where metrics is running.

Fixes #4500

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>