### PR TITLE
scripts: Make die show stacktrace and other info under CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ else
 fi
 ```
 
+### Display verbose failure details
+
+By default, when scripts in this repository fail, they display an
+error message to `stderr` and return `1` (failure) to the shell.
+However, when [called by the CI](#detecting-a-ci-system), the scripts
+will also dump a full stack trace and some environment details to `stderr`.
+
+To force this behaviour outside of a CI environment, ensure the variable below is set:
+
+```bash
+export KATA_TEST_VERBOSE=true
+```
+
 ### Breaking Compatibility
 
 In case the patch you submit breaks the CI because it needs to be tested

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -52,7 +52,7 @@ handle_error() {
 }
 trap 'handle_error $LINENO' ERR
 
-waitForProcess(){
+waitForProcess() {
 	wait_time="$1"
 	sleep_time="$2"
 	cmd="$3"
@@ -71,7 +71,7 @@ waitForProcess(){
 # Kata runtime. Of course, the end user can choose any name they
 # want in reality, but this function knows the names of the default
 # and recommended Kata docker runtime install names.
-is_a_kata_runtime(){
+is_a_kata_runtime() {
 	if [ "$1" = "containerd-shim-kata-v2" ] || [ "$1" = "io.containerd.kata.v2" ]; then
 		echo "1"
 	else
@@ -81,7 +81,7 @@ is_a_kata_runtime(){
 
 
 # Try to find the real runtime path for the docker runtime passed in $1
-get_docker_kata_path(){
+get_docker_kata_path() {
 	local jpaths=$(sudo docker info --format "{{json .Runtimes}}" || true)
 	local rpath=$(jq .\"$1\".path <<< "$jpaths")
 	# Now we have to de-quote it..
@@ -92,7 +92,7 @@ get_docker_kata_path(){
 
 # Gets versions and paths of all the components
 # list in kata-env
-extract_kata_env(){
+extract_kata_env() {
 	RUNTIME_CONFIG_PATH=$(kata-runtime kata-env --json | jq -r .Runtime.Config.Path)
 	RUNTIME_VERSION=$(kata-runtime kata-env --json | jq -r .Runtime.Version | grep Semver | cut -d'"' -f4)
 	RUNTIME_COMMIT=$(kata-runtime kata-env --json | jq -r .Runtime.Version | grep Commit | cut -d'"' -f4)

--- a/lib/error.sh
+++ b/lib/error.sh
@@ -1,0 +1,218 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Description: Error handling functions.
+
+# Write specified message to stderr.
+stderr()
+{
+	local msg="$*"
+
+	echo >&2 "$msg"
+}
+
+# Simplified version of die that should be called by functions that
+# could fail as part of the normal "die()" code path. Required to
+# avoid infinite recursion.
+_fatal()
+{
+	local msg="$*"
+
+	echo >&2 "FATAL: $msg"
+	exit 1
+}
+
+# Canonicalize the specified path (which must be valid).
+resolve_path()
+{
+	local file="${1:-}"
+	[ -z "$file" ] && _fatal "need file to resolve"
+
+	local path
+
+	path=$(readlink --canonicalize-existing "$file" || \
+		_fatal "failed to resolve file '$file'")
+
+	echo "$path"
+}
+
+show_proc_hierarchy()
+{
+	local pid="${$}"
+
+	local details
+
+	stderr "process-hierarchy:"
+
+	local -i i
+
+	for ((i=0; ; i++))
+	do
+		local details
+		local msg
+
+		local current=''
+
+		[ "${pid}" = "${$}" ] && current=", current='yes'"
+
+		details=$(ps --no-headers -p "$pid" -o ppid,cmd)
+
+		# The parent PID is always the first column due to the
+		# format specifier used above.
+		local ppid=$(echo "$details" | awk '{print $1}')
+
+		# But the command part has a variable number of fields
+		# (since it could contain any number of spaces).
+		# Hence, delete the first field (PPID) and what
+		# remains is the entire command line.
+		local cmd=$(echo "$details" |\
+			awk '{$1=""; print $0}' |\
+			sed \
+			-e 's/^ *//g' \
+			-e 's/ *$//g')
+
+		msg=$(printf "  %d: {pid: %d, command: '%s'%s}" \
+			"${i}" \
+			"${pid}" \
+			"${cmd}" \
+			"${current}")
+		stderr "$msg"
+
+		[ "$pid" = 1 ] && break
+
+		pid="$ppid"
+	done
+}
+
+show_stacktrace()
+{
+	local err_line="${1:-}"
+	local err_func="${2:-}"
+	local err_path="${3:-}"
+
+	[ -z "$err_line" ] && _fatal "need error location line number"
+	[ -z "$err_func" ] && _fatal "need error location func"
+	[ -z "$err_path" ] && _fatal "need error location file path"
+
+	local line
+	local func
+	local file
+
+	local -i i
+
+	stderr "stacktrace:"
+
+	for ((i = 0; ; i++))
+	do
+		local result
+		result=$(caller "$i" || true)
+
+		[ -z "$result" ] && break
+
+		line=$(echo "$result"|awk '{print $1}')
+		func=$(echo "$result"|awk '{print $2}')
+		file=$(echo "$result"|awk '{print $3}')
+
+		local path
+		path=$(resolve_path "$file")
+
+		local msg
+
+		local current=''
+
+		# Add a visual marker showing where the original error was
+		# detected.
+		[ "${line}" = "${err_line}" ] && \
+		[ "${func}" = "${err_func}" ] && \
+		[ "${path}" = "${err_path}" ] && \
+		current=", current='yes'"
+
+		msg=$(printf "  %d: {function: '%s', file: '%s', line: %d%s}\n" \
+			"${i}" \
+			"${func}" \
+			"${path}" \
+			"${line}" \
+			"${current}" )
+
+		stderr "$msg"
+	done
+}
+
+# Function to be called by die() or a trap/signal handler to dump all
+# details of the environment (in YAML format), to help with debugging.
+dump_details()
+{
+	local err_line="${1:-}"
+	local err_func="${2:-}"
+	local err_path="${3:-}"
+
+	[ -z "$err_line" ] && _fatal "need error location line number"
+	[ -z "$err_func" ] && _fatal "need error location func"
+	[ -z "$err_path" ] && _fatal "need error location file path"
+
+	# Spacer
+	stderr
+
+	stderr "script:"
+	stderr "  name: '$0'"
+	stderr "  pid: $$"
+	stderr "  directory: '$PWD'"
+	stderr "  details: '$(ls -dlZ "$PWD")'"
+	stderr "failure:"
+	stderr "  function: '$func'"
+	stderr "  file: '$path'"
+	stderr "  line: $line"
+	stderr "  name: '$0'"
+
+	show_stacktrace \
+		"${err_line}" \
+		"${err_func}" \
+		"${err_path}"
+
+	show_proc_hierarchy
+
+	stderr "time: '$(date -Isec)'"
+	stderr "runtime-seconds: ${SECONDS}"
+	stderr "host:"
+	stderr "  name: '$(hostname)'"
+	stderr "  uname: '$(uname -a)'"
+
+	stderr "locale:"
+	locale 2>/dev/null | sed \
+		-e 's/^/  /g' \
+		-e 's/=/: '\''/g' \
+		-e 's/$/'\''/g' \
+		>&2
+
+	stderr "user:"
+	stderr "  uid: {value: $UID, name: '$(getent passwd "$UID"|cut -d: -f1)'}"
+	stderr "  euid: {value: $EUID , name: '$(getent passwd "$EUID"|cut -d: -f1)'}"
+	stderr "  groups: '$(id)'"
+
+	stderr "bash:"
+	stderr "  version: '${BASH_VERSION}'"
+	stderr "  version-info: '${BASH_VERSINFO[*]}'"
+
+	stderr "environment:"
+
+	# Remove bash functions (that can span multiple lines)
+	env |\
+		grep -v "^BASH_FUNC" |\
+		grep -Ei "^[a-z_][a-z0-9_]+=" |\
+		sort -t '=' -k1 |\
+		sed \
+		-e 's/^/  /g' \
+		-e 's/=/: '\''/' \
+		-e 's/$/'\''/g' \
+		>&2
+
+	stderr "mounts: |"
+	mount | sed 's/^/  /g' >&2
+
+	stderr "processes: |"
+	ps -eF | sed 's/^/  /g' >&2
+
+	# Spacer
+	stderr
+}


### PR DESCRIPTION
Enhance the standard `die()` function to dump lots of information (in
YAML format) after displaying the error message when running under the
CI. The dump includes a full stacktrace and lots of environment details
to help with debugging.

> **Note:**
>
> The conventional way of displaying this additional information is by
> defining a `trap` handler. However, that technique cannot be used here
> as this is effectively a library and the callers of this library can
> (and do) define their own `traps` (and only one `trap` can be defined
> per signal).

Fixes: #4732.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>