### PR TITLE
metrics: Update network documentation

### DIFF
--- a/metrics/network/README.md
+++ b/metrics/network/README.md
@@ -1,4 +1,4 @@
-# Kata Containers `iperf3` and `nuttcp` network metrics
+# Kata Containers `iperf3` network metrics
 
 * [Performance tools](#performance-tools)
 * [Networking tests](#networking-tests)
@@ -6,38 +6,15 @@
 * [Expected results](#expected-results)
 
 Kata Containers provides a series of network performance tests. Running these provides
-a basic reference for measuring  network essentials like bandwidth, jitter,
-packet per second throughput, and latency.
+a basic reference for measuring  network essentials like bandwidth.
 
 ## Performance tools
 
 - `iperf3` measures bandwidth and the quality of a network link.
 
-- `nuttcp` determines the raw UDP layer throughput.
-
 ## Networking tests
 
-- `network-metrics-iperf3.sh` measures bandwidth, jitter,
-and packet-per-second throughput using `iperf3` on single threaded connections. The
-bandwidth test shows the speed of the data transfer. The jitter test measures the
-variation in the delay of received packets. The packet-per-second tests show the
-maximum number of (smallest sized) packets allowed through the transports.
-
-- `network-metrics-nuttcp.sh` measures the UDP bandwidth using `nuttcp`. This tool
-shows the speed of the data transfer for the UDP protocol.
-
-- `network-metrics-iperf.sh` measures bidirectional bandwidth. Bidirectional tests
-are used to test both servers for the maximum amount of throughput.
- 
-- `network-metrics-memory.sh` measures the Proportional Set Size (PSS), Resident Set Size (RSS),
-and Virtual Set Size (VSS) of the hypervisor footprint on the host using
-`smem` while running a transfer of one GB with `nuttcp`.
-
-- `network-metrics-nginx-ab-benchmark.sh` uses an Nginx container and runs the Apache
-benchmarking tool on the host to calculate the requests per second.
-
-- `network-latency.sh` measures the latency using ping. The ping utility measures
-how long it takes one packet to get from one point to another.
+- `k8s-network-metrics-iperf3.sh` measures bandwidth which is the speed of the data transfer.
 
 ## Running the tests
 
@@ -45,7 +22,7 @@ Individual tests can be run by hand, for example:
 
 ```
 $ cd metrics
-$ bash network/network-metrics-nuttcp.sh
+$ bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -b
 ```
 
 ## Expected results


### PR DESCRIPTION
This PR updates the network documentation for kata 2.0 metrics.

Fixes #4555

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>