### PR TITLE
metrics: Use clean env for ctr for blogbench metrics

### DIFF
--- a/metrics/storage/blogbench.sh
+++ b/metrics/storage/blogbench.sh
@@ -119,7 +119,7 @@ EOF
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
 	metrics_json_save
-	clean_env
+	clean_env_ctr
 }
 
 main "$@"


### PR DESCRIPTION
This PR updates the blogbench clean environment to use the
clean_env_ctr which is used to remove containerd containers.

Fixes #4510

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>