### PR TITLE
ci: Fixed: convert nodename to lower case to match kubectl

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -27,7 +27,7 @@ CRI_RUNTIME="${CRI_RUNTIME:-crio}"
 
 untaint_node() {
 	# Enable the master node to be able to schedule pods.
-	local node_name="$(hostname)"
+	local node_name="$(hostname | awk '{print tolower($0)}')"
 	local get_taints="kubectl get 'node/${node_name}' -o jsonpath='{.spec.taints}'"
 	if eval $get_taints | grep -q 'NoSchedule'; then
 		info "Taint 'NoSchedule' is found. Untaint the node so pods can be scheduled."

--- a/integration/kubernetes/k8s-block-volume.bats
+++ b/integration/kubernetes/k8s-block-volume.bats
@@ -31,7 +31,7 @@ setup() {
 	# Create Persistent Volume
 	tmp_pv_yaml=$(mktemp --tmpdir block_persistent_vol.XXXXX.yaml)
 	sed -e "s|LOOP_DEVICE|${loop_dev}|" volume/block-loop-pv.yaml > "$tmp_pv_yaml"
-	sed -i "s|HOSTNAME|$(hostname)|" "$tmp_pv_yaml"
+	sed -i "s|HOSTNAME|$(hostname | awk '{print tolower($0)}')|" "$tmp_pv_yaml"
 	sed -i "s|CAPACITY|${vol_capacity}|" "$tmp_pv_yaml"
 	kubectl create -f "$tmp_pv_yaml"
 	cmd="kubectl get pv/${volume_name} | grep Available"

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -185,7 +185,7 @@ main() {
 
 	# wait for the virtio_net resource
 	for _ in $(seq 1 30); do
-		v="$(sudo -E kubectl get node $(hostname) -o json | jq '.status.allocatable["intel.com/virtio_net"]')"
+		v="$(sudo -E kubectl get node $(hostname | awk '{print tolower($0)}') -o json | jq '.status.allocatable["intel.com/virtio_net"]')"
 		[ "${v}" == \"1\" ] && break
 		sleep 5
 	done


### PR DESCRIPTION
`kubectl get nodes` returns all node names in lower case.
`hostname` returns the true host name, with capitalization honored.

This converts the hostname to lower case so that the master node
is successfully untainated for scheduling. Without this, the node
name is not recognized and the test fails with the error:

```
0/1 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.
```

Fixes: #4502

Signed-off-by: Agam Dua <agam_dua@apple.com>