### PR TITLE
labels: Remove unused github label

### DIFF
--- a/cmd/github-labels/archive/labeler-original-labels-kata-containers-tests.yaml
+++ b/cmd/github-labels/archive/labeler-original-labels-kata-containers-tests.yaml
@@ -17,9 +17,6 @@ labels:
   - name: P4
     color: fef2c0
     description: Noteworthy issue
-  - name: add-to-userguide
-    color: 55bf3d
-    description: https://github.com/kata-containers/documentation/wiki/UserGuide
   - name: backlog
     color: ededed
   - name: bitesize


### PR DESCRIPTION
This PR removes an unused github label as the User Guide does not exist
in kata 2.0 and this is referring to kata 1.x

Fixes #4671

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>