### PR TITLE
stable-2.3 | static-checks: Exclude Dockerfile.template

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1151,6 +1151,7 @@ static_check_dockerfiles()
 		"tools/osbuilder/rootfs-builder/centos/Dockerfile.in"
 		"tools/osbuilder/rootfs-builder/debian/Dockerfile.in"
 		"tools/osbuilder/rootfs-builder/fedora/Dockerfile.in"
+		"tools/osbuilder/rootfs-builder/template/Dockerfile.template"
 		"tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in"
 		"tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in"
 		"tools/packaging/tests/Dockerfile/Dockerfile.in"


### PR DESCRIPTION
contains too many assumptions about substitutions

Fixes: #4504
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Backport of #4505