### PR TITLE
tracing: Update tracing configuration script

### DIFF
--- a/.ci/configure_tracing_for_kata.sh
+++ b/.ci/configure_tracing_for_kata.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2019-2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -18,20 +18,14 @@ kata_cfg_file=$(kata-runtime kata-env --json |jq '.Runtime | .Config | .Path' |c
 
 enable_tracing() {
 	info "Enabling kata tracing on $kata_cfg_file"
-	sudo crudini --set "$kata_cfg_file" shim.kata enable_tracing true
+	sudo crudini --set "$kata_cfg_file" agent.kata enable_tracing true
 	sudo crudini --set "$kata_cfg_file" runtime enable_tracing true
-	sudo crudini --set "$kata_cfg_file" runtime internetworking_model \"none\"
-	sudo crudini --set "$kata_cfg_file" runtime disable_new_netns true
-	sudo crudini --set "$kata_cfg_file" netmon enable_netmon false
 }
 
 disable_tracing() {
 	info "Disabling kata tracing on $kata_cfg_file"
-	sudo crudini --set "$kata_cfg_file" shim.kata enable_tracing false
+	sudo crudini --set "$kata_cfg_file" agent.kata enable_tracing false
 	sudo crudini --set "$kata_cfg_file" runtime enable_tracing false
-	sudo crudini --set "$kata_cfg_file" runtime internetworking_model \"macvtap\"
-	sudo crudini --set "$kata_cfg_file" runtime disable_new_netns false
-	sudo crudini --set "$kata_cfg_file" netmon enable_netmon false
 }
 
 main() {


### PR DESCRIPTION
Change configuration section for agent tracing. Remove setting for
netmon since it is no longer a configuration option and for
internetworking model and network namespace since they are not relevant
for tracing in 2.x.

Fixes #4543

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>