### PR TITLE
ci: Add Cloud Hypervisor / QEMU jobs to test with the "devmapper" snapshotter

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -104,6 +104,14 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="qemu"
 	[ "${CI_JOB}" == "CRI_CONTAINERD_K8S" ] && export KUBERNETES="yes"
 	;;
+"CRI_CONTAINERD_K8S_DEVMAPPER")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="qemu"
+	export KUBERNETES="yes"
+	export USE_DEVMAPPER="true"
+	;;
 "CRIO_K8S")
 	init_ci_flags
 	export CRI_RUNTIME="crio"

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -52,6 +52,9 @@ init_ci_flags() {
 	export experimental_qemu="false"
 	# Run the kata-check checks
 	export RUN_KATA_CHECK="true"
+	# Use devmapper snapshotter
+	# Only works with containerd
+	export USE_DEVMAPPER="false"
 
 	# METRICS_CI flags
 	# Request to run METRICS_CI
@@ -162,6 +165,7 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="firecracker"
 	export KUBERNETES="yes"
+	export USE_DEVMAPPER="true"
 	;;
 "VFIO")
 	init_ci_flags

--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -142,6 +142,14 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	;;
+"CLOUD-HYPERVISOR-K8S-CONTAINERD-DEVMAPPER")
+	init_ci_flags
+	export CRI_CONTAINERD="yes"
+	export CRI_RUNTIME="containerd"
+	export KATA_HYPERVISOR="cloud-hypervisor"
+	export KUBERNETES="yes"
+	export USE_DEVMAPPER="true"
+	;;
 "EXTERNAL_CLOUD_HYPERVISOR")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"

--- a/.ci/containerd_devmapper_setup.sh
+++ b/.ci/containerd_devmapper_setup.sh
@@ -12,13 +12,13 @@ set -o pipefail
 cidir=$(dirname "$0")
 source "${cidir}/../lib/common.bash"
 
-KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+USE_DEVMAPPER="${USE_DEVMAPPER:-false}"
 
 containerd_config_dir="/etc/containerd"
 containerd_config_file="${containerd_config_dir}/config.toml"
 
-if [ "$KATA_HYPERVISOR" != "firecracker" ]; then
-	echo "WARNING: Devicemapper configuration is only for Firecracker. Exiting"
+if [ "$USE_DEVMAPPER" != "true" ]; then
+	echo "WARNING: Devicemapper configuration was not explicitly required. Exiting"
 	exit 0
 fi
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -81,7 +81,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running kubernetes tests"
 		sudo -E PATH="$PATH" bash -c "make kubernetes"
 		;;
-	"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+	"CLOUD-HYPERVISOR-K8S-CONTAINERD"|"CLOUD-HYPERVISOR-K8S-CONTAINERD-DEVMAPPER")
 		echo "INFO: Containerd checks"
 		sudo -E PATH="$PATH" bash -c "make cri-containerd"
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -37,7 +37,7 @@ case "${CI_JOB}" in
 		echo "INFO: Running QAT integration test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
-	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S")
+	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER")
 		echo "INFO: Running nydus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
 		echo "INFO: Running stability test"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -23,6 +23,7 @@ CRI_CONTAINERD="${CRI_CONTAINERD:-no}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KUBERNETES="${KUBERNETES:-yes}"
 TEST_CGROUPSV2="${TEST_CGROUPSV2:-false}"
+USE_DEVMAPPER="${USE_DEVMAPPER:-false}"
 
 setup_distro_env() {
 	local setup_type="$1"
@@ -123,8 +124,8 @@ install_extra_tools() {
 		bash -f "${cidir}/configure_containerd_for_kata.sh"
 	fi
 
-	if [ "${KATA_HYPERVISOR}" == "firecracker" ]; then
-		info "Configure devicemapper for firecracker"
+	if [ "${USE_DEVMAPPER}" == "true" ]; then
+		info "Configure devicemapper"
 		bash -f "${cidir}/containerd_devmapper_setup.sh"
 	fi
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -26,6 +26,7 @@ SHIMV2_TEST=${SHIMV2_TEST:-""}
 FACTORY_TEST=${FACTORY_TEST:-""}
 KILL_VMM_TEST=${KILL_VMM_TEST:-""}
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+USE_DEVMAPPER="${USE_DEVMAPPER:-false}"
 ARCH=$(uname -m)
 
 default_runtime_type="io.containerd.runc.v2"
@@ -141,7 +142,7 @@ cat << EOF | sudo tee "${CONTAINERD_CONFIG_FILE}"
        shim = "${containerd_shim_path}"
 EOF
 
-if [ "$KATA_HYPERVISOR" == "firecracker" ]; then
+if [ "$USE_DEVMAPPER" == "true" ]; then
 	sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"4096MB\"|' ${CONTAINERD_CONFIG_FILE}
 	echo "Devicemapper configured"
 	cat "${CONTAINERD_CONFIG_FILE}"


### PR DESCRIPTION

ci: Add USE_DEVMAPPER flag

Currently selecting whether devmapper should (or should not) be used as
the containerd snapshotter is done based on the HYPERVISOR used with
Kata Containers, leading the only testing it when using Firecracker.

In order to prepare the ground for adding new jobs, let's ensure we
un-tie its configuration from the hypervisor being used.

---

ci: Add cloud-hypervisor + devmapper CI

In order to ensure situations like the ones reported on the following
issues* won't happen again, let's add a new CI job covering Cloud
Hypervisor, running with containerd as the CRI Engine, having devmapper
as its snapshotter.

---

ci: Add QEMU + devmapper CI

In order to ensure situations like the ones reported on the following
issues* won't happen again, let's add a new CI job covering QEMU,
running with containerd as the CRI Engine, having devmapper as its
snapshotter.

---

*:
https://github.com/kata-containers/kata-containers/issues/4005
https://github.com/kata-containers/kata-containers/issues/4043

Fixes: #4688
