### PR TITLE
uefi/arm64: optimize UEFI installation

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -19,15 +19,19 @@ TOOLCHAIN_ARCHIVE="${TOOLCHAIN_ARCHIVE_PREFIX}.tar.xz"
 TOOLCHAIN_PREFIX="${TOOLCHAIN_ARCHIVE_PREFIX}/bin/aarch64-none-elf-"
 TOOLCHAIN_SOURCE_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/${TOOLCHAIN_VERSION}/binrel/${TOOLCHAIN_ARCHIVE}"
 
-export WORKSPACE=$(mktemp -d)
+export EDK2_WORKSPACE=$(mktemp -d)
 
-QEMU_EFI_BUILD_PATH="${WORKSPACE}/Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd"
+#tag or commit id of source code
+EDK2_REPO_TAG_ID="edk2-stable202202"
+ACPICA_TAG_ID="R12_17_21"
+
+QEMU_EFI_BUILD_PATH="${EDK2_WORKSPACE}/Build/ArmVirtQemu-AARCH64/RELEASE_GCC5/FV/QEMU_EFI.fd"
 
 PREFIX="${PREFIX:-/usr}"
 INSTALL_PATH="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
 EFI_NAME="QEMU_EFI.fd"
-EFI_DEFAULT_DIR="/usr/share/qemu-efi-aarch64"
+EFI_DEFAULT_DIR="${EDK2_WORKSPACE}/qemu-efi-aarch64"
 EFI_DEFAULT_PATH="${EFI_DEFAULT_DIR}/${EFI_NAME}"
 
 FLASH0_NAME="kata-flash0.img"
@@ -39,11 +43,12 @@ arch=$(uname -m)
 
 build_uefi()
 {
-	pushd "${WORKSPACE}"
-	git clone "${EDK2_REPO}"
-	git clone "${EDK2_PLAT_REPO}"
-	git clone "${ACPICA}"
+	pushd "${EDK2_WORKSPACE}"
+	export WORKSPACE="${EDK2_WORKSPACE}"
 
+	git clone -b "${EDK2_REPO_TAG_ID}" "${EDK2_REPO}" 
+	git clone "${EDK2_PLAT_REPO}"
+	git clone -b "${ACPICA_TAG_ID}"  "${ACPICA}"
 
 	sudo apt install -y python python3 python3-distutils uuid-dev build-essential bison flex
 
@@ -54,9 +59,9 @@ build_uefi()
 
 	make -C acpica/
 
-	export GCC5_AARCH64_PREFIX="${WORKSPACE}/toolchain/${TOOLCHAIN_PREFIX}"
-	export PACKAGES_PATH=$WORKSPACE/edk2:$WORKSPACE/edk2-platforms
-	export IASL_PREFIX=$WORKSPACE/acpica/generate/unix/bin/
+	export GCC5_AARCH64_PREFIX="${EDK2_WORKSPACE}/toolchain/${TOOLCHAIN_PREFIX}"
+	export PACKAGES_PATH=${EDK2_WORKSPACE}/edk2:${EDK2_WORKSPACE}/edk2-platforms
+	export IASL_PREFIX=${EDK2_WORKSPACE}/acpica/generate/unix/bin/
 
 	export PYTHON_COMMAND=/usr/bin/python3
 
@@ -65,6 +70,11 @@ build_uefi()
 	make -C edk2/BaseTools
 
 	build -a AARCH64 -t GCC5 -p edk2/ArmVirtPkg/ArmVirtQemu.dsc -b RELEASE
+
+	[ ! -d ${EFI_DEFAULT_DIR} ] && mkdir -p ${EFI_DEFAULT_DIR}
+	cp ${QEMU_EFI_BUILD_PATH} ${EFI_DEFAULT_DIR} || clean_up_and_die "fail to build uefi for arm64"
+
+	export -n WORKSPACE
 	echo "Info: build uefi successfully"
 
 	popd
@@ -72,24 +82,20 @@ build_uefi()
 
 prepare_default_uefi()
 {
-	if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
-		sudo apt remove -y qemu-efi-aarch64
-		sudo apt install -y qemu-efi-aarch64
-	else
-		local efi_url="https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd"
-		sudo mkdir -p "${EFI_DEFAULT_DIR}"
-		pushd "${WORKSPACE}" || clean_up_and_die "fail to prepare default uefi."
-		curl -LO ${efi_url}
-		sudo install -o root -g root -m 644 QEMU_EFI.fd ${EFI_DEFAULT_DIR}
-		popd
-	fi
+	echo "will download qemu_efi.fd"
+	readonly efi_url="https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd"
+	sudo mkdir -p "${EFI_DEFAULT_DIR}"
+	pushd "${EDK2_WORKSPACE}"
+	curl -LO ${efi_url}
+	sudo install -o root -g root -m 644 QEMU_EFI.fd ${EFI_DEFAULT_DIR}
+	popd
 }
 
 prepare_uefi_flash() {
-	pushd "${WORKSPACE}"
+	pushd "${EDK2_WORKSPACE}"
 
 	dd if=/dev/zero of=${FLASH0_NAME} bs=1M count=64
-	dd if="$1" of=${FLASH0_NAME} conv=notrunc
+	dd if=${EFI_DEFAULT_PATH} of=${FLASH0_NAME} conv=notrunc
 	dd if=/dev/zero of=${FLASH1_NAME} bs=1M count=64
 
 	popd
@@ -99,8 +105,8 @@ install_uefi_flash()
 {
 	[ -z "$1" -o -z "$2" ] && clean_up_and_die "fail to install uefi flash for lack of input"
 	[ -d "${INSTALL_PATH}" ] || mkdir -p ${INSTALL_PATH}
-	sudo install --mode 0544 -D "$1" "${INSTALL_PATH}/${FLASH0_NAME}"
-	sudo install --mode 0544 -D "$2" "${INSTALL_PATH}/${FLASH1_NAME}"
+	sudo install --mode 0544 -D "${EDK2_WORKSPACE}/${FLASH0_NAME}" "${INSTALL_PATH}/${FLASH0_NAME}"
+	sudo install --mode 0544 -D "${EDK2_WORKSPACE}/${FLASH1_NAME}" "${INSTALL_PATH}/${FLASH1_NAME}"
 }
 
 clean_up_and_die()
@@ -112,34 +118,28 @@ clean_up_and_die()
 
 clean_up()
 {
-	sudo rm -rf "${WORKSPACE}"
+	sudo rm -rf "${EDK2_WORKSPACE}"
 }
 
 main()
 {
-	[ $(id -u) == 0 ] && echo "run this script as root"
-
-	# If you want to build the latest uefi from source code (and it is recommended)
-	# please run this script in ubuntu:18.04+ on arm64 machine or cross build then copy
-	# the rom images to your arm64 machine.
 	if [ "${arch}" != "aarch64" ]; then
 		echo "Please find solution at ${HOW_TO_CROSS_BUILD}"
 		exit 0
 	fi
 
-	if [ "$ID" == "ubuntu" -a `echo "${VERSION_ID} > 18" | bc` -eq 1 ]; then
-		build_uefi
-		prepare_uefi_flash "${QEMU_EFI_BUILD_PATH}"
-		install_uefi_flash "${WORKSPACE}/${FLASH0_NAME}" "${WORKSPACE}/${FLASH1_NAME}"
-	else
-		prepare_default_uefi
-		if [ -e  "${EFI_DEFAULT_PATH}" ]; then
-			prepare_uefi_flash "${EFI_DEFAULT_PATH}"
-			install_uefi_flash "${WORKSPACE}/${FLASH0_NAME}" "${WORKSPACE}/${FLASH1_NAME}"
+	#There maybe something wrong with the qemu efi download from linaro
+	#Just build it from source code until the issue is fixed
+	if [ ! -e "${EFI_DEFAULT_PATH}" ]; then
+		if [ "$ID" == "ubuntu" -a `echo "${VERSION_ID} > 18" | bc` -eq 1 ]; then
+			build_uefi
 		else
 			clean_up_and_die "fail to install uefi flash image on arm64"
 		fi
 	fi
+
+	prepare_uefi_flash
+	install_uefi_flash "${EDK2_WORKSPACE}/${FLASH0_NAME}" "${EDK2_WORKSPACE}/${FLASH1_NAME}"
 
 	echo "Info: install uefi rom image successfully"
 	clean_up


### PR DESCRIPTION
It's better clone source code, including acpica and edk2, from a stable tag.
As there maybe some unkonw issue about qemu efi from linaro, which doesn't
work well with ata. So, only create qemu efi from souce code, until the issue is fixed.

Fixes: #4603
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>