### PR TITLE
ci: Enable full debug

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -43,7 +43,6 @@ declare -A packages=( \
 	[libsystemd]="libsystemd-dev" \
 	[redis]="redis-server" \
 	[agent_shutdown_test]="tmux" \
-	[confidential_container_test]="socat" \
 )
 
 if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == "1" ]; then


### PR DESCRIPTION
- Update the enable full debug method to toggle all the debug flags on
kata's configuration.toml to ensure that hypervisor debug is enabled
- This seems to mean that logs are not streamed to the console socket
so we need to get them from the journal instead

Fixes: #4609
Signed-off-by: stevenhorsman <steven@uk.ibm.com>