### PR TITLE
checkcommits: Remove semaphore from documentation and scripts

### DIFF
--- a/cmd/checkcommits/README.md
+++ b/cmd/checkcommits/README.md
@@ -109,8 +109,3 @@ $ checkcommits --verbose --need-fixes --need-sign-offs --body-length 99 --subjec
 $ checkcommits "$TRAVIS_COMMIT" "$TRAVIS_BRANCH"
 ```
 
-### Run under SemaphoreCI
-
-```
-$ checkcommits "$REVISION" "$BRANCH_NAME"
-```

--- a/cmd/checkcommits/checkcommits.go
+++ b/cmd/checkcommits/checkcommits.go
@@ -477,26 +477,6 @@ func detectCIEnvironment() (commit, dstBranch, srcBranch string) {
 
 		srcBranch = os.Getenv("TRAVIS_PULL_REQUEST_BRANCH")
 		dstBranch = os.Getenv("TRAVIS_BRANCH")
-
-	} else if os.Getenv("SEMAPHORE") != "" {
-		name = "SemaphoreCI"
-
-		commit = os.Getenv("REVISION")
-
-		dstBranch = os.Getenv("BRANCH_NAME")
-
-		// Semaphore only has a single branch variable. For a PR
-		// branch, it will contain the name of the PR branch,
-		// but for a build of "master", that same variable will
-		// contain "master". Essentially, the variable always
-		// refers to the name of the current branch being built.
-		if os.Getenv("PULL_REQUEST_NUMBER") != "" {
-			srcBranch = dstBranch
-
-			// Oddly, a git checkout for a PR under Semaphore *only*
-			// contains that branch: master doesn't exist.
-			dstBranch = "origin"
-		}
 	} else if os.Getenv("ghprbPullId") != "" {
 		name = "JenkinsCI - github pull request builder"
 
@@ -757,7 +737,7 @@ func main() {
 	app.UsageText += "     source branch that wants to be merged into the specified (destination)\n"
 	app.UsageText += "     branch.\n\n"
 	app.UsageText += "   - If not specified, commit and branch will be set automatically\n"
-	app.UsageText += "     if running in a supported CI environment (Travis or Semaphore).\n\n"
+	app.UsageText += "     if running in a supported CI environment (Travis).\n\n"
 	app.UsageText += "   - If not running under a recognised CI environment, commit will default\n"
 	app.UsageText += fmt.Sprintf("     to %q and branch to %q.", defaultCommit, defaultBranch)
 

--- a/cmd/checkcommits/checkcommits_test.go
+++ b/cmd/checkcommits/checkcommits_test.go
@@ -48,22 +48,6 @@ var travisNonPREnv = map[string]TestEnvVal{
 	"TRAVIS_PULL_REQUEST_BRANCH": {"", true},
 }
 
-var semaphorePREnv = map[string]TestEnvVal{
-	"SEMAPHORE":           {"true", true},
-	"BRANCH_NAME":         {"semaphore-pr", true},
-	"REVISION":            {"semaphore-commit", true},
-	"PULL_REQUEST_NUMBER": {"semaphore-pr", true},
-}
-
-var semaphoreNonPREnv = map[string]TestEnvVal{
-	"SEMAPHORE":   {"true", true},
-	"BRANCH_NAME": {"master", true},
-	"REVISION":    {"semaphore-commit", true},
-
-	// XXX: the odd one out - unset it
-	"PULL_REQUEST_NUMBER": {"", false},
-}
-
 var testCIEnvData = []TestCIEnvData{
 	{
 		name:              "TravisCI PR branch",
@@ -78,20 +62,6 @@ var testCIEnvData = []TestCIEnvData{
 		expectedCommit:    travisNonPREnv["TRAVIS_PULL_REQUEST_SHA"].value,
 		expectedSrcBranch: travisNonPREnv["TRAVIS_PULL_REQUEST_BRANCH"].value,
 		expectedDstBranch: travisNonPREnv["TRAVIS_BRANCH"].value,
-	},
-	{
-		name:              "SemaphoreCI PR branch",
-		env:               semaphorePREnv,
-		expectedCommit:    semaphorePREnv["REVISION"].value,
-		expectedSrcBranch: semaphorePREnv["BRANCH_NAME"].value,
-		expectedDstBranch: "origin",
-	},
-	{
-		name:              "SemaphoreCI non-PR branch",
-		env:               semaphoreNonPREnv,
-		expectedCommit:    semaphoreNonPREnv["REVISION"].value,
-		expectedSrcBranch: "",
-		expectedDstBranch: semaphoreNonPREnv["BRANCH_NAME"].value,
 	},
 }
 
@@ -175,11 +145,6 @@ func clearCIVariables() {
 		"TRAVIS_BRANCH",
 		"TRAVIS_PULL_REQUEST_SHA",
 		"TRAVIS_PULL_REQUEST_BRANCH",
-
-		"SEMAPHORE",
-		"REVISION",
-		"BRANCH_NAME",
-		"PULL_REQUEST_NUMBER",
 
 		"ghprbPullId",
 		"ghprbActualCommit",


### PR DESCRIPTION
This PR removes semaphore CI from checkcommits documentation and scripts as we
are not longer using this CI for kata 2.0

Fixes #4592

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>