### PR TITLE
k8s: Wait for k8s replication controller to show up

### DIFF
--- a/integration/kubernetes/k8s-replication.bats
+++ b/integration/kubernetes/k8s-replication.bats
@@ -26,8 +26,8 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test-replication-controller.yaml"
 
 	# Check replication controller
-	kubectl describe replicationcontrollers/"$replication_name" | \
-		grep "replication-controller"
+	local cmd="kubectl describe replicationcontrollers/$replication_name | grep replication-controller"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	number_of_replicas=$(kubectl get replicationcontrollers/"$replication_name" \
 		--output=jsonpath='{.spec.replicas}')


### PR DESCRIPTION
This avoids intermittent failures in the CI

Fixes: #4653

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>
Suggested-by: Greg Kurz <groug@kaod.org>