### PR TITLE
ci/ci_job_flags.sh: Do not set SECCOMP=yes on CC jobs

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -107,7 +107,6 @@ case "${CI_JOB}" in
 			# Export any CC specific environment variables
 			export CCV0="yes"
 			export UMOCI=yes
-			export SECCOMP=yes
 			if [ "${CI_JOB}" == "CC_SKOPEO_CRI_CONTAINERD" ]; then
 				export SKOPEO=yes
 			fi
@@ -123,7 +122,6 @@ case "${CI_JOB}" in
 	# Export any CC specific environment variables
 	export CCV0="yes"
 	export UMOCI=yes
-	export SECCOMP=yes
 	if [ "${CI_JOB}" == "CC_SKOPEO_CRI_CONTAINERD_CLOUD_HYPERVISOR" ]; then
 		export SKOPEO=yes
 	fi


### PR DESCRIPTION
It is not needed to export SECCOMP=yes for the Confidential Containers
jobs because the osbuilder's rootfs.sh script sets that variable by
default.

Fixes #4626
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>