### PR TITLE
ci: Remove unused metrics experimental flag

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -171,16 +171,12 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export experimental_qemu="true"
 	;;
-"METRICS"|"METRICS_EXPERIMENTAL")
+"METRICS")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="yes"
 	export METRICS_CI=1
-	if [ "$CI_JOB" == "METRICS_EXPERIMENTAL" ]; then
-		export DEFVIRTIOFSCACHESIZE="1024"
-		export experimental_qemu="true"
-	fi
 ;;
 esac

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -119,14 +119,6 @@ case "${CI_JOB}" in
 		echo "INFO: Running cloud hypervisor metrics tests"
 		sudo -E PATH="$PATH" ".ci/run_metrics_PR_ci.sh"
 		;;
-	"METRICS_EXPERIMENTAL")
-		sudo -E PATH="$PATH"  bash -c "./integration/kubernetes/e2e_conformance/setup.sh"
-		# Some k8s cli commands have extra output using DEBUG env var.
-		unset DEBUG
-		sudo -E PATH="$PATH"  bash -c 'make -C "./metrics/storage/fio-k8s/" "test"'
-		sudo -E PATH="$PATH"  bash -c 'make -C "./metrics/storage/fio-k8s/" "run"'
-		sudo -E PATH="$PATH"  bash -c "./integration/kubernetes/cleanup_env.sh"
-		;;
 	"VIRTIOFS_EXPERIMENTAL")
 		sudo -E PATH="$PATH" bash -c "make filesystem"
 		;;


### PR DESCRIPTION
This PR removes the metrics experimental flag from the definition as well
as the run script as this is not being used in any CI for kata 2.0

Fixes #4527

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>