### PR TITLE
docs: Update storage README

### DIFF
--- a/metrics/storage/README.md
+++ b/metrics/storage/README.md
@@ -9,8 +9,6 @@ to perform measurements upon a single test file.
 
 The test configuration used by the script can be modified by setting a number of
 environment variables to change or over-ride the test defaults.
-Please consult the [source](fio.sh) for more details on the
-which variables are available.
 
 ## DAX `virtio-fs` `fio` Kubernetes tests
 


### PR DESCRIPTION
This PR updates the storage README by removing the old references
for the fio benchmark that uses docker and is not part of the kata 2.x CI.

Fixes #4594

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>