### PR TITLE
setup: avoid appending duplicated lines to config files

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -21,7 +21,9 @@ fi
 [ "$centos_version" == 8 ] || die "This script is for CentOS 8 only"
 
 # Send error when a package is not available in the repositories
-echo "skip_missing_names_on_install=0" | sudo tee -a /etc/yum.conf
+if [ "$(tail -1 /etc/yum.conf | tr -d '\n')" != "skip_missing_names_on_install=0" ]; then
+	echo "skip_missing_names_on_install=0" | sudo tee -a /etc/yum.conf
+fi
 
 # Ensure EPEL repository is configured
 sudo -E dnf -y install epel-release
@@ -37,7 +39,10 @@ for repo_file_path in /etc/yum.repos.d/CentOS-Base.repo \
 	fi
 done
 [ -n "${repo_file:-}" ] || die "Unable to find the CentOS base repository file"
-echo "priority=1" | sudo tee -a "$repo_file"
+
+if [ "$(tail -1 ${repo_file} | tr -d '\n')" != "priority=1" ]; then
+	echo "priority=1" | sudo tee -a "$repo_file"
+fi
 
 sudo -E dnf -y clean all
 


### PR DESCRIPTION
setup_env_centos.sh appends some lines to package manager
config files, it makes too many duplicated lines in the
config files.

Since these config files are not edited manually too often,
so check the last line and append new lines only when needed.

Fixes: #4535

Signed-off-by: bin <bin@hyper.sh>