### PR TITLE
ci: add CC_SKOPEO_CRI_CONTAINERD CI job type

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -93,7 +93,7 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="no"
 	;;
-"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CC_CRI_CONTAINERD")
+"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CC_CRI_CONTAINERD"|"CC_SKOPEO_CRI_CONTAINERD")
 	# This job only tests containerd + k8s
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
@@ -103,12 +103,14 @@ case "${CI_JOB}" in
 		"CRI_CONTAINERD_K8S")
 			export KUBERNETES="yes"
 			;;
-		"CC_CRI_CONTAINERD")
+		"CC_CRI_CONTAINERD"|"CC_SKOPEO_CRI_CONTAINERD")
 			# Export any CC specific environment variables
 			export CCV0="yes"
-			#export SKOPEO=${SKOPEO:-}
 			export UMOCI=yes
 			export SECCOMP=yes
+			if [ "${CI_JOB}" == "CC_SKOPEO_CRI_CONTAINERD" ]; then
+				export SKOPEO=yes
+			fi
 			;;
 	esac
 	;;

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -59,7 +59,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running kata-monitor test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
 		;;
-	"CC_CRI_CONTAINERD")
+	"CC_CRI_CONTAINERD"|"CC_SKOPEO_CRI_CONTAINERD")
 		echo "INFO: Running Confidential Container tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
 		;;


### PR DESCRIPTION
Currently the kata-agent integrates with skopeo to pull and verify
container images inside the guest. On the absence of skopeo, the agent
falls back to a (still) limited implementation. For example, without skopeo
the container policy file is not ignored, so images cannot be verified.

This adds the CC_SKOPEO_CRI_CONTAINERD job type which extends the
CC_CRI_CONTAINERD (added in commit 0678babef540884) configuration
so that skopeo is installed in the guest image. We will use that configuration
to test features which relies on skopeo.

Fixes #4572
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>