### PR TITLE
tracing: Enable agent tracing in test

### DIFF
--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -745,9 +745,11 @@ setup()
 		exit 0
 	}
 
-	# Do not run on ppc64le/s390x for now
-	[ "$(uname -m)" = "ppc64le" -o "$(uname -m)" = "s390x" ] && {
-		info "Exiting, do not run on ppc64le or s390x. For s390x, see https://github.com/kata-containers/tests/issues/4597."
+	# Only run on x86_64 for now
+	[ "$(uname -m)" != "x86_64" ] && {
+		info "Exiting, only run on x86_64 for now. \\
+			For s390x, see https://github.com/kata-containers/tests/issues/4597. \\
+			For aarch64, see https://github.com/kata-containers/tests/issues/4684."
 		exit 0
 	}
 

--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -606,6 +606,8 @@ cleanup()
 		return 0
 	fi
 
+	kill_tmux_sessions
+
 	unconfigure_kata
 
 	 [ "$arg" != 'initial' ] && [ -d "$bundle_dir" ] && rm -rf "$bundle_dir"

--- a/tracing/tracing-test.sh
+++ b/tracing/tracing-test.sh
@@ -392,9 +392,9 @@ main()
                 exit 0
         }
 
-        # Do not run on ppc64le for now
-        [ "$(uname -m)" = "ppc64le" ] && {
-                info "Exiting, do not run on ppc64le"
+	# Only run on x86_64 for now
+        [ "$(uname -m)" != "x86_64" ] && {
+                info "Exiting, only run on x86_64"
                 exit 0
         }
 


### PR DESCRIPTION
Use trace forwarder in tracing test to forward agent spans in order to
include agent tracing in test.

Fixes #4634

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>