### PR TITLE
CCv0: Enable TEE related CI behind firewall

### DIFF
--- a/integration/containerd/confidential/agent_image.bats
+++ b/integration/containerd/confidential/agent_image.bats
@@ -93,7 +93,19 @@ setup() {
 
 	echo "Reconfigure Kata Containers"
 	switch_image_service_offload on
-	clear_kernel_params
+	kernel_params=$(get_kernel_params)
+
+        local_dns=$(grep nameserver /etc/resolv.conf \
+            /run/systemd/resolve/resolv.conf  2>/dev/null \
+            |grep -v "127.0.0.53" | cut -d " " -f 2 | head -n 1)
+
+        if [ ! -z "$HTTPS_PROXY" ]; then
+	    add_kernel_params "agent.https_proxy=$HTTPS_PROXY"
+            sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+        elif [ ! -z "$https_proxy" ]; then
+	    add_kernel_params "agent.https_proxy=$https_proxy"
+            sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+        fi
 }
 
 # Check the logged messages on host have a given message.
@@ -192,6 +204,7 @@ teardown() {
 	crictl_delete_cc_pod_if_exists "$sandbox_name" || true
 
 	clear_kernel_params
+        add_kernel_params "$kernel_params"
 	switch_image_service_offload off
 	disable_full_debug
 

--- a/integration/containerd/confidential/lib.sh
+++ b/integration/containerd/confidential/lib.sh
@@ -200,6 +200,21 @@ add_kernel_params() {
 		"$RUNTIME_CONFIG_PATH"
 }
 
+# Get the 'kernel_params' property on kata's configuration.toml
+#
+# Environment variables:
+#	RUNTIME_CONFIG_PATH - path to kata's configuration.toml. If it is not
+#			      export then it will figure out the path via
+#			      `kata-runtime env` and export its value.
+#
+get_kernel_params() {
+	load_RUNTIME_CONFIG_PATH
+
+        local kernel_params=$(sed -n -e 's#^kernel_params = "\(.*\)"#\1#gp' \
+                "$RUNTIME_CONFIG_PATH")
+	echo "$kernel_params"
+}
+
 # Clear the 'kernel_params' property on kata's configuration.toml
 #
 # Environment variables:


### PR DESCRIPTION
ci: Enable ci build behind firewall    
    For CI jobs behind firewall, we need pass the https_proxy to guest.
    Current confidential CI did not utilize kubernetes coredns service, we
    also need extract the dns from host. For the dns service provided by
    systemd-resolved, we need get from file /run/systemd/resolve/resolv.conf

ci: Add TEE_TYPE flag for TEE enabled kernel/hypervisor