### PR TITLE
tests: unify runtime type to io.containerd.kata.v2

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -69,7 +69,7 @@ init_ci_flags() {
 	export METRICS_JOB_BASELINE=""
 	# Configure test to use Kata SHIM V2
 	export SHIMV2_TEST="true"
-	export CTR_RUNTIME="io.containerd.run.kata.v2"
+	export CTR_RUNTIME="io.containerd.kata.v2"
 }
 
 # Setup Kata Containers Environment

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -98,7 +98,7 @@ case "${CI_JOB}" in
 		;;
 	"METRICS")
 		export RUNTIME="kata-runtime"
-		export CTR_RUNTIME="io.containerd.run.kata.v2"
+		export CTR_RUNTIME="io.containerd.kata.v2"
 		export config_path="/usr/share/defaults/kata-containers"
 		tests_repo="github.com/kata-containers/tests"
 

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -72,7 +72,7 @@ run_container() {
 	local container_id="$1"
 	local bundle_dir="$2"
 
-	sudo -E ctr run -d --runtime io.containerd.run.kata.v2 --config "${bundle_dir}/config.json" "${container_id}"
+	sudo -E ctr run -d --runtime io.containerd.kata.v2 --config "${bundle_dir}/config.json" "${container_id}"
 }
 
 

--- a/integration/qat/qat_test.sh
+++ b/integration/qat/qat_test.sh
@@ -28,7 +28,7 @@ QAT_DEVICE_ID=37c8
 QAT_VENDOR_ID=8086
 QAT_DEV_ADDR=
 SSL_IMAGE_TAG=openssl-qat-engine
-CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.run.kata.v2}"
+CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 
 if [ "${arch}" == "aarch64" ] || [ "${arch}" == "s390x" ] || [ "${arch}" == "ppc64le" ]; then
 	echo "Skip QAT test: $arch doesn't support QAT"

--- a/metrics/density/memory_usage.sh
+++ b/metrics/density/memory_usage.sh
@@ -385,7 +385,7 @@ main(){
 	check_cmds "${SMEM_BIN}" bc
 	check_images "$IMAGE"
 
-	if [ "${CTR_RUNTIME}" == "io.containerd.run.kata.v2" ]; then
+	if [ "${CTR_RUNTIME}" == "io.containerd.kata.v2" ]; then
 		export RUNTIME="kata-runtime"
         elif [ "${CTR_RUNTIME}" == "io.containerd.runc.v2" ]; then
 		export RUNTIME="runc"

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -15,7 +15,7 @@ source /etc/os-release || source /usr/lib/os-release
 # Set variables to reasonable defaults if unset or empty
 CTR_EXE="${CTR_EXE:-ctr}"
 DOCKER_EXE="${DOCKER_EXE:-docker}"
-CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.run.kata.v2}"
+CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
@@ -227,7 +227,7 @@ show_system_ctr_state() {
 }
 
 common_init(){
-	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ] || [ "$RUNTIME" == "containerd-shim-kata-v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ] || [ "$RUNTIME" == "containerd-shim-kata-v2" ]; then
 		extract_kata_env
 	else
 		# We know we have nothing to do for runc or shimv2

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -44,7 +44,7 @@ metrics_json_init() {
 EOF
 )"
 
-	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ]; then
 		metrics_json_add_fragment "$json"
 
 		local json="$(cat << EOF
@@ -81,7 +81,7 @@ EOF
 EOF
 )"
 
-	if [ "$CTR_RUNTIME" == "io.containerd.run.kata.v2" ]; then
+	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ]; then
 		metrics_json_add_fragment "$json"
 
 		# Now add a runtime specific environment section if we can


### PR DESCRIPTION
Generally speaking, the runtime type consists of 4 parts,
such as `io.containerd.runc.v1`, but `io.containerd.run.kata.v2`
may mislead users about how to name runtime type.

Fixes: #4531

Signed-off-by: bin <bin@hyper.sh>