### PR TITLE
setup: install openssl(1)

### DIFF
--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -84,6 +84,7 @@ declare -A packages=( \
 	[make]="make" \
 	[agent_shutdown_test]="tmux" \
 	[virtiofsd_dependencies]="unzip" \
+	[webhook_dependencies]="openssl" \
 )
 
 main()

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -39,6 +39,7 @@ declare -A packages=( \
 	[agent_shutdown_test]="tmux" \
 	[vfio_test]="pciutils driverctl" \
 	[virtiofsd_dependencies]="unzip" \
+	[webhook_dependencies]="openssl" \
 )
 
 if [ "$(uname -m)" == "x86_64" ] || ([ "$(uname -m)" == "ppc64le" ] && [ "${VERSION_ID}" -ge "32" ]); then

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -44,6 +44,7 @@ declare -A packages=( \
 	[redis]="redis-server" \
 	[agent_shutdown_test]="tmux" \
 	[virtiofsd_dependencies]="unzip" \
+	[webhook_dependencies]="openssl" \
 )
 
 if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == "1" ]; then


### PR DESCRIPTION
The kata-webhook deployment script uses the openssl(1) command to create
SSL certificates. This changed the setup scripts of CentOS, Ubuntu, and
Fedora to ensure that tool is installed in the CI environment.

Fixes #4775
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>