### PR TITLE
CI: Make here document checker die on error

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -130,7 +130,7 @@ install_kernel() {
 
 usage() {
 	exit_code="$1"
-	cat <<EOT
+	cat <<EOF
 Overview:
 
 	Build and install a kernel for Kata Containers
@@ -143,7 +143,7 @@ Options:
     -d          : Enable bash debug.
     -h          : Display this help.
     -t <kernel> : kernel type, such as vanilla, experimental, tdx.
-EOT
+EOF
 	exit "$exit_code"
 }
 

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -171,7 +171,7 @@ run() {
 
 usage() {
 	exit_code="$1"
-	cat <<EOT
+	cat <<EOF
 Overview:
 
 	Build and install QEMU for Kata Containers
@@ -184,7 +184,7 @@ Options:
     -d          : Enable bash debug.
     -h          : Display this help.
     -t <qemu> : qemu type, such as tdx, vanilla.
-EOT
+EOF
 	exit "$exit_code"
 }
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -838,7 +838,7 @@ static_check_eof()
 		sort -u |\
 		egrep -v '^$' |\
 		egrep -v "$anchor" || true)
-	[ -z "$invalid" ] || echo "Expected '$anchor' here anchor, in $file found: $invalid"
+	[ -z "$invalid" ] || die "Expected '$anchor' here anchor, in $file found: $invalid"
 }
 
 # Tests to apply to all files.

--- a/functional/kata-monitor/run.sh
+++ b/functional/kata-monitor/run.sh
@@ -92,7 +92,7 @@ create_sandbox_json() {
 	local uid_name_suffix="$(gen_unique_id)"
 	local sbfile="$TMPATH/sandbox-$uid_name_suffix.json"
 
-	cat <<OEM >$sbfile
+	cat <<EOF >$sbfile
 {
 	"metadata": {
 		"name": "nginx-$uid_name_suffix",
@@ -103,7 +103,7 @@ create_sandbox_json() {
 	"linux": {
 	}
 }
-OEM
+EOF
 	echo "$sbfile"
 }
 
@@ -111,7 +111,7 @@ create_container_json() {
 	local uid_name_suffix="$(gen_unique_id)"
 	local cntfile="$TMPATH/container-$uid_name_suffix.json"
 
-	cat <<OEM >$cntfile
+	cat <<EOF >$cntfile
 {
 	"metadata": {
 		"name": "busybox"
@@ -126,7 +126,7 @@ create_container_json() {
 	"linux": {
 	}
 }
-OEM
+EOF
 	echo "$cntfile"
 }
 


### PR DESCRIPTION
Fix the shell here document static check added on #3937 which detects
problems perfectly, but doesn't actually exit on error.

Fixes: #4568.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>