### PR TITLE
Reorganize the tests - part 3 (move tracing to functional)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,12 +100,12 @@ qat:
 	bash integration/qat/qat_test.sh
 
 agent-shutdown:
-	bash tracing/test-agent-shutdown.sh
+	bash functional/tracing/test-agent-shutdown.sh
 
 # Tracing requires the agent to shutdown cleanly,
 # so run the shutdown test first.
 tracing: agent-shutdown
-	bash tracing/tracing-test.sh
+	bash functional/tracing/tracing-test.sh
 
 vcpus:
 	bash -f functional/vcpus/default_vcpus_test.sh

--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -41,7 +41,7 @@ set -o pipefail
 set -o errtrace
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
-source "${SCRIPT_PATH}/../.ci/lib.sh"
+source "${SCRIPT_PATH}/../../.ci/lib.sh"
 
 CTR_RUNTIME=${CTR_RUNTIME:-"io.containerd.kata.v2"}
 
@@ -757,7 +757,7 @@ setup()
 		exit 0
 	}
 
-	"${SCRIPT_PATH}/../.ci/install_rust.sh" && source "$HOME/.cargo/env"
+	"${SCRIPT_PATH}/../../.ci/install_rust.sh" && source "$HOME/.cargo/env"
 
 	trap cleanup EXIT
 

--- a/functional/tracing/tracing-test.sh
+++ b/functional/tracing/tracing-test.sh
@@ -24,7 +24,7 @@ DEBUG_KEEP_FORWARDER=${DEBUG_KEEP_FORWARDER:-}
 [ -n "$DEBUG" ] && set -o xtrace
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
-source "${SCRIPT_PATH}/../lib/common.bash"
+source "${SCRIPT_PATH}/../../lib/common.bash"
 
 RUNTIME="io.containerd.kata.v2"
 CONTAINER_IMAGE="quay.io/prometheus/busybox:latest"
@@ -63,7 +63,7 @@ cleanup()
 		if [ -n "$DEBUG" ]; then
 			eval "$fp" "test $result - logs left in '$dest'"
 		else
-			"${SCRIPT_PATH}/../.ci/configure_tracing_for_kata.sh" disable
+			"${SCRIPT_PATH}/../../.ci/configure_tracing_for_kata.sh" disable
 
 			[ -d "$logdir" ] && rm -rf "$logdir" || true
 		fi
@@ -294,7 +294,7 @@ setup()
 
 	start_jaeger
 
-	"${SCRIPT_PATH}/../.ci/configure_tracing_for_kata.sh" enable
+	"${SCRIPT_PATH}/../../.ci/configure_tracing_for_kata.sh" enable
 }
 
 run_test()


### PR DESCRIPTION
Continuing part 1 (#4751)  and 2 (#4752)...

The tracing tests are conceptually functional testing, so moving them to the
right directory.

Fixes #4645
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>