### PR TITLE
scripts: Remove duplicated die/info/warn functions

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -8,6 +8,9 @@ set -e
 
 source /etc/os-release || source /usr/lib/os-release
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/../../lib/common.bash"
+
 EDK2_REPO="https://github.com/tianocore/edk2.git"
 EDK2_PLAT_REPO="https://github.com/tianocore/edk2-platforms.git"
 ACPICA="https://github.com/acpica/acpica.git"
@@ -112,8 +115,7 @@ install_uefi_flash()
 clean_up_and_die()
 {
 	clean_up
-	echo "ERROR: $*" >&2
-	exit 1
+	die "$*"
 }
 
 clean_up()

--- a/.ci/install_go.sh
+++ b/.ci/install_go.sh
@@ -24,15 +24,6 @@ finish() {
 	rm -rf "$tmp_dir"
 }
 
-die() {
-	echo >&2 "ERROR: $*"
-	exit 1
-}
-
-info() {
-	echo "INFO: $*"
-}
-
 usage(){
 	exit_code="$1"
 	cat <<EOF

--- a/.ci/kata-simplify-log.sh
+++ b/.ci/kata-simplify-log.sh
@@ -10,12 +10,8 @@ set -o pipefail
 
 readonly script_name=${0##*/}
 
-die()
-{
-    local -r msg="$*"
-    echo >&2 "ERROR: $msg"
-    exit 1
-}
+cidir="$(dirname $(readlink -f "$0"))"
+source "${cidir}/lib.sh"
 
 usage()
 {

--- a/.ci/vagrant-cleaner.sh
+++ b/.ci/vagrant-cleaner.sh
@@ -6,11 +6,9 @@
 #
 cidir="$(dirname $(readlink -f "$0"))"
 
-# Print message to stderr (add the 'ERROR:' prefix) and exit 1.
-die() {
-	echo -e "ERROR: $*" >&2
-	exit 1
-}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/lib.sh"
 
 usage() {
 	cat <<-EOF

--- a/cmd/check-spelling/kata-spell-check.sh
+++ b/cmd/check-spelling/kata-spell-check.sh
@@ -28,6 +28,8 @@ fi
 self_dir=$(dirname "$(readlink -f "$0")")
 cidir="${self_dir}/../../.ci"
 
+source "${cidir}/lib.sh"
+
 # Directory containing word lists.
 #
 # Each file in this directory must:
@@ -77,25 +79,6 @@ kata_dict_ref="${KATA_DICT_DIR}/${KATA_DICT_NAME}"
 # "directory and name prefix" and which must also be the first specified
 # dictionary.
 dict_languages="${kata_dict_ref},en_US,en_GB"
-
-die()
-{
-	local msg="$*"
-	echo >&2 "ERROR: $msg"
-	exit 1
-}
-
-info()
-{
-	local msg="$*"
-	echo "INFO: $msg"
-}
-
-warn()
-{
-	local msg="$*"
-	echo >&2 "WARNING: $msg"
-}
 
 make_dictionary()
 {

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -75,9 +75,9 @@ install_docker(){
 	# Get system architecture
 	arch=$(go env GOARCH)
 	# Check if docker is present in the system
-	if [ "$(info_docker)" ] && [ ${force} == false ]; then
+	if info_docker && [ ${force} == false ]; then
 		die "Docker is already installed. Please use -f flag to force new installation"
-	elif [ "$(info_docker)" ] && [ ${force} == true ]; then
+	elif info_docker && [ ${force} == true ]; then
 		remove_docker
 	fi
 
@@ -234,7 +234,7 @@ configure_docker(){
 	# Default storage driver is overlay2
 	[ -z "$storage_driver" ] && storage_driver="overlay2"
 
-	if [ ! "$(info_docker)" ]; then
+	if ! info_docker; then
 		die "Docker is not installed. Please install it before configuring the runtime"
 	fi
 

--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -37,20 +37,9 @@ Example:
 EOF
 }
 
-die(){
-	msg="$*"
-	echo "$SCRIPT_NAME - ERROR: $msg" >&2
-	exit 1
-}
-
-warning(){
-	msg="$*"
-	echo "$SCRIPT_NAME - WARNING: $msg" >&2
-}
-
 message(){
 	msg="$*"
-	echo "$SCRIPT_NAME - INFO: $msg" >&2
+	info "$SCRIPT_NAME: $msg"
 }
 
 log_message(){
@@ -204,7 +193,7 @@ info_docker(){
 		message "docker_info: default runtime: $(get_docker_default_runtime)"
 		message "docker_info: package name: $(get_docker_package_name)"
 	else
-		warning "docker is not installed on this system"
+		warn "docker is not installed on this system"
 		return 1
 	fi
 }
@@ -310,7 +299,7 @@ main(){
 			parse_subcommand_options "$@"
 			;;
 		*)
-			warning "container manager \"$ctr_manager\" is not supported."
+			warn "container manager \"$ctr_manager\" is not supported."
 			usage
 			exit 1
 	esac

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -9,18 +9,8 @@ FS=""
 MNT_DIR=""
 SIZE=""
 
-die() {
-	echo "ERROR: $*" >&2
-	exit 1
-}
-
-warn() {
-	echo -e "WARNING: $*" >&2
-}
-
-info() {
-	echo -e "INFO: $*"
-}
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/../../lib/common.bash"
 
 help() {
 cat << EOF

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -37,22 +37,6 @@ public.ecr.aws/lts
 mirror.gcr.io/library
 quay.io/libpod"
 
-# If we fail for any reason, exit through here and we should log that to the correct
-# place and return the correct code to halt the run
-die(){
-	msg="$*"
-	echo "ERROR: $msg" >&2
-	exit 1
-}
-
-# Sometimes we just want to warn about something - let's have a standard
-# method for that, so maybe we can make a standard form that can be searched
-# for in the logs/tooling
-warning(){
-	msg="$*"
-	echo "WARNING: $msg" >&2
-}
-
 # This function checks existence of commands.
 # They can be received standalone or as an array, e.g.
 #
@@ -232,7 +216,7 @@ common_init(){
 	else
 		# We know we have nothing to do for runc or shimv2
 		if [ "$CTR_RUNTIME" != "io.containerd.runc.v2" ] || [ "$RUNTIME" != "runc" ]; then
-			warning "Unrecognised runtime"
+			warn "Unrecognised runtime"
 		fi
 	fi
 }


### PR DESCRIPTION
Rework the scripts that used to define their own `die()`, `info()`
and/or `warn()` functions to use the standard versions defined in
`lib/common.bash`.

Fixes: #4702.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>