### PR TITLE
scripts: fix git security issue when install qemu for arm64

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -34,6 +34,7 @@ build_and_install_qemu() {
         sudo -E make -j $(nproc)
 
         echo "Install Qemu"
+	sudo git config --global --add safe.directory $(pwd)
         sudo -E make install
 
         local qemu_bin=$(command -v qemu-system-${QEMU_ARCH})


### PR DESCRIPTION
There is a enhancement on security for git recently. It affects
git working on multi-user machines. eg. When working in git repo
whose user is non-root as a root, git may stop us to do something
affect other dirs out of this repo. We can add this repo explicitly
as a safe dir to avoid this issue.

see [1] to find more.

[1] https://github.blog/2022-04-12-git-security-vulnerability-announced/

Fixes: #4714
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>