### PR TITLE
Prepare to merge CCv0 into main: introduce the KATA_BUILD_CC variable

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -96,13 +96,24 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	export KUBERNETES="no"
 	;;
-"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S")
+"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CC_CRI_CONTAINERD")
 	# This job only tests containerd + k8s
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	[ "${CI_JOB}" == "CRI_CONTAINERD_K8S" ] && export KUBERNETES="yes"
+	case "${CI_JOB}" in
+		"CRI_CONTAINERD_K8S")
+			export KUBERNETES="yes"
+			;;
+		"CC_CRI_CONTAINERD")
+			# Export any CC specific environment variables
+			export CCV0="yes"
+			#export SKOPEO=${SKOPEO:-}
+			export UMOCI=yes
+			export SECCOMP=yes
+			;;
+	esac
 	;;
 "CRI_CONTAINERD_K8S_DEVMAPPER")
 	init_ci_flags

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -123,6 +123,17 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export USE_DEVMAPPER="true"
 	;;
+"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
+	# This job only tests containerd + k8s
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	# Export any CC specific environment variables
+	export CCV0="yes"
+	export UMOCI=yes
+	export SECCOMP=yes
+	;;
 "CRIO_K8S")
 	init_ci_flags
 	export CRI_RUNTIME="crio"

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -112,7 +112,6 @@ case "${CI_JOB}" in
 		"CC_CRI_CONTAINERD")
 			# Export any CC specific environment variables
 			export KATA_BUILD_CC="yes"
-			export SECCOMP=yes
 			;;
 	esac
 	;;
@@ -132,7 +131,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	# Export any CC specific environment variables
 	export KATA_BUILD_CC="yes"
-	export SECCOMP=yes
 	;;
 "CRIO_K8S")
 	init_ci_flags

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -112,8 +112,6 @@ case "${CI_JOB}" in
 		"CC_CRI_CONTAINERD")
 			# Export any CC specific environment variables
 			export KATA_BUILD_CC="yes"
-			#export SKOPEO=${SKOPEO:-}
-			export UMOCI=yes
 			export SECCOMP=yes
 			;;
 	esac
@@ -134,7 +132,6 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	# Export any CC specific environment variables
 	export KATA_BUILD_CC="yes"
-	export UMOCI=yes
 	export SECCOMP=yes
 	;;
 "CRIO_K8S")

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -34,6 +34,9 @@ init_ci_flags() {
 	# Ask runtime to only use cgroup at pod level
 	# Useful for pod overhead
 	export DEFSANDBOXCGROUPONLY="false"
+	# Build Kata for Confidential Containers
+	# Values: "yes|no"
+	export KATA_BUILD_CC="no"
 	# Hypervisor to use
 	export KATA_HYPERVISOR=""
 	# Install k8s
@@ -108,7 +111,7 @@ case "${CI_JOB}" in
 			;;
 		"CC_CRI_CONTAINERD")
 			# Export any CC specific environment variables
-			export CCV0="yes"
+			export KATA_BUILD_CC="yes"
 			#export SKOPEO=${SKOPEO:-}
 			export UMOCI=yes
 			export SECCOMP=yes
@@ -130,7 +133,7 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	# Export any CC specific environment variables
-	export CCV0="yes"
+	export KATA_BUILD_CC="yes"
 	export UMOCI=yes
 	export SECCOMP=yes
 	;;

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -61,6 +61,10 @@ case "${CI_JOB}" in
 		echo "INFO: Running tracing test"
 		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
+	"CC_CRI_CONTAINERD")
+		echo "INFO: Running Confidential Container tests"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
+		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -61,7 +61,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running tracing test"
 		sudo -E PATH="$PATH" bash -c "make tracing"
 		;;
-	"CC_CRI_CONTAINERD")
+	"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
 		echo "INFO: Running Confidential Container tests"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
 		;;

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -37,14 +37,14 @@ case "${CI_JOB}" in
 		echo "INFO: Running QAT integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
-	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER")
+	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER"|"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
 		echo "INFO: Running nydus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
-		[ "${CI_JOB}" != "CRI_CONTAINERD" ] && \
+		[[ "${CI_JOB}" =~ K8S ]] && \
 			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make kubernetes"
 		echo "INFO: Running vcpus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vcpus"
@@ -60,10 +60,10 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
 		echo "INFO: Running tracing test"
 		sudo -E PATH="$PATH" bash -c "make tracing"
-		;;
-	"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
-		echo "INFO: Running Confidential Container tests"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
+		if [[ "${CI_JOB}" =~ CC_CRI_CONTAINERD ]]; then
+			echo "INFO: Running Confidential Container tests"
+			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"
+		fi
 		;;
 	"CRIO_K8S")
 		echo "INFO: Running kubernetes tests"

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ shimv2:
 cri-containerd:
 	bash integration/containerd/cri/integration-tests.sh
 
+# Run the Confidential Containers tests for containerd.
+cc-containerd:
+	bash integration/containerd/confidential/run_tests.sh
+
 log-parser:
 	make -C cmd/log-parser
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,11 @@ cri-containerd:
 
 # Run the Confidential Containers tests for containerd.
 cc-containerd:
-	bash integration/containerd/confidential/run_tests.sh
+# TODO: The Confidential Containers test aren't merged into main yet, so
+# disable their execution. They should be enabled again at the point when
+# https://github.com/kata-containers/tests/issues/4628 is ready to be merged.
+	@echo "No Confidential Containers tests to run yet. Do nothing."
+#	bash integration/containerd/confidential/run_tests.sh
 
 log-parser:
 	make -C cmd/log-parser


### PR DESCRIPTION
In order to merge the Confidential Containers (CC) CCv0 branch into main (https://github.com/kata-containers/tests/issues/4441), there will be needed to differentiate the "vanilla" and "CC" builds of Kata Containers because the later depends on a [fork of containerd](https://github.com/confidential-containers/containerd). In other words, in some situations the scripts will need to tweak the code for CC. Thus, this pull requests introduces the `KATA_BUILD_CC` variable, which should be use exported in the environment (`export KATA_BUILD_CC=yes`) to indicate the build target is for CC.

Apart from this new variable, there are created:

1. the `CC_CRI_CONTAINERD` and `CC_CRI_CONTAINERD_CLOUD_HYPERVISOR`  CI job configurations. They will be used on near future to test more merges, being #4627 likely the first. Those jobs are configured to run the current containerd tests (i.e. run the same tests as the `CRI_CONTAINERD` configuration) plus CC specific tests (at this point no specific tests are merged on main, so it will do nothing).
2. the `cc-containerd` makefile target meant to run CC specific tests with CRI+Containerd. As mentioned above, there aren't specific tests into the main branch yet, so this make target is just a placeholder for now.

Cc @kata-containers/architecture-committee @stevenhorsman @fidencio @jodh-intel 

Fixes #4626