### PR TITLE
integration/k8s: Drop caches before hugepages

### DIFF
--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -36,6 +36,8 @@ setup() {
 
 	old_pages=$(cat "/sys/kernel/mm/hugepages/$hugepages_sysfs_dir/nr_hugepages")
 
+	sync
+	echo 3 > /proc/sys/vm/drop_caches
 	echo "$hugepages_count" > "/sys/kernel/mm/hugepages/$hugepages_sysfs_dir/nr_hugepages"
 
 	systemctl restart kubelet


### PR DESCRIPTION
Sync and free pagecache, dentries and inodes before enabling hugepages.
Ensures enough hugepages can be allocated.

Fixes: #4575
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @liubin