### PR TITLE
integration/containerd: Remove Kata config

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -101,7 +101,7 @@ ci_cleanup() {
 	fi
 
 	[ -f "$kata_config_backup" ] && sudo mv "$kata_config_backup" "$kata_config" || \
-		sudo cp "$default_kata_config" "$kata_config"
+		sudo rm "$kata_config"
 }
 
 create_containerd_config() {


### PR DESCRIPTION
if not present previously (otherwise, a backup would have existed).

Fixes: #4435
This is a forward-port of a comment made in #4469, a backport of #4436.
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>