### PR TITLE
crio: Update golang to 1.18+ in this specific CI

### DIFF
--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -121,6 +121,10 @@ cd "${katacontainers_repo_dir}"
 # Install yq
 ${GOPATH}/src/${tests_repo}/.ci/install_yq.sh
 
+# CRI-O switched to using go 1.18+
+golang_version="1.18.1"
+yq w -i versions.yaml languages.golang.meta.newest-version "${golang_version}"
+
 critools_version="${branch_release_number}.0"
 echo "Using critools ${critools_version}"
 yq w -i versions.yaml externals.critools.version "${critools_version}"


### PR DESCRIPTION
CRI-O has moved to using golang 1.18+, for some time now.
Peter Hunt has approached us to do the bump as part of our CI as well.

Fixes: #4767

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>