### PR TITLE
CCv0: refactoring common code into tests_common.sh

### DIFF
--- a/integration/containerd/confidential/agent_api.bats
+++ b/integration/containerd/confidential/agent_api.bats
@@ -4,27 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-load "${BATS_TEST_DIRNAME}/lib.sh"
-load "${BATS_TEST_DIRNAME}/asserts.sh"
 load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	start_date=$(date +"%Y-%m-%d %H:%M:%S")
-	sandbox_name="kata-cc-busybox-sandbox"
-	pod_config="${FIXTURES_DIR}/pod-config.yaml"
-	pod_id=""
-
-	echo "Delete any existing ${sandbox_name} pod"
-	crictl_delete_cc_pod_if_exists "$sandbox_name"
-
-	echo "Prepare containerd for Confidential Container"
-	SAVED_CONTAINERD_CONF_FILE="/etc/containerd/config.toml.$$"
-	configure_cc_containerd "$SAVED_CONTAINERD_CONF_FILE"
-
-	echo "Reconfigure Kata Containers"
-	clear_kernel_params
-	switch_image_service_offload on
-	enable_full_debug
+	setup_common
 
 	# Test will change the guest image so let's save it to restore
 	# on teardown.
@@ -40,7 +24,7 @@ setup() {
 	# Check that the agent allow ExecProcessRequest requests by default.
 	#
 	echo "Check can create a container and exec a command"
-	crictl_create_cc_pod "$pod_config"
+	create_test_pod
 	assert_container "$container_config"
 
 	# Check that the agent endpoints can be restricted. In this case it will
@@ -53,7 +37,7 @@ setup() {
 	add_kernel_params \
 		"agent.config_file=/tests/fixtures/${agent_config_filename}"
 
-	crictl_create_cc_pod "$pod_config"
+	create_test_pod
 	crictl_create_cc_container "$sandbox_name" "$pod_config" \
 		"$container_config"
 
@@ -66,18 +50,9 @@ setup() {
 }
 
 teardown() {
-	# Restore containerd to pre-test state.
-	if [ -f "$SAVED_CONTAINERD_CONF_FILE" ]; then
-		systemctl stop containerd || true
-		sleep 5
-		mv -f "$SAVED_CONTAINERD_CONF_FILE" "/etc/containerd/config.toml"
-		systemctl start containerd || true
-	fi
+	teardown_common
 
 	# Restore the original guest image file.
 	new_guest_img "$saved_img" || true
 	rm -f "$saved_img"
-
-	switch_image_service_offload off
-	disable_full_debug
 }

--- a/integration/containerd/confidential/agent_image.bats
+++ b/integration/containerd/confidential/agent_image.bats
@@ -101,5 +101,5 @@ teardown() {
 
 	# Print the logs and cleanup resources.
 	echo "-- Kata logs:"
-	sudo journalctl -xe -t kata --since "$start_date"
+	sudo journalctl -xe -t kata --since "$test_start_time"
 }

--- a/integration/containerd/confidential/asserts.sh
+++ b/integration/containerd/confidential/asserts.sh
@@ -55,7 +55,7 @@ assert_container_fail() {
 # Parameters:
 #	$1 - the message
 #
-# Note: get the logs since the global $start_date.
+# Note: get the logs since the global $test_start_time.
 #
 assert_logs_contain() {
 	local message="$1"
@@ -63,6 +63,6 @@ assert_logs_contain() {
 	for syslog_id in kata containerd crio;do
 		cmd+=" -t \"$syslog_id\""
 	done
-	cmd+=" --since \"$start_date\""
+	cmd+=" --since \"$test_start_time\""
 	eval $cmd | grep "$message"
 }

--- a/integration/containerd/confidential/fixtures/agent-configuration-no-exec.toml
+++ b/integration/containerd/confidential/fixtures/agent-configuration-no-exec.toml
@@ -1,4 +1,3 @@
-#!/usr/bin/env bats
 # Copyright (c) 2022 Red Hat
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/containerd/confidential/tests_common.sh
+++ b/integration/containerd/confidential/tests_common.sh
@@ -46,16 +46,22 @@ setup_common() {
 		enable_agent_console
 	fi
 
-	local local_dns=$(grep nameserver /etc/resolv.conf \
-		/run/systemd/resolve/resolv.conf  2>/dev/null \
-		|grep -v "127.0.0.53" | cut -d " " -f 2 | head -n 1)
-
-	if [ ! -z "$HTTPS_PROXY" ]; then
-		add_kernel_params "agent.https_proxy=$HTTPS_PROXY"
-		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
-	elif [ ! -z "$https_proxy" ]; then
+	# In case the tests run behind a firewall where images needed to be
+	# fetched through a proxy.
+	local https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
+	if [ -n "$https_proxy" ]; then
+		echo "Enable agent https proxy"
 		add_kernel_params "agent.https_proxy=$https_proxy"
+
+		local local_dns=$(grep nameserver /etc/resolv.conf \
+			/run/systemd/resolve/resolv.conf  2>/dev/null \
+			|grep -v "127.0.0.53" | cut -d " " -f 2 | head -n 1)
+		local new_file="${BATS_FILE_TMPDIR}/$(basename ${pod_config})"
+		echo "New pod configuration with local dns: $new_file"
+		cp -f "${pod_config}" "${new_file}"
+		pod_config="$new_file"
 		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+		cat "$pod_config"
 	fi
 }
 

--- a/integration/containerd/confidential/tests_common.sh
+++ b/integration/containerd/confidential/tests_common.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/asserts.sh"
+
+# Common setup for tests.
+#
+# Global variables exported:
+#	$start_date          - test start time
+#	$pod_config          - path to default pod configuration file.
+#	$sandbox_name        - the sandbox name set on default pod configuration.
+#	$saved_kernel_params - saved the original list of kernel parameters.
+#
+setup_common() {
+	export start_date=$(date +"%Y-%m-%d %H:%M:%S")
+	export sandbox_name="kata-cc-busybox-sandbox"
+	export pod_config="${FIXTURES_DIR}/pod-config.yaml"
+
+	echo "Delete any existing ${sandbox_name} pod"
+	crictl_delete_cc_pod_if_exists "$sandbox_name"
+
+	echo "Prepare containerd for Confidential Container"
+	SAVED_CONTAINERD_CONF_FILE="/etc/containerd/config.toml.$$"
+	configure_cc_containerd "$SAVED_CONTAINERD_CONF_FILE"
+
+	# Note: ensure that intructions changing the kernel parameters are
+	# executed *after* saving the original list.
+	saved_kernel_params=$(get_kernel_params)
+	export saved_kernel_params
+
+	echo "Enable image service offload"
+	switch_image_service_offload on
+
+	# On CI mode we only want to enable the agent debug for the case of
+	# the test failure to obtain logs.
+	if [ "${CI:-}" == "true" ]; then
+		echo "Enable full debug"
+		enable_full_debug
+	elif [ "${DEBUG:-}" == "true" ]; then
+		echo "Enable full debug"
+		enable_full_debug
+		echo "Enable agent console"
+		enable_agent_console
+	fi
+
+	local local_dns=$(grep nameserver /etc/resolv.conf \
+		/run/systemd/resolve/resolv.conf  2>/dev/null \
+		|grep -v "127.0.0.53" | cut -d " " -f 2 | head -n 1)
+
+	if [ ! -z "$HTTPS_PROXY" ]; then
+		add_kernel_params "agent.https_proxy=$HTTPS_PROXY"
+		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+	elif [ ! -z "$https_proxy" ]; then
+		add_kernel_params "agent.https_proxy=$https_proxy"
+		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+	fi
+}
+
+# Common teardown for tests. Use alongside setup_common().
+#
+teardown_common() {
+	# Allow to not destroy the environment if you are developing/debugging
+	# tests.
+	if [[ "${CI:-false}" == "false" && "${DEBUG:-}" == true ]]; then
+		echo "Leaving changes and created resources untoughted"
+		return
+	fi
+
+	crictl_delete_cc_pod_if_exists "$sandbox_name" || true
+
+	# Restore the kernel parameters set before the test.
+	clear_kernel_params
+	[ -n "$saved_kernel_params" ] && \
+		add_kernel_params "$saved_kernel_params"
+
+	switch_image_service_offload off
+	disable_full_debug
+
+	# Restore containerd to pre-test state.
+	if [ -f "$SAVED_CONTAINERD_CONF_FILE" ]; then
+		systemctl stop containerd || true
+		sleep 5
+		mv -f "$SAVED_CONTAINERD_CONF_FILE" "/etc/containerd/config.toml"
+		systemctl start containerd || true
+	fi
+}
+
+# Create the test pod. Use alongside setup_common().
+#
+# Note: the global $pod_config should be set already.
+#
+create_test_pod() {
+	echo "Create the test sandbox"
+	crictl_create_cc_pod "$pod_config"
+}

--- a/integration/containerd/confidential/tests_common.sh
+++ b/integration/containerd/confidential/tests_common.sh
@@ -9,13 +9,13 @@ load "${BATS_TEST_DIRNAME}/asserts.sh"
 # Common setup for tests.
 #
 # Global variables exported:
-#	$start_date          - test start time
+#	$test_start_time     - test start time.
 #	$pod_config          - path to default pod configuration file.
 #	$sandbox_name        - the sandbox name set on default pod configuration.
 #	$saved_kernel_params - saved the original list of kernel parameters.
 #
 setup_common() {
-	export start_date=$(date +"%Y-%m-%d %H:%M:%S")
+	export test_start_time="$(date +"%Y-%m-%d %H:%M:%S")"
 	export sandbox_name="kata-cc-busybox-sandbox"
 	export pod_config="${FIXTURES_DIR}/pod-config.yaml"
 


### PR DESCRIPTION
This is a follow up of https://github.com/kata-containers/tests/pull/4677 where @stevenhorsman suggested to put common test code into a library. While here I changed the name of the `$start_date` variable to a more meaningful one. 