### PR TITLE
CI: Create GHA to add PR sizing label

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -1,0 +1,32 @@
+name: Add PR sizing label
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  add-pr-size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Install PR sizing label script
+        run: |
+          # Clone into a temporary directory to avoid overwriting
+          # any existing github directory.
+          pushd $(mktemp -d) &>/dev/null
+          git clone --single-branch --depth 1 "https://github.com/kata-containers/.github" && cd .github/scripts
+          sudo install pr-add-size-label.sh /usr/local/bin
+          popd &>/dev/null
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
+        run: |
+          pr=${{ github.event.number }}
+          sudo apt -y install diffstat patchutils
+
+          pr-add-size-label.sh -p "$pr"


### PR DESCRIPTION
Created a new GitHub Action workflow file that adds a sizing label to
each PR.

Fixes: #4550.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>