### PR TITLE
metrics: Adjust blogbench value for cloud hypervisor

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -55,7 +55,7 @@ description = "measure container average of blogbench write"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
-midval = 966.0
+midval = 898.0
 minpercent = 10.0
 maxpercent = 10.0
 


### PR DESCRIPTION
This PR adjusts the blogbench value for cloud hypervisor for the
write operations in order to avoid random failures, the change
is related with the new release.

Fixes #4665

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>