### PR TITLE
log-parser: match agent log levels

### DIFF
--- a/cmd/log-parser/agent.go
+++ b/cmd/log-parser/agent.go
@@ -122,7 +122,24 @@ func unpackAgentLogEntry_v2(le LogEntry) (agent LogEntry, err error) {
 		case "container-id", "cid": // better to ensure consistency in the agent
 			agent.Container = v
 		case "level":
-			agent.Level = strings.ToLower(v)
+			switch v {
+			// match agent's slog short version log leveling to the common log levels
+			case "CRIT":
+				agent.Level = "critical"
+			case "DEBG":
+				agent.Level = "debug"
+			case "ERRO":
+				agent.Level = "error"
+			case "INFO":
+				agent.Level = "info"
+			case "TRCE":
+				agent.Level = "trace"
+			case "WARN":
+				agent.Level = "warning"
+			default:
+				agent.Level = v
+			}
+			agent.Data[k] = v // in any case let's leave original level under Data
 		case "msg":
 			agent.Msg = v
 		case "name":


### PR DESCRIPTION
The agent logging carte "slog" is using short naming for its log leveling,
this is causing the parser to log redundant/duplicated log levels such as
"erro"/"error", "warn"/"warning"... this patch groups the common log levels

See: https://docs.rs/slog/2.0.6/slog/static.LOG_LEVEL_SHORT_NAMES.html

Fixes: #4700
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>