### PR TITLE
CCv1 | ci: Add cloud-hypervisor to the CC specific jobs

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -114,6 +114,20 @@ case "${CI_JOB}" in
 			;;
 	esac
 	;;
+"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR"|"CC_SKOPEO_CRI_CONTAINERD_CLOUD_HYPERVISOR")
+	# This job only tests containerd + k8s
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	# Export any CC specific environment variables
+	export CCV0="yes"
+	export UMOCI=yes
+	export SECCOMP=yes
+	if [ "${CI_JOB}" == "CC_SKOPEO_CRI_CONTAINERD_CLOUD_HYPERVISOR" ]; then
+		export SKOPEO=yes
+	fi
+	;;
 "CRIO_K8S")
 	init_ci_flags
 	export CRI_RUNTIME="crio"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -59,7 +59,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running kata-monitor test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
 		;;
-	"CC_CRI_CONTAINERD"|"CC_SKOPEO_CRI_CONTAINERD")
+	"CC_CRI_CONTAINERD"|"CC_SKOPEO_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR"|"CC_SKOPEO_CRI_CONTAINERD_CLOUD_HYPERVISOR")
 		echo "INFO: Running Confidential Container tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
 		;;


### PR DESCRIPTION
As we're running those with QEMU only, let's improve the coverage and
add cloud-hypervisor to the possible tests.

Note: This is only addin the possibility to run the jobs, but the jobs
are not yet created.

Fixes: #4580

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>