### PR TITLE
tess: enable TestContainerMemoryUpdate test

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -502,8 +502,8 @@ main() {
 			make -e cri-integration
 	done
 
-	#TestContainerMemoryUpdate 1
-	#TestContainerMemoryUpdate 0
+	TestContainerMemoryUpdate 1
+	TestContainerMemoryUpdate 0
 
 	TestKilledVmmCleanup
 


### PR DESCRIPTION
Test TestContainerMemoryUpdate is deisabled by #4394,
re-enable it.

Fixes: #4525

Signed-off-by: bin <bin@hyper.sh>