### PR TITLE
ci,clh: Set DEFAULT_HYPERVISOR on kata reinstall

### DIFF
--- a/.ci/ci_clh_entry_point.sh
+++ b/.ci/ci_clh_entry_point.sh
@@ -99,7 +99,7 @@ pushd "${katacontainers_repo_dir}"
 		make generate-client-code && make go-fmt
 	popd
 	pushd src/runtime/
-		make && sudo -E make install
+		make DEFAULT_HYPERVISOR="cloud-hypervisor" && sudo -E make DEFAULT_HYPERVISOR="cloud-hypervisor" install
 	popd
 popd
 


### PR DESCRIPTION
`make install` will overwrite the previous configuration and, if we
don't set DEFAULT_HYPERVISOR=cloud-hypervisor, the kata-containers'
makefile assumes DEFAULT_HYPEVISOR=qemu, which results in the CI running
with QEMU instead of Cloud Hypervisor.

Fixes: #4669

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>