### PR TITLE
Reorganize the tests - part 2 (new stability directory)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ sandbox-cgroup:
 	bash -f integration/sandbox_cgroup/sandbox_cgroup_test.sh
 
 stability:
-	cd integration/stability && \
+	cd stability && \
 	ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
-	cd integration/stability && ./hypervisor_stability_kill_test.sh
+	cd stability && ./hypervisor_stability_kill_test.sh
 
 # Run the static checks on this repository.
 static-checks:

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ help:
 	qat \
 	rootless \
 	sandbox-cgroup \
+	stability \
 	static-checks \
 	test \
 	tracing \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and with different container managers.
 1. Integration tests to ensure compatibility with:
    - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
    - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
+2. [Stability tests](./stability)
 3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
 4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
 

--- a/stability/agent_stability_test.sh
+++ b/stability/agent_stability_test.sh
@@ -12,7 +12,7 @@ set -e -x
 
 cidir=$(dirname "$0")
 
-source "${cidir}/../../metrics/lib/common.bash"
+source "${cidir}/../metrics/lib/common.bash"
 
 # Environment variables
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"

--- a/stability/agent_stability_test.sh
+++ b/stability/agent_stability_test.sh
@@ -46,8 +46,10 @@ function exec_loop {
 }
 
 function teardown {
+	echo "Ending stability test"
 	clean_env_ctr
 }
+trap teardown EXIT
 
 echo "Starting stability test"
 setup
@@ -56,6 +58,3 @@ echo "Running stability test"
 while [[ $end_time > $(date +%s) ]]; do
 	exec_loop
 done
-
-echo "Ending stability test"
-teardown

--- a/stability/hypervisor_stability_kill_test.sh
+++ b/stability/hypervisor_stability_kill_test.sh
@@ -11,7 +11,7 @@ set -e
 
 cidir=$(dirname "$0")
 
-source "${cidir}/../../metrics/lib/common.bash"
+source "${cidir}/../metrics/lib/common.bash"
 
 # Environment variables
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"

--- a/stability/soak_parallel_rm.sh
+++ b/stability/soak_parallel_rm.sh
@@ -13,7 +13,7 @@
 # - catch any hang ups
 
 cidir=$(dirname "$0")
-source "${cidir}/../../metrics/lib/common.bash"
+source "${cidir}/../metrics/lib/common.bash"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
 # How many times will we run the test loop...
@@ -176,7 +176,7 @@ init() {
 		check_kata_components=0
 	fi
 
-	versions_file="${cidir}/../../versions.yaml"
+	versions_file="${cidir}/../versions.yaml"
 	nginx_version=$("${GOPATH}/bin/yq" read "$versions_file" "docker_images.nginx.version")
 	nginx_image="docker.io/library/nginx:$nginx_version"
 


### PR DESCRIPTION
Continuing the part 1 (https://github.com/kata-containers/tests/pull/4751), this is going to create a `stability` directory out of `integration` to host any test related with stability/load testing.

Fixes #4645