### PR TITLE
kubernetes: Fix syntaxis for qos tests

### DIFF
--- a/integration/kubernetes/k8s-qos-pods.bats
+++ b/integration/kubernetes/k8s-qos-pods.bats
@@ -37,7 +37,7 @@ setup() {
 	pod_name="burstable-test"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-burstable.yam"l
+	kubectl create -f "${pod_config_dir}/pod-burstable.yaml"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -51,7 +51,7 @@ setup() {
 	pod_name="besteffort-test"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-besteffort.yam"l
+	kubectl create -f "${pod_config_dir}/pod-besteffort.yaml"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"


### PR DESCRIPTION
This PR fix the syntaxis for qos tests by correcting the
position of the double quotation marks.

Fixes #4705

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>