### PR TITLE
CI: Fix PR sizing label GHA

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
 name: Add PR sizing label
 
 on:
@@ -23,6 +28,7 @@ jobs:
           sudo install pr-add-size-label.sh /usr/local/bin
           popd &>/dev/null
 
+      - name: Add PR sizing label
         env:
           GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
         run: |


### PR DESCRIPTION
Fixed the new GitHub Action added on
https://github.com/kata-containers/tests/pull/4551, which had two
problems:

- Missing copyright header.

- Multiple `run` entries for the 2nd step

  As a result, although the file was valid YAML, it was not a valid GHA.

Fixes: #4560.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>