### PR TITLE
openshift-ci: Install dracut on build environment

### DIFF
--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -145,6 +145,9 @@ fi
 # osbuilder's make define a VERSION variable which value might clash with
 # VERSION sourced from /etc/os-release.
 unset VERSION
+# It will be built a dracut-based rootfs so ensure dracut is installed in the
+# build environment.
+yum install -y dracut
 "${cidir}/install_kata_image.sh"
 
 "${cidir}/install_runtime.sh"


### PR DESCRIPTION
Dracut is used to build the image rootfs. Ensure the tool is installed
on the build environment.

Fixes #4564
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>