### PR TITLE
metrics: Update lower limit for boot time

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -17,7 +17,7 @@ description = "measure container lifecycle timings"
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.60
-minpercent = 10.0
+minpercent = 20.0
 maxpercent = 10.0
 
 [[metric]]


### PR DESCRIPTION
This PR updates the lower limit for boot time for qemu in order to avoid
random failures related with showing less boot time in the metrics CI.
This is related with the change of the baremetal for the metrics CI.

Fixes #4538

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>