### PR TITLE
ci: Update test container config names

### DIFF
--- a/integration/containerd/confidential/fixtures/container-config.yaml
+++ b/integration/containerd/confidential/fixtures/container-config.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 metadata:
-  name: kata-cc-busybox
+  name: kata-cc-busybox-signed
 image:
   image: quay.io/kata-containers/confidential-containers:signed
 command:

--- a/integration/containerd/confidential/fixtures/container-config_signed-protected-other.yaml
+++ b/integration/containerd/confidential/fixtures/container-config_signed-protected-other.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 metadata:
-  name: kata-cc-busybox
+  name: kata-cc-busybox-signed-other
 image:
   image: quay.io/kata-containers/confidential-containers:other_signed
 command:

--- a/integration/containerd/confidential/fixtures/container-config_unsigned-protected.yaml
+++ b/integration/containerd/confidential/fixtures/container-config_unsigned-protected.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 metadata:
-  name: kata-cc-busybox
+  name: kata-cc-busybox-unsigned
 image:
   image: quay.io/kata-containers/confidential-containers:unsigned
 command:

--- a/integration/containerd/confidential/fixtures/container-config_unsigned-unprotected.yaml
+++ b/integration/containerd/confidential/fixtures/container-config_unsigned-unprotected.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 metadata:
-  name: kata-cc-busybox
+  name: prometheus-busybox-unsigned
 image:
   image: quay.io/prometheus/busybox:latest
 command:


### PR DESCRIPTION
- Update the names of the four cc test container config to be unique
- This allows them to run in the same pod

Fixes: #4637
Signed-off-by: stevenhorsman <steven@uk.ibm.com>