### PR TITLE
dictionary: Correct entry for NVIDIA

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -69,7 +69,7 @@ mmap/AB
 nack/AB
 namespace/ABCD
 netlink
-Nvidia
+NVIDIA
 onwards
 OpenAPI
 OS/AB


### PR DESCRIPTION
For reference: https://images.nvidia.com/aem-dam/en-zz/Solutions/about-us/NVIDIA-Partner-Network-Brand-Guidelines-May-2020.pdf 

Please use NVIDIA not NVidia, Nvidia or any other camel-case.