### PR TITLE
integration/k8s: Re-add DOCKER iptables chain

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -17,6 +17,8 @@ iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 # you must do it manually
 # Here, we restore the iptables based on the previously cached file.
 sudo iptables-restore < "$iptables_cache"
+# All chains were cleared, but we'll need Docker
+sudo iptables -N DOCKER
 
 # The kubeadm reset process does not clean your kubeconfig files.
 # you must remove them manually.


### PR DESCRIPTION
in baremetal cleanup. Prior to saving iptables, all rules are removed,
but this is still required for the tracing test.

Fixes #4617
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @GabyCT @cmaf -- this is required because of https://github.com/kata-containers/tests/blob/08a08131669057c7c2de8c2428d38691979ec2ca/integration/kubernetes/init.sh#L178-L179 Please tell me if you think we should instead remove rules less aggressively in the first place there.
