### PR TITLE
Add kata-monitor tests in CI jobs

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -56,12 +56,16 @@ case "${CI_JOB}" in
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		echo "INFO: Running ksm test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
+		echo "INFO: Running kata-monitor test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
 		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		echo "INFO: Running rootless tests"
 		sudo -E PATH="$PATH" bash -c "make rootless"
+		echo "INFO: Running kata-monitor test"
+		sudo -E PATH="$PATH" bash -c "make monitor"
 		;;
 	"CRIO_K8S_COMPLETE")
 		echo "INFO: Running kubernetes tests (minimal) with CRI-O"

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ vfio:
 
 agent: bash -f integration/agent/agent_test.sh
 
+monitor:
+	bash -f functional/kata-monitor/run.sh
+
 help:
 	@echo Subsets of the tests can be run using the following specific make targets:
 	@echo " $(UNION)" | sed 's/ /\n\t/g'

--- a/functional/kata-monitor/run.sh
+++ b/functional/kata-monitor/run.sh
@@ -21,6 +21,7 @@ set -o pipefail
 readonly MONITOR_HTTP_ENDPOINT="127.0.0.1:8090"
 # we should collect few hundred metrics, let's put a reasonable minimum
 readonly MONITOR_MIN_METRICS_NUM=200
+BAREMETAL=${BAREMETAL:-"false"}
 CRI_RUNTIME=${CRI_RUNTIME:-"crio"}
 CRICTL_RUNTIME=${CRICTL_RUNTIME:-"kata"}
 KATA_MONITOR_BIN="${KATA_MONITOR_BIN:-$(command -v kata-monitor || true)}"
@@ -205,6 +206,15 @@ is_sandbox_missing_iterate() {
 
 main() {
 	local args=""
+
+	# Our baremetal CI enforces cleanups of the environment (e.g., cni plugins):
+	# we here want a ready environment to just do few quick checks. So, let's skip
+	# baremetal environments for now.
+	# (kata-containers-2.0-tests-ubuntu-ARM-PR would fail)
+	if [ "$BAREMETAL" = true ]; then
+		echo "INFO: baremetal environment - skip kata-monitor tests"
+		exit 0
+	fi
 
 	###########################
 	title "pre-checks"

--- a/functional/kata-monitor/run.sh
+++ b/functional/kata-monitor/run.sh
@@ -22,7 +22,7 @@ readonly MONITOR_HTTP_ENDPOINT="127.0.0.1:8090"
 # we should collect few hundred metrics, let's put a reasonable minimum
 readonly MONITOR_MIN_METRICS_NUM=200
 CRI_RUNTIME=${CRI_RUNTIME:-"crio"}
-RUNTIME=${RUNTIME:-"containerd-shim-kata-v2"}
+CRICTL_RUNTIME=${CRICTL_RUNTIME:-"kata"}
 KATA_MONITOR_BIN="${KATA_MONITOR_BIN:-$(command -v kata-monitor || true)}"
 KATA_MONITOR_PID=""
 IAM=$(whoami)
@@ -225,8 +225,8 @@ main() {
 	RUNC_CID="$CID"
 	echo_ok "$CURRENT_TASK - POD ID:$POD_ID, CID:$CID"
 
-	CURRENT_TASK="start workload ($RUNTIME)"
-	start_workload "$RUNTIME"
+	CURRENT_TASK="start workload ($CRICTL_RUNTIME)"
+	start_workload "$CRICTL_RUNTIME"
 	echo_ok "$CURRENT_TASK - POD ID:$POD_ID, CID:$CID"
 
 	###########################
@@ -268,7 +268,7 @@ main() {
 	###########################
 	title "remove kata workload"
 
-	CURRENT_TASK="stop workload ($RUNTIME)"
+	CURRENT_TASK="stop workload ($CRICTL_RUNTIME)"
 	stop_workload
 	echo_ok "$CURRENT_TASK"
 


### PR DESCRIPTION
Include kata-monitor testing in our CI jobs.
Namely: add to CI_JOBs "CRIO_K8S" and  "CRI_CONTAINERD|CRI_CONTAINERD_K8S".
Since the current kata-monitor tests are quite basic and quick (less than one minute) shouldn't affect the CI pipeline that much.
Fixes #4506 