### PR TITLE
CI: Update GHA secret name

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Add PR sizing label
         env:
-          GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_PR_SIZE_TOKEN }}
         run: |
           pr=${{ github.event.number }}
           sudo apt -y install diffstat patchutils


### PR DESCRIPTION
Change the secret used by the GitHub Action  that adds the PR size
label to one with the correct set of privileges.

Fixes: #4562.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>