### PR TITLE
backport-2.4: tests: fix unsafe repository for new versions of git

### DIFF
--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -22,16 +22,16 @@ build_and_install_qemu() {
 	clone_katacontainers_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
-        git fetch
-        [ -d "capstone" ] || git clone https://github.com/qemu/capstone.git --depth 1 capstone
-        [ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git --depth 1 ui/keycodemapdb
+        sudo -E git fetch
+        [ -d "capstone" ] || sudo -E git clone https://github.com/qemu/capstone.git --depth 1 capstone
+        [ -d "ui/keycodemapdb" ] || sudo -E git clone  https://github.com/qemu/keycodemapdb.git --depth 1 ui/keycodemapdb
 
         # Apply required patches
-	${PACKAGING_DIR}/scripts/patch_qemu.sh ${CURRENT_QEMU_VERSION} ${PACKAGING_DIR}/qemu/patches
+	sudo -E ${PACKAGING_DIR}/scripts/patch_qemu.sh ${CURRENT_QEMU_VERSION} ${PACKAGING_DIR}/qemu/patches
 
         echo "Build Qemu"
-        "${QEMU_CONFIG_SCRIPT}" "qemu" | xargs ./configure
-        make -j $(nproc)
+        "${QEMU_CONFIG_SCRIPT}" "qemu" | xargs sudo -E ./configure
+        sudo -E make -j $(nproc)
 
         echo "Install Qemu"
         sudo -E make install

--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -41,6 +41,9 @@ install_from_source() {
 		containerd_repo=$(get_version "externals.containerd.url")
 		go get "${containerd_repo}"
 		cd "${GOPATH}/src/${containerd_repo}" >>/dev/null
+
+		add_repo_to_git_safe_directory "${GOPATH}/src/${containerd_repo}"
+
 		git fetch
 		git checkout "${containerd_tarball_version}"
 		make BUILD_TAGS="${BUILDTAGS:-}" cri-cni-release

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -77,12 +77,12 @@ install_cached_qemu() {
 
 clone_qemu_repo() {
 	# check if git is capable of shadow cloning
-        git_shadow_clone=$(check_git_version "${GIT_SHADOW_VERSION}")
+	git_shadow_clone=$(check_git_version "${GIT_SHADOW_VERSION}")
 
 	if [ "$git_shadow_clone" == "true" ]; then
-		git clone --branch "${CURRENT_QEMU_VERSION}" --single-branch --depth 1 --shallow-submodules "${QEMU_REPO_URL}" "${GOPATH}/src/${gopath_qemu_repo}"
+		sudo -E git clone --branch "${CURRENT_QEMU_VERSION}" --single-branch --depth 1 --shallow-submodules "${QEMU_REPO_URL}" "${GOPATH}/src/${gopath_qemu_repo}"
 	else
-		git clone --branch "${CURRENT_QEMU_VERSION}" --single-branch --depth 1 "${QEMU_REPO_URL}" "${GOPATH}/src/${gopath_qemu_repo}"
+		sudo -E git clone --branch "${CURRENT_QEMU_VERSION}" --single-branch --depth 1 "${QEMU_REPO_URL}" "${GOPATH}/src/${gopath_qemu_repo}"
 	fi
 }
 
@@ -99,12 +99,12 @@ build_and_install_qemu() {
 	clone_qemu_repo
 
 	pushd "${GOPATH}/src/${gopath_qemu_repo}"
-	git fetch
-	[ -n "$(ls -A capstone)" ] || git clone https://github.com/qemu/capstone.git capstone
-	[ -n "$(ls -A ui/keycodemapdb)" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
+	sudo -E git fetch
+	[ -n "$(ls -A capstone)" ] || sudo -E git clone https://github.com/qemu/capstone.git capstone
+	[ -n "$(ls -A ui/keycodemapdb)" ] || sudo -E git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 
 	# Apply required patches
-	${PACKAGING_DIR}/scripts/patch_qemu.sh ${CURRENT_QEMU_VERSION} ${PACKAGING_DIR}/qemu/patches
+	sudo -E ${PACKAGING_DIR}/scripts/patch_qemu.sh ${CURRENT_QEMU_VERSION} ${PACKAGING_DIR}/qemu/patches
 
 	echo "Build QEMU"
 	# Not all distros have the libpmem package
@@ -113,8 +113,8 @@ build_and_install_qemu() {
 			sed -e 's/--enable-libpmem/--disable-libpmem/g'
 		else
 			cat
-		fi | xargs ./configure --prefix=${PREFIX}
-	make -j $(nproc)
+		fi | xargs sudo -E ./configure --prefix=${PREFIX}
+	sudo -E make -j $(nproc)
 
 	echo "Install QEMU"
 	sudo -E make install

--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -21,21 +21,21 @@ build_and_install_qemu() {
         PACKAGING_DIR="${katacontainers_repo_dir}/tools/packaging"
         QEMU_CONFIG_SCRIPT="${PACKAGING_DIR}/scripts/configure-hypervisor.sh"
 
-        git clone --branch "$CURRENT_QEMU_TAG" --depth 1 "$QEMU_REPO_URL" "${GOPATH}/src/${QEMU_REPO}"
+        sudo -E git clone --branch "$CURRENT_QEMU_TAG" --depth 1 "$QEMU_REPO_URL" "${GOPATH}/src/${QEMU_REPO}"
 
         clone_katacontainers_repo
 
         pushd "${GOPATH}/src/${QEMU_REPO}"
-        git fetch
+        sudo -E git fetch
 
-        [ -d "capstone" ] || git clone https://github.com/qemu/capstone.git capstone
-        [ -d "ui/keycodemapdb" ] || git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
+        [ -d "capstone" ] || sudo -E git clone https://github.com/qemu/capstone.git capstone
+        [ -d "ui/keycodemapdb" ] || sudo -E git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 	
-        ${packaging_dir}/scripts/apply_patches.sh "${packaging_dir}/qemu/patches/${stable_branch}"        
+        sudo -E ${packaging_dir}/scripts/apply_patches.sh "${packaging_dir}/qemu/patches/${stable_branch}"
 	
         echo "Build Qemu"
-        "${QEMU_CONFIG_SCRIPT}" "qemu" | xargs ./configure
-        make -j $(nproc)
+        "${QEMU_CONFIG_SCRIPT}" "qemu" | xargs sudo -E ./configure
+        sudo -E make -j $(nproc)
 
         echo "Install Qemu"
         sudo -E make install


### PR DESCRIPTION
New git will check git repo's mode/permission, and will return error:

fatal: unsafe repository ('/some/path' is owned by someone else)

See:

https://github.blog/2022-04-12-git-security-vulnerability-announced/

for more information.

We have 3 repos run into this issue: kata-containers, containerd and
QEMU(only build from source for aarch64/ppc64le).

For the first two repos,
we can just use `git config --global --add safe.directory`.

But QEMU have
some submodules, we need to add all submodules to the safe
directory, so unlike kata-containers and containerd repos,
for QEMU we add `sudo -E` before commands run in the repo.

Fixes: #4692

Signed-off-by: Bin Liu <bin@hyper.sh>