### PR TITLE
tracing: Fix or skip on s390x

### DIFF
--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -743,9 +743,9 @@ setup()
 		exit 0
 	}
 
-	# Do not run on ppc64le for now
-	[ "$(uname -m)" = "ppc64le" ] && {
-		info "Exiting, do not run on ppc64le"
+	# Do not run on ppc64le/s390x for now
+	[ "$(uname -m)" = "ppc64le" -o "$(uname -m)" = "s390x" ] && {
+		info "Exiting, do not run on ppc64le or s390x. For s390x, see https://github.com/kata-containers/tests/issues/4597."
 		exit 0
 	}
 

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -82,6 +82,8 @@ start_jaeger()
 {
 	local jaeger_docker_image="jaegertracing/all-in-one:latest"
 
+	docker rm -f "${jaeger_docker_container_name}"
+
 	# Defaults - see https://www.jaegertracing.io/docs/getting-started/
 	docker run -d --runtime runc --name "${jaeger_docker_container_name}" \
 		-e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \


### PR DESCRIPTION
tracing: Remove Jaeger container before starting

can be left over on permanent instances

---

tracing: Skip agent shutdown test on s390x

is unstable, see https://github.com/kata-containers/tests/issues/4597

Fixes: #4598
