### PR TITLE
ci: Update lib script to use clean env for ctr

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -190,7 +190,7 @@ function get_test_version(){
 
 kill_stale_process()
 {
-	clean_env
+	clean_env_ctr
 	extract_kata_env
 	stale_process_union=( "${stale_process_union[@]}" "${HYPERVISOR_PATH}" "${SHIM_PATH}" )
 	for stale_process in "${stale_process_union[@]}"; do


### PR DESCRIPTION
This PR updates the lib script to run the clean env for ctr as
clean env was used for docker and currently we are using containerd
in our tests in kata 2.0

Fixes #4514

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>