### PR TITLE
tests: add test case for kata agent API configuration

### DIFF
--- a/integration/containerd/confidential/agent_api.bats
+++ b/integration/containerd/confidential/agent_api.bats
@@ -5,19 +5,8 @@
 #
 
 load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/asserts.sh"
 load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
-
-# Check the containerd logged messages on host have a given message.
-#
-# Parameters:
-#      $1 - the message
-#
-# Note: get the logs since the global $start_date.
-#
-assert_containerd_logs_contain() {
-	local message="$1"
-	journalctl -x -t containerd --since "$start_date" | grep "$message"
-}
 
 setup() {
 	start_date=$(date +"%Y-%m-%d %H:%M:%S")
@@ -78,7 +67,7 @@ setup() {
 	# operation should fail.
 	! crictl exec "$container_id" cat /proc/cmdline
 
-	assert_containerd_logs_contain "ExecProcessRequest is blocked"
+	assert_logs_contain "ExecProcessRequest is blocked"
 }
 
 teardown() {

--- a/integration/containerd/confidential/agent_api.bats
+++ b/integration/containerd/confidential/agent_api.bats
@@ -39,13 +39,9 @@ setup() {
 
 	# Check that the agent allow ExecProcessRequest requests by default.
 	#
+	echo "Check can create a container and exec a command"
 	crictl_create_cc_pod "$pod_config"
-	crictl_create_cc_container "$sandbox_name" "$pod_config" \
-		"$container_config"
-
-	pod_id=$(crictl pods --name "$sandbox_name" -q)
-	container_id=$(crictl ps --pod ${pod_id} -q)
-	crictl exec "$container_id" cat /proc/cmdline
+	assert_container "$container_config"
 
 	# Check that the agent endpoints can be restricted. In this case it will
 	# have ExecProcessRequest blocked.
@@ -61,12 +57,11 @@ setup() {
 	crictl_create_cc_container "$sandbox_name" "$pod_config" \
 		"$container_config"
 
-	pod_id=$(crictl pods --name "$sandbox_name" -q)
-	container_id=$(crictl ps --pod ${pod_id} -q)
-	# The endpoint ExecProcessRequest is not allowed so this exec
+	# The endpoint ExecProcessRequest is not allowed so any exec
 	# operation should fail.
-	! crictl exec "$container_id" cat /proc/cmdline
-
+	echo "Check cannot exec on container"
+	! assert_can_exec_on_container
+	echo "Check failed to exec because the endpoint is blocked"
 	assert_logs_contain "ExecProcessRequest is blocked"
 }
 

--- a/integration/containerd/confidential/agent_api.bats
+++ b/integration/containerd/confidential/agent_api.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# Copyright (c) 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
+
+# Check the containerd logged messages on host have a given message.
+#
+# Parameters:
+#      $1 - the message
+#
+# Note: get the logs since the global $start_date.
+#
+assert_containerd_logs_contain() {
+	local message="$1"
+	journalctl -x -t containerd --since "$start_date" | grep "$message"
+}
+
+setup() {
+	start_date=$(date +"%Y-%m-%d %H:%M:%S")
+	sandbox_name="kata-cc-busybox-sandbox"
+	pod_config="${FIXTURES_DIR}/pod-config.yaml"
+	pod_id=""
+
+	echo "Delete any existing ${sandbox_name} pod"
+	crictl_delete_cc_pod_if_exists "$sandbox_name"
+
+	echo "Prepare containerd for Confidential Container"
+	SAVED_CONTAINERD_CONF_FILE="/etc/containerd/config.toml.$$"
+	configure_cc_containerd "$SAVED_CONTAINERD_CONF_FILE"
+
+	echo "Reconfigure Kata Containers"
+	clear_kernel_params
+	switch_image_service_offload on
+	enable_full_debug
+
+	# Test will change the guest image so let's save it to restore
+	# on teardown.
+	saved_img="$(save_guest_img)"
+}
+
+@test "[cc][agent][cri][containerd] Test agent API endpoint can be restricted" {
+	local agent_config_filename="agent-configuration-no-exec.toml"
+	local container_config="${FIXTURES_DIR}/container-config.yaml"
+	local pod_id=""
+	local container_id=""
+
+	# Check that the agent allow ExecProcessRequest requests by default.
+	#
+	crictl_create_cc_pod "$pod_config"
+	crictl_create_cc_container "$sandbox_name" "$pod_config" \
+		"$container_config"
+
+	pod_id=$(crictl pods --name "$sandbox_name" -q)
+	container_id=$(crictl ps --pod ${pod_id} -q)
+	crictl exec "$container_id" cat /proc/cmdline
+
+	# Check that the agent endpoints can be restricted. In this case it will
+	# have ExecProcessRequest blocked.
+	#
+	crictl_delete_cc_pod_if_exists "$sandbox_name"
+	# Copy an configuration file to the guest image and pass to the agent.
+	cp_to_guest_img "/tests/fixtures" \
+		"${FIXTURES_DIR}/${agent_config_filename}"
+	add_kernel_params \
+		"agent.config_file=/tests/fixtures/${agent_config_filename}"
+
+	crictl_create_cc_pod "$pod_config"
+	crictl_create_cc_container "$sandbox_name" "$pod_config" \
+		"$container_config"
+
+	pod_id=$(crictl pods --name "$sandbox_name" -q)
+	container_id=$(crictl ps --pod ${pod_id} -q)
+	# The endpoint ExecProcessRequest is not allowed so this exec
+	# operation should fail.
+	! crictl exec "$container_id" cat /proc/cmdline
+
+	assert_containerd_logs_contain "ExecProcessRequest is blocked"
+}
+
+teardown() {
+	# Restore containerd to pre-test state.
+	if [ -f "$SAVED_CONTAINERD_CONF_FILE" ]; then
+		systemctl stop containerd || true
+		sleep 5
+		mv -f "$SAVED_CONTAINERD_CONF_FILE" "/etc/containerd/config.toml"
+		systemctl start containerd || true
+	fi
+
+	# Restore the original guest image file.
+	new_guest_img "$saved_img" || true
+	rm -f "$saved_img"
+
+	switch_image_service_offload off
+	disable_full_debug
+}

--- a/integration/containerd/confidential/agent_image.bats
+++ b/integration/containerd/confidential/agent_image.bats
@@ -5,6 +5,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/asserts.sh"
 
 # Currently the agent can only check images signature if using skopeo.
 # There isn't a way to probe the agent to determine if skopeo is present
@@ -42,41 +43,6 @@ create_test_pod() {
 	crictl_create_cc_pod "$pod_config"
 }
 
-# Create container and check it is operational.
-#
-# Parameters:
-#	$1 - the container configuration file.
-#
-# Note: the global $sandbox_name should be set already.
-#
-assert_container() {
-	local container_config="$1"
-
-	echo "Create the cc container"
-	crictl_create_cc_container "$sandbox_name" "$pod_config" \
-		"$container_config"
-
-	echo "Check the container is operational"
-	local pod_id=$(crictl pods --name "$sandbox_name" -q)
-	local container_id=$(crictl ps --pod ${pod_id} -q)
-	crictl exec "$container_id" cat /proc/cmdline
-}
-
-# Try to create a container when it is expected to fail.
-#
-# Parameters:
-# 	$1 - the container configuration file.
-#
-# Note: the global $sandbox_name and $pod_config should be set already.
-#
-assert_container_fail() {
-	local container_config="$1"
-
-	echo "Attempt to create the container but it should fail"
-	! crictl_create_cc_container "$sandbox_name" "$pod_config" \
-		"$container_config" || /bin/false
-}
-
 setup() {
 	start_date=$(date +"%Y-%m-%d %H:%M:%S")
 
@@ -94,17 +60,6 @@ setup() {
 	echo "Reconfigure Kata Containers"
 	switch_image_service_offload on
 	clear_kernel_params
-}
-
-# Check the logged messages on host have a given message.
-# Parameters:
-#      $1 - the message
-#
-# Note: get the logs since the global $start_date.
-#
-assert_logs_contain() {
-	local message="$1"
-    journalctl -x -t kata --since "$start_date" | grep "$message"
 }
 
 @test "[cc][agent][cri][containerd] Test can pull an unencrypted image inside the guest" {

--- a/integration/containerd/confidential/asserts.sh
+++ b/integration/containerd/confidential/asserts.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2021, 2022 IBM Corporation
+# Copyright (c) 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This provides generic assert functions to use in the tests.
+#
+
+# Create container and check it is operational.
+#
+# Parameters:
+#	$1 - the container configuration file.
+#
+# Note: the global $sandbox_name should be set already.
+#
+assert_container() {
+	local container_config="$1"
+
+	echo "Create the cc container"
+	crictl_create_cc_container "$sandbox_name" "$pod_config" \
+		"$container_config"
+
+	echo "Check the container is operational"
+	local pod_id=$(crictl pods --name "$sandbox_name" -q)
+	local container_id=$(crictl ps --pod ${pod_id} -q)
+	crictl exec "$container_id" cat /proc/cmdline
+}
+
+# Try to create a container when it is expected to fail.
+#
+# Parameters:
+#	$1 - the container configuration file.
+#
+# Note: the global $sandbox_name and $pod_config should be set already.
+#
+assert_container_fail() {
+	local container_config="$1"
+
+	echo "Attempt to create the container but it should fail"
+	! crictl_create_cc_container "$sandbox_name" "$pod_config" \
+		"$container_config" || /bin/false
+}
+
+# Check the logged messages on host have a given message.
+#
+# Parameters:
+#	$1 - the message
+#
+# Note: get the logs since the global $start_date.
+#
+assert_logs_contain() {
+	local message="$1"
+	journalctl -x -t kata --since "$start_date" | grep "$message"
+}
+

--- a/integration/containerd/confidential/asserts.sh
+++ b/integration/containerd/confidential/asserts.sh
@@ -51,6 +51,10 @@ assert_container_fail() {
 #
 assert_logs_contain() {
 	local message="$1"
-	journalctl -x -t kata --since "$start_date" | grep "$message"
+	local cmd="journalctl -x"
+	for syslog_id in kata containerd crio;do
+		cmd+=" -t \"$syslog_id\""
+	done
+	cmd+=" --since \"$start_date\""
+	eval $cmd | grep "$message"
 }
-

--- a/integration/containerd/confidential/asserts.sh
+++ b/integration/containerd/confidential/asserts.sh
@@ -22,6 +22,14 @@ assert_container() {
 		"$container_config"
 
 	echo "Check the container is operational"
+	assert_can_exec_on_container
+}
+
+# Check the container is operational by running a simple command.
+#
+# Note: the global $sandbox_name should be set already.
+#
+assert_can_exec_on_container() {
 	local pod_id=$(crictl pods --name "$sandbox_name" -q)
 	local container_id=$(crictl ps --pod ${pod_id} -q)
 	crictl exec "$container_id" cat /proc/cmdline

--- a/integration/containerd/confidential/fixtures/agent-configuration-no-exec.toml
+++ b/integration/containerd/confidential/fixtures/agent-configuration-no-exec.toml
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# Copyright (c) 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This is an agent configuration file used to test the API endpoints can be
+# blocked. The list of allowed endpoints below excludes 'ExecProcessRequest',
+# as a result it is expected the agent won't allow the container tool to exec
+# a process on a running container.
+
+[endpoints]
+# All endpoints except "ExecProcessRequest" are allowed.
+allowed = [
+        "AddARPNeighborsRequest",
+        "AddSwapRequest",
+        "CloseStdinRequest",
+        "CopyFileRequest",
+        "CreateContainerRequest",
+        "CreateSandboxRequest",
+        "DestroySandboxRequest",
+        "GetMetricsRequest",
+        "GetOOMEventRequest",
+        "GuestDetailsRequest",
+        "ListInterfacesRequest",
+        "ListRoutesRequest",
+        "MemHotplugByProbeRequest",
+        "OnlineCPUMemRequest",
+        "PauseContainerRequest",
+        "PullImageRequest",
+        "ReadStreamRequest",
+        "RemoveContainerRequest",
+        "ReseedRandomDevRequest",
+        "ResizeVolumeRequest",
+        "ResumeContainerRequest",
+        "SetGuestDateTimeRequest",
+        "SignalProcessRequest",
+        "StartContainerRequest",
+        "StatsContainerRequest",
+        "TtyWinResizeRequest",
+        "UpdateContainerRequest",
+        "UpdateInterfaceRequest",
+        "UpdateRoutesRequest",
+        "VolumeStatsRequest",
+        "WaitProcessRequest",
+        "WriteStreamRequest"
+]

--- a/integration/containerd/confidential/run_tests.sh
+++ b/integration/containerd/confidential/run_tests.sh
@@ -14,7 +14,8 @@ source "${cidir}/lib.sh"
 main() {
 	# Ensure bats is installed.
 	${cidir}/install_bats.sh >/dev/null
-	bats ${script_dir}/agent_image.bats
+	bats ${script_dir}/agent_image.bats \
+		${script_dir}/agent_api.bats
 }
 
 main $@

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -218,43 +218,66 @@ cp_to_guest_img() {
 	local dest_dir="$1"
 	shift # remaining arguments are the list of files.
 	local src_files=($@)
+	local rootfs_dir=""
 
 	if [ "${#src_files[@]}" -eq 0 ]; then
 		echo "Expected a list of files"
 		return 1
 	fi
 
+	rootfs_dir="$(mktemp -d)"
+
 	# Open the original initrd/image, inject the agent file
 	local image_path="$(kata-runtime kata-env --json | jq -r .Image.Path)"
 	if [ -f "$image_path" ]; then
-		local tmp_mnt="$(mktemp -d)"
 		if ! sudo mount -o loop,offset=$((512*6144)) "$image_path" \
-			"$tmp_mnt"; then
+			"$rootfs_dir"; then
 			echo "Failed to mount the image file: $image_path"
-			rm -rf "$tmp_mnt"
+			rm -rf "$rootfs_dir"
 			return 1
 		fi
-
-		mkdir -p "${tmp_mnt}/${dest_dir}"
-		for file in ${src_files[@]}; do
-			if [ ! -f "$file" ]; then
-				echo "File not found, not copying: $file"
-				continue
-			fi
-			sudo cp -f "${file}" "${tmp_mnt}/${dest_dir}"
-		done
-
-		sudo umount "$tmp_mnt"
-		rm -rf ${tmp_mnt}
 	else
 		local initrd_path="$(kata-runtime kata-env --json | \
 			jq -r .Initrd.Path)"
 		if [ ! -f "$initrd_path" ]; then
 			echo "Guest initrd and image not found"
+			rm -rf "$rootfs_dir"
 			return 1
 		fi
-		# TODO: implement me.
+
+                if ! cat "${initrd_path}" | cpio --extract --preserve-modification-time \
+                        --make-directories --directory="${rootfs_dir}"; then
+                        echo "Failed to uncompress the image file: $initrd_path"
+                        rm -rf "$rootfs_dir"
+                        return 1
+                fi
 	fi
+
+	mkdir -p "${rootfs_dir}/${dest_dir}"
+	for file in ${src_files[@]}; do
+		if [ ! -f "$file" ]; then
+			echo "File not found, not copying: $file"
+			continue
+		fi
+		cp -af "${file}" "${rootfs_dir}/${dest_dir}"
+	done
+
+	if [ -f "$image_path" ]; then
+		if ! sudo umount "$rootfs_dir"; then
+			echo "Failed to umount the directory: $rootfs_dir"
+			rm -rf "$rootfs_dir"
+			return 1
+		fi
+	else
+		if ! sudo bash -c "cd "${rootfs_dir}" && find . | \
+			cpio -H newc -o | gzip -9 > ${initrd_path}"; then
+			echo "Failed to compress the image file"
+			rm -rf "$rootfs_dir"
+			return 1
+		fi
+	fi
+
+	rm -rf "$rootfs_dir"
 }
 
 # Find the path to the current guest image file.

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -208,6 +208,105 @@ clean_env_ctr()
 	sudo ctr containers delete ${containers[@]}
 }
 
+# Copy local files to the guest image.
+#
+# Parameters:
+#	$1      - destination directory in the image. It is created if not exist.
+#	$2..*   - list of local files.
+#
+cp_to_guest_img() {
+	local dest_dir="$1"
+	shift # remaining arguments are the list of files.
+	local src_files=($@)
+
+	if [ "${#src_files[@]}" -eq 0 ]; then
+		echo "Expected a list of files"
+		return 1
+	fi
+
+	# Open the original initrd/image, inject the agent file
+	local image_path="$(kata-runtime kata-env --json | jq -r .Image.Path)"
+	if [ -f "$image_path" ]; then
+		local tmp_mnt="$(mktemp -d)"
+		if ! sudo mount -o loop,offset=$((512*6144)) "$image_path" \
+			"$tmp_mnt"; then
+			echo "Failed to mount the image file: $image_path"
+			rm -rf "$tmp_mnt"
+			return 1
+		fi
+
+		mkdir -p "${tmp_mnt}/${dest_dir}"
+		for file in ${src_files[@]}; do
+			if [ ! -f "$file" ]; then
+				echo "File not found, not copying: $file"
+				continue
+			fi
+			sudo cp -f "${file}" "${tmp_mnt}/${dest_dir}"
+		done
+
+		sudo umount "$tmp_mnt"
+		rm -rf ${tmp_mnt}
+	else
+		local initrd_path="$(kata-runtime kata-env --json | \
+			jq -r .Initrd.Path)"
+		if [ ! -f "$initrd_path" ]; then
+			echo "Guest initrd and image not found"
+			return 1
+		fi
+		# TODO: implement me.
+	fi
+}
+
+# Find the path to the current guest image file.
+#
+# Return the guest image file.
+#
+find_guest_img() {
+	local file=""
+
+	for img_type in Image Initrd; do
+		file="$(kata-runtime kata-env --json | \
+			jq -r .${img_type}.Path)"
+		[ -f "$file" ] && break
+	done
+
+	echo "$file"
+}
+
+# Copy the current guest image file to a temporary file, unless a destination
+# file path is given.
+#
+# Parameters:
+# 	$1      - copy to file.
+#
+# Return the destination file path.
+#
+save_guest_img() {
+	local dest_file="${1:-}"
+	local file="$(find_guest_img)"
+
+	[ -n "$dest_file" ] || dest_file="$(mktemp -t "$(basename $file).XXXXXXXXXX")"
+
+	cp -f "$file" "$dest_file"
+	echo "$dest_file"
+}
+
+# Overwrite the current guest image file with the one given.
+#
+# Parameters:
+# 	$1      - the new image file.
+#
+new_guest_img() {
+	local new_file="${1:-}"
+	local file="$(find_guest_img)"
+
+	if [ ! -f "$new_file" ]; then
+		echo "Cannot set guest image as the file does not exit: $new_file"
+		return 1
+	fi
+
+	sudo cp -f "$new_file" "$file"
+}
 
 # Restarts a systemd service while ensuring the start-limit-burst is set to 0.
 # Outputs warnings to stdio if something has gone wrong.


### PR DESCRIPTION
Added a e2e test to check that when a pod is created with an agent API
config that blocked certain endpoints that requests to these are rejected.

Fixes #4676
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>