### PR TITLE
tdx: Fix TDX availability message and make it clear the test is QEMU specific

### DIFF
--- a/functional/tdx/run.sh
+++ b/functional/tdx/run.sh
@@ -31,7 +31,7 @@ trap cleanup EXIT
 
 setup() {
 	[ "$(uname -m)" == "x86_64" ] || die "Only x86_64 is supported"
-	[ -d "/sys/firmware/tdx_seam" ] || die "Intel TDX is available in this system"
+	[ -d "/sys/firmware/tdx_seam" ] || die "Intel TDX is not available in this system"
 
 	[ -n "${FIRMWARE}" ] || die "FIRMWARE environment variable is not set"
 	[ -n "${FIRMWARE_VOLUME}" ] || warn "FIRMWARE_VOLUME environment variable is not set"

--- a/functional/tdx/run.sh
+++ b/functional/tdx/run.sh
@@ -26,6 +26,7 @@ container_name=test
 jenkins_job_url="http://jenkins.katacontainers.io/job"
 FIRMWARE="${FIRMWARE:-}"
 FIRMWARE_VOLUME="${FIRMWARE_VOLUME:-}"
+KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 trap cleanup EXIT
 
@@ -35,6 +36,8 @@ setup() {
 
 	[ -n "${FIRMWARE}" ] || die "FIRMWARE environment variable is not set"
 	[ -n "${FIRMWARE_VOLUME}" ] || warn "FIRMWARE_VOLUME environment variable is not set"
+
+	[ "${KATA_HYPERVISOR}" == "qemu" ] || die "This test only supports QEMU for now"
 
 	local config_file="$(get_config_file)"
 	sudo cp "${config_file}" "${config_file}.bak"


### PR DESCRIPTION
tdx: Fix TDX availability message

If /sys/firmwware/tdx_seam is not present in the system, then Intel TDX
is **not** available there.

Fixes: #4673

---

tdx: Make it clear the tests is QEMU specific

Right now the tests is totally tied to QEMU, and we better make it
clear, failing in case someone tries to run it with a different
hypervisor.

---

@devimc, please, take a look.