### PR TITLE
ci: Add an external job for testing cloud-hypervisor

### DIFF
--- a/.ci/ci_clh_entry_point.sh
+++ b/.ci/ci_clh_entry_point.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is called by our jenkins instances, triggered by PRs on Cloud Hypervisor.
+# It relies on the following environment variables being set:
+# REPO_OWNER    - owner of the source repository (default: cloud-hypervisor)
+# REPO_NAME     - repository name (default: cloud-hypervisor)
+# PULL_BASE_REF - name of the branch where the pull request is merged to (default: main)
+# PULL_NUMBER   - pull request number (REQUIRED)
+#
+# (see: http://jenkins.katacontainers.io/job/kata-containers-2-clh-PR/)
+#
+# Usage:
+# curl -OL https://raw.githubusercontent.com/kata-containers/tests/main/.ci/ci_clh_entry_point.sh
+# bash ci_clh_entry_point.sh
+
+set -o errexit
+set -o pipefail
+set -o errtrace
+set -o nounset
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+if [ -z "$PULL_NUMBER" ]; then
+	echo "No pull number given: testing with HEAD"
+	PULL_NUMBER="NONE"
+fi
+
+# set defaults for required variables
+export REPO_OWNER=${REPO_OWNER:-"cloud-hypervisor"}
+export REPO_NAME=${REPO_NAME:-"cloud-hypervisor"}
+export PULL_BASE_REF=${PULL_BASE_REF:-"main"}
+
+# Export all environment variables needed.
+export CI_JOB="EXTERNAL_CLOUD_HYPERVISOR"
+export INSTALL_KATA="yes"
+export GO111MODULE=auto
+
+export cloud_hypervisor_pr="${PULL_NUMBER}"
+export cloud_hypervisor_pull_ref_branch="${PULL_BASE_REF}"
+
+export ghprbGhRepository="${REPO_OWNER}/${REPO_NAME}"
+export GOROOT="/usr/local/go"
+
+# Put our go area into the Jenkins job WORKSPACE tree
+export GOPATH=${WORKSPACE}/go
+export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
+mkdir -p "${GOPATH}"
+
+git config --global user.email "katacontainersbot@gmail.com"
+git config --global user.name "Kata Containers Bot"
+
+github="github.com"
+kata_github="${github}/kata-containers"
+
+# Kata Containers Tests repository
+tests_repo="${kata_github}/tests"
+tests_repo_dir="${GOPATH}/src/${tests_repo}"
+
+# Kata Containers repository
+katacontainers_repo="${kata_github}/kata-containers"
+katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
+
+# Print system info and env variables in case we need to debug
+uname -a
+env
+
+echo "This Job will test Cloud Hypervisor changes using Kata Containers runtime."
+echo "Testing PR number ${cloud_hypervisor_pr}."
+
+# Clone the tests repository
+mkdir -p $(dirname "${tests_repo_dir}")
+[ -d "${tests_repo_dir}" ] || git clone "https://${tests_repo}.git" "${tests_repo_dir}"
+source ${tests_repo_dir}/.ci/ci_job_flags.sh
+
+# Clone the kata-containers repository
+mkdir -p $(dirname "${katacontainers_repo_dir}")
+[ -d "${katacontainers_repo_dir}" ] || git clone "https://${katacontainers_repo}.git" "${katacontainers_repo_dir}"
+
+# Run kata-containers setup
+cd "${tests_repo_dir}"
+.ci/setup.sh
+
+pushd "${katacontainers_repo_dir}"
+	src_clh_yaml="${katacontainers_repo_dir}/build/cloud-hypervisor/builddir/cloud-hypervisor/vmm/src/api/openapi/cloud-hypervisor.yaml"
+	dest_clh_yaml="${katacontainers_repo_dir}/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml"
+
+	if [ ! -f ${dest_clh_yaml} ]; then
+		echo "${dest_clh_yaml} should already exist, but it does not, indicating some change in the kata-containers repo"
+		return 1
+	fi
+
+	echo "Rebuild Kata Containers' runtime using the latest cloud-hypervisor.yaml file"
+
+	cp ${src_clh_yaml} ${dest_clh_yaml}
+	pushd src/runtime/virtcontainers/pkg/cloud-hypervisor/
+		make generate-client-code && make go-fmt
+	popd
+	pushd src/runtime/
+		make && sudo -E make install
+	popd
+popd
+
+.ci/run.sh

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -139,6 +139,13 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	;;
+"EXTERNAL_CLOUD_HYPERVISOR")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="no"
+	;;
 "EXTERNAL_CRIO")
 	init_ci_flags
 	export CRIO="yes"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -17,11 +17,13 @@ arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
 
 main() {
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+
 	# Just in case the kata-containers repo is not cloned yet.
 	clone_katacontainers_repo
 
 	pushd $katacontainers_repo_dir
-	sudo -E PATH=$PATH make cloud-hypervisor-tarball
+	sudo -E PATH=$PATH bash ${buildscript} --build=cloud-hypervisor
 	sudo tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
 	sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
 	popd

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -23,6 +23,7 @@ main() {
 	pushd $katacontainers_repo_dir
 	sudo -E PATH=$PATH make cloud-hypervisor-tarball
 	sudo tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
+	sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
 	popd
 }
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -85,7 +85,6 @@ case "${KATA_HYPERVISOR}" in
 		;;
 	"cloud-hypervisor")
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-clh.toml"
-		sudo sed -i 's|/usr/bin/cloud-hypervisor|/opt/kata/bin/cloud-hypervisor|g' "${runtime_config_path}"
 		;;
 	"firecracker")
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -88,6 +88,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests with containerd"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		;;
+	"EXTERNAL_CLOUD_HYPERVISOR")
+		echo "INFO:n Running tests on Cloud Hypervisor PR"
+		sudo -E PATH="$PATH" bash -c "make cri-containerd"
+		;;
 	"EXTERNAL_CRIO")
 		echo "INFO: Running tests on cri-o PR"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"


### PR DESCRIPTION
This will allow to test each cloud-hypervisor PR, and give us a head's
up on changes that will break Kata Containers, as we've faced in the
past.

Fixes: #4600

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>