### PR TITLE
agent-shutdown: remove trace mode configuration

### DIFF
--- a/tracing/test-agent-shutdown.sh
+++ b/tracing/test-agent-shutdown.sh
@@ -457,7 +457,6 @@ configure_kata()
 		run_cmd sudo crudini --set "${kata_cfg_file}" 'agent.kata' 'enable_tracing' 'false'
 	else
 		run_cmd sudo crudini --set "${kata_cfg_file}" 'agent.kata' 'enable_tracing' 'true'
-		run_cmd sudo crudini --set "${kata_cfg_file}" 'agent.kata' 'trace_mode' '\"static\"'
 	fi
 }
 


### PR DESCRIPTION
Trace mode was previously removed to simplify tracing; remove associated
configuration step from agent shutdown test.

Fixes #4720

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>