### PR TITLE
github: Update go version to 1.18

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -587,7 +587,7 @@ static_check_docs()
 		url=$(get_test_version "externals.xurls.url")
 
 		# xurls is very fussy about how it's built.
-		GO111MODULE=on go get "${url}@${version}"
+		GO111MODULE=on go install "${url}@${version}"
 
 		command -v xurls &>/dev/null ||
 			die 'xurls not found. Ensure that "$GOPATH/bin" is in your $PATH'
@@ -974,7 +974,7 @@ static_check_vendor()
 	info "Checking vendoring metadata"
 
 	# Get the vendoring tool
-	go get github.com/golang/dep/cmd/dep
+	go install github.com/golang/dep/cmd/dep@latest
 
 	# Check, but don't touch!
 	dep check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:
-      GO111MODULE: off
+      GO111MODULE: auto
       TRAVIS: "true"
       TRAVIS_BRANCH: ${{ github.base_ref }}
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}

--- a/cmd/checkcommits/README.md
+++ b/cmd/checkcommits/README.md
@@ -82,8 +82,8 @@ $ ./checkcommits -h
 ### Download and Build
 
 ```
-$ repo="github.com/kata-containers/tests/cmd/checkcommits"
-$ go get -d "$repo"
+$ repo="github.com/kata-containers/tests/cmd/checkcommits@latest"
+$ go install "$repo"
 $ (cd "$GOPATH/src/$repo" && make)
 ```
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -62,7 +62,7 @@ externals:
   golangci-lint:
     description: "utility to run various golang linters"
     url: "github.com/golangci/golangci-lint"
-    version: "v1.41.1"
+    version: "v1.46.1"
 
   hadolint:
     description: "the dockerfile linter used by static-checks"


### PR DESCRIPTION
This PR updates the go version to 1.18 that is used to triggered the github actions.

Fixes #4779

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>