### PR TITLE
k8s: Enable port forward kubernetes test

### DIFF
--- a/integration/kubernetes/k8s-port-forward.bats
+++ b/integration/kubernetes/k8s-port-forward.bats
@@ -8,15 +8,11 @@ load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
-issue="https://github.com/kata-containers/runtime/issues/1834"
-
 setup() {
-	skip "test not working see: ${issue}"
 	get_pod_config_dir
 }
 
 @test "Port forwarding" {
-	skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
 	# Create deployment
@@ -65,7 +61,6 @@ setup() {
 }
 
 teardown() {
-	skip "test not working see: ${issue}"
 	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
 }


### PR DESCRIPTION
This PR enables the port forward integration kubernetes test.

Fixes #4771

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>