### PR TITLE
checkspelling: Update link in files document

### DIFF
--- a/cmd/check-spelling/data/files.txt
+++ b/cmd/check-spelling/data/files.txt
@@ -7,7 +7,7 @@
 # Notes: These *should* strictly be placed in backticks but alas this
 #   doesn't always happen.
 #
-# References: https://github.com/kata-containers/documentation/blob/master/Documentation-Requirements.md#files-and-command-names
+# References: https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md#files-and-command-names
 
 cgroup/AB
 coredump/A


### PR DESCRIPTION
This PR updates the correct link for documentation reference in
the files document.

Fixes #4663

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>