### PR TITLE
ci: Get firecracker binaries from the released tarball

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -29,11 +29,13 @@ install_fc() {
 
 	# Download firecracker and jailer
 	firecracker_binary="firecracker-${firecracker_version}-${arch}"
-	curl -fsL ${firecracker_repo}/releases/download/${firecracker_version}/${firecracker_binary} -o ${firecracker_binary}
-	sudo -E install -m 0755 -D ${firecracker_binary} /usr/bin/firecracker
 	jailer_binary="jailer-${firecracker_version}-${arch}"
-	curl -fsL ${firecracker_repo}/releases/download/${firecracker_version}/${jailer_binary} -o ${jailer_binary}
-	sudo -E install -m 0755 -D ${jailer_binary} /usr/bin/jailer
+	curl -fsL ${firecracker_repo}/releases/download/${firecracker_version}/${firecracker_binary}.tgz -o ${firecracker_binary}.tgz
+	tar -zxf ${firecracker_binary}.tgz
+	firecracker_binary_fullpath=release-${firecracker_version}/${firecracker_binary}
+	jailer_binary_fullpath=release-${firecracker_version}/${jailer_binary}
+	sudo -E install -m 0755 -D ${firecracker_binary_fullpath} /usr/bin/firecracker
+	sudo -E install -m 0755 -D ${jailer_binary_fullpath} /usr/bin/jailer
 }
 
 main() {


### PR DESCRIPTION
Starting with v0.23.2, firecracker binaries are relased in a tarball.
Prepare CI for that in order to bump the firecracker version from
v0.23.1 to v0.23.4 in the kata repo.

Fixes #4647

Depends-on: github.com/kata-containers/kata-containers#4011

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>
Signed-off-by: Greg Kurz <groug@kaod.org>