### PR TITLE
setup: Add "alinux" support

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -34,6 +34,8 @@ setup_distro_env() {
 
 	if [[ "$ID" =~ ^opensuse.*$ ]]; then
 		script="${cidir}/setup_env_opensuse.sh"
+	elif [[ "$ID" == "alinux" ]]; then
+		script="${cidir}/setup_env_centos.sh"
 	else
 		script="${cidir}/setup_env_${ID}.sh"
 	fi


### PR DESCRIPTION
Alibaba Cloud Linux seems to be a RHEL / CentOS like distro.  Let's try
to treat it the same as CentOS and hope for the best.

This is needed as it seems the ARM CIs switched to using Alibaba Cloud
Linux.

Fixes: #4518

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>