### PR TITLE
log-parser: update documentation with recent changes

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -37,6 +37,7 @@ Jaeger/B
 Jenkins/B
 Jupyter/B
 journald/B
+jq/B
 Kata/B
 Kibana/B
 Kubelet/B


### PR DESCRIPTION
- remove outdated kata v1 info (although it may still be valid)
- mention the cmdline options
- present jq processing examples

Fixes: #4712
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>