### PR TITLE
tests: kata-log-parser should not make an error for missing fields

### DIFF
--- a/cmd/log-parser/agent.go
+++ b/cmd/log-parser/agent.go
@@ -78,7 +78,7 @@ func unpackAgentLogEntry_v1(le LogEntry) (agent LogEntry, err error) {
 
 	reader := strings.NewReader(le.Msg)
 
-	entries, err := parseLogFmtData(reader, file)
+	entries, err := parseLogFmtData(reader, file, false)
 	if err != nil {
 		return LogEntry{}, fmt.Errorf("failed to parse agent log entry %+v: %v", le, err)
 	}

--- a/cmd/log-parser/agent_test.go
+++ b/cmd/log-parser/agent_test.go
@@ -149,7 +149,7 @@ func TestUnpackAgentLogEntry(t *testing.T) {
 			assert.NoErrorf(err, "test[%d]: %+v", i, d)
 
 			// Ensure the newly unpacked LogEntry is valid
-			err = agent.Check()
+			err = agent.Check(false)
 			assert.NoError(err)
 
 			assert.Equal(d.le.Filename, agent.Filename)
@@ -198,7 +198,7 @@ func TestUnpackAgentLogEntryWithContainerID(t *testing.T) {
 	assert.NoError(err)
 
 	// Ensure the newly unpacked LogEntry is valid
-	err = agent.Check()
+	err = agent.Check(false)
 	assert.NoError(err)
 
 	assert.Equal(containerID, agent.Container)

--- a/cmd/log-parser/logentry.go
+++ b/cmd/log-parser/logentry.go
@@ -115,7 +115,7 @@ func (le LogEntry) Fields() []string {
 }
 
 // Check runs basic checks on the LogEntry to ensure it is valid.
-func (le LogEntry) Check() error {
+func (le LogEntry) Check(ignoreMissingFields bool) error {
 	if le.Filename == "" {
 		return fmt.Errorf("missing filename: %+v", le)
 	}
@@ -134,24 +134,26 @@ func (le LogEntry) Check() error {
 		return fmt.Errorf("missing timestamp: %+v", le)
 	}
 
-	if le.Pid == 0 {
-		return fmt.Errorf("missing pid: %+v", le)
+	if !ignoreMissingFields {
+		if le.Pid == 0 {
+			return fmt.Errorf("missing pid: %+v", le)
+		}
+
+		if le.Level == "" {
+			return fmt.Errorf("missing log level: %+v", le)
+		}
+
+		if le.Source == "" {
+			return fmt.Errorf("missing component source: %+v", le)
+		}
+
+		if le.Name == "" {
+			return fmt.Errorf("missing component name: %+v", le)
+		}
 	}
 
 	if le.Pid < 0 {
 		return fmt.Errorf("invalid pid: %+v", le)
-	}
-
-	if le.Level == "" {
-		return fmt.Errorf("missing log level: %+v", le)
-	}
-
-	if le.Source == "" {
-		return fmt.Errorf("missing component source: %+v", le)
-	}
-
-	if le.Name == "" {
-		return fmt.Errorf("missing component name: %+v", le)
 	}
 
 	// Note: le.Container and le.Sandbox cannot be checked since they are not
@@ -165,7 +167,7 @@ func (le LogEntry) Check() error {
 
 	for k, v := range m {
 		fields := strings.Fields(v)
-		if len(fields) != 1 {
+		if len(fields) > 1 {
 			return fmt.Errorf("field %q cannot be multi-word: %+v", k, le)
 		}
 	}

--- a/cmd/log-parser/logentry_test.go
+++ b/cmd/log-parser/logentry_test.go
@@ -40,12 +40,13 @@ func TestLogEntryCheck(t *testing.T) {
 	assert := assert.New(t)
 
 	type testData struct {
-		le    LogEntry
-		valid bool
+		le        LogEntry
+		valid     bool
+		ignorable bool
 	}
 
 	data := []testData{
-		{LogEntry{}, false},
+		{LogEntry{}, false, false},
 
 		{
 			// No Filename
@@ -57,6 +58,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Source: "source",
 				Name:   "name",
 			},
+			false,
 			false,
 		},
 
@@ -71,6 +73,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			false,
+			false,
 		},
 
 		{
@@ -83,6 +86,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Source:   "source",
 				Name:     "name",
 			},
+			false,
 			false,
 		},
 
@@ -97,6 +101,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			false,
+			true,
 		},
 
 		{
@@ -110,6 +115,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			false,
+			true,
 		},
 
 		{
@@ -123,6 +129,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			false,
+			true,
 		},
 
 		{
@@ -136,6 +143,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Source:   "source",
 			},
 			false,
+			true,
 		},
 
 		{
@@ -149,6 +157,7 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			true,
+			false,
 		},
 
 		{
@@ -162,13 +171,22 @@ func TestLogEntryCheck(t *testing.T) {
 				Name:     "name",
 			},
 			true,
+			false,
 		},
 	}
 
 	for i, d := range data {
-		err := d.le.Check()
-
+		// check that an error is raised when expected
+		err := d.le.Check(false)
 		if d.valid {
+			assert.NoErrorf(err, "test[%d]: %+v", i, d)
+		} else {
+			assert.Errorf(err, "test[%d]: %+v", i, d)
+		}
+
+		// check that the error is ignored when asked to
+		err = d.le.Check(true)
+		if d.valid || d.ignorable {
 			assert.NoErrorf(err, "test[%d]: %+v", i, d)
 		} else {
 			assert.Errorf(err, "test[%d]: %+v", i, d)

--- a/cmd/log-parser/main.go
+++ b/cmd/log-parser/main.go
@@ -173,7 +173,7 @@ func handleLogFiles(c *cli.Context) (err error) {
 		return err
 	}
 
-	entries, err := parseLogFiles(files)
+	entries, err := parseLogFiles(files, c.GlobalBool("ignore-missing-fields"))
 	if err != nil {
 		return err
 	}
@@ -307,6 +307,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "error-if-no-records",
 			Usage: "error if all logfiles are empty",
+		},
+		cli.BoolFlag{
+			Name:  "ignore-missing-fields",
+			Usage: "do not make an error for lines with no pid, source, name, or level",
 		},
 		cli.BoolFlag{
 			Name:  "list-output-formats",


### PR DESCRIPTION
Adding a parameter to kata-log-parser to make it accept lines with
missing fields (name, source, level or pid).
Other checks are kept untouched.

Some tests have been added to verify this new behavior.

Fixes: #4632

Signed-off-by: Julien Ropé <jrope@redhat.com>