### PR TITLE
ci: update scripts to support OpenShift 4.11

### DIFF
--- a/.ci/openshift-ci/cluster/deployments/configmap_installer_qemu_4_10.yaml
+++ b/.ci/openshift-ci/cluster/deployments/configmap_installer_qemu_4_10.yaml
@@ -10,5 +10,5 @@ kind: ConfigMap
 metadata:
   name: ci.kata.installer.qemu
 data:
-  qemu_path: /usr/libexec/qemu-kvm
+  qemu_path: /usr/libexec/qemu-kiwi
   host_kernel: "yes"

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -35,6 +35,10 @@ export DAEMONSET_NAME="kata-deploy"
 #
 export DAEMONSET_LABEL="kata-deploy"
 
+# The OpenShift Server version.
+#
+ocp_version="$(oc version -o json | jq -r '.openshiftVersion')"
+
 # Wait all worker nodes reboot.
 #
 # Params:
@@ -152,7 +156,16 @@ if [ "${KATA_WITH_SYSTEM_QEMU}" == "yes" ]; then
 	enable_sandboxedcontainers_extension
 	# Export additional information for the installer to deal with
 	# the QEMU path, for example.
-	oc apply -f ${deployments_dir}/configmap_installer_qemu.yaml
+	case $ocp_version in
+		4.10*)
+			oc apply -f ${deployments_dir}/configmap_installer_qemu_4_10.yaml
+			;;
+		4.11*)
+			oc apply -f ${deployments_dir}/configmap_installer_qemu.yaml
+			;;
+		*)
+			die "Unsupported OpenShift version: $ocp_version"
+	esac
 fi
 
 if [ "${KATA_WITH_HOST_KERNEL}" == "yes" ]; then

--- a/.ci/openshift-ci/images/Dockerfile.installer
+++ b/.ci/openshift-ci/images/Dockerfile.installer
@@ -5,7 +5,7 @@
 # Build the image which wraps the kata-containers installation along with the
 # install script. It is used on a daemonset to deploy kata on OpenShift.
 #
-FROM registry.centos.org/centos:8
+FROM quay.io/centos/centos:stream8
 
 RUN yum install -y rsync dracut && \
   yum clean all

--- a/.ci/openshift-ci/images/entrypoint.sh
+++ b/.ci/openshift-ci/images/entrypoint.sh
@@ -130,7 +130,7 @@ rsync -O -a . "$HOST_MOUNT"
 # Ensure the binaries are searcheable via PATH. Notice it expects that
 # kata has been built with PREFIX=/opt/kata.
 #
-chroot "$HOST_MOUNT" sh -c 'for t in /opt/kata/bin/*; do ln -s "$t" /var/usrlocal/bin/; done'
+chroot "$HOST_MOUNT" sh -c 'for t in /opt/kata/bin/*; do ln --force -s "$t" /var/usrlocal/bin/; done'
 
 # Check the installation is good (or not).
 echo "INFO: run kata-check to check the installation is fine"


### PR DESCRIPTION
In order to update the job on OpenShift CI to test on 4.11 there is needed to adapt the installer script (among a few changes).

Fixes #4707