### PR TITLE
metrics: Increase midval of memory-footprint and memory-footprint-ksm

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -29,7 +29,7 @@ description = "measure container average footprint"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 118601.0
+midval = 120053.0
 minpercent = 5.0
 maxpercent = 5.0
 
@@ -42,7 +42,7 @@ description = "measure container average footprint with KSM"
 # within (inclusive)
 checkvar = ".\"memory-footprint-ksm\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 54538.11
+midval = 55538.11
 minpercent = 15.0
 maxpercent = 15.0
 


### PR DESCRIPTION
metrics: Increase midval of memory-footprint and memory-footprint-ksm

Increase midval of memory-footprint and memory-footprint-ksm to handle the memory-footprint issue when add wasm function to kata-agent.

Depends-on: github.com/https://github.com/kata-containers/kata-containers/pull/4032

Fixes: #4696

Signed-off-by: Hui Zhu <teawater@antgroup.com>