### PR TITLE
Add the needed support to start using the rust version of the virtiofsd

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -21,7 +21,7 @@ main() {
 
 	pushd $katacontainers_repo_dir
 	sudo -E PATH=$PATH bash ${buildscript} --build=cloud-hypervisor
-	sudo tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
+	sudo tar -xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
 	sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
 	popd
 }

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -10,10 +10,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-readonly script_dir=$(dirname $(readlink -f "$0"))
-
 cidir=$(dirname "$0")
-arch=$("${cidir}"/kata-arch.sh -d)
 source "${cidir}/lib.sh"
 
 main() {

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -18,6 +18,7 @@ KATA_BUILD_QEMU_TYPE="${KATA_BUILD_QEMU_TYPE:-vanilla}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 experimental_qemu="${experimental_qemu:-false}"
 TEE_TYPE="${TEE_TYPE:-}"
+arch=$("${cidir}"/kata-arch.sh -d)
 
 if [ -n "${TEE_TYPE}" ]; then
 	echo "Install with TEE type: ${TEE_TYPE}"
@@ -53,12 +54,14 @@ case "${KATA_HYPERVISOR}" in
 		"${cidir}/install_cloud_hypervisor.sh"
 		echo "Installing experimental_qemu to install virtiofsd"
 		install_qemu
+		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh"
 		;;
 	"firecracker")
 		"${cidir}/install_firecracker.sh"
 		;;
 	"qemu")
 		install_qemu
+		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh"
 		;;
 	*)
 		die "${KATA_HYPERVISOR} not supported for CI install"

--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+main() {
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH bash ${buildscript} --build=virtiofsd
+	sudo tar -xvJpf build/kata-static-virtiofsd.tar.xz -C /
+	sudo ln -sf /opt/kata/libexec/virtiofsd /usr/libexec/virtiofsd
+	popd
+}
+
+main "$@"

--- a/.ci/setup_env_alinux.sh
+++ b/.ci/setup_env_alinux.sh
@@ -72,6 +72,7 @@ declare -A packages=( \
 	[redis]="redis" \
 	[make]="make" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 main()

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -83,6 +83,7 @@ declare -A packages=( \
 	[redis]="redis" \
 	[make]="make" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 main()

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -38,6 +38,7 @@ declare -A packages=( \
 	[versionlock]="python3-dnf-plugin-versionlock" \
 	[agent_shutdown_test]="tmux" \
 	[vfio_test]="pciutils driverctl" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 if [ "$(uname -m)" == "x86_64" ] || ([ "$(uname -m)" == "ppc64le" ] && [ "${VERSION_ID}" -ge "32" ]); then

--- a/.ci/setup_env_opensuse.sh
+++ b/.ci/setup_env_opensuse.sh
@@ -42,6 +42,7 @@ declare -A packages=( \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 if [ "${arch}" == "x86_64" ] || [ "${arch}" == "ppc64le" ]; then

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -47,6 +47,7 @@ declare -A packages=(
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 if [ "$(uname -m)" == "x86_64" ] ; then

--- a/.ci/setup_env_sles.sh
+++ b/.ci/setup_env_sles.sh
@@ -51,6 +51,7 @@ declare -A packages=( \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 if [ "${arch}" == "x86_64" ] || [ "${arch}" == "ppc64le" ]; then

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -43,6 +43,7 @@ declare -A packages=( \
 	[libsystemd]="libsystemd-dev" \
 	[redis]="redis-server" \
 	[agent_shutdown_test]="tmux" \
+	[virtiofsd_dependencies]="unzip" \
 )
 
 if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == "1" ]; then


### PR DESCRIPTION
As the very basic steps on the tests repo, we need to:
* Create a script to install virtiofsd;
* Ensure it gets installed for the supported architectures;

For this we can rely on the work that's been proposed on the kata-containers repo (see: https://github.com/kata-containers/kata-containers/pull/4233) and take advantage of the installation script already provided there (as already done for Cloud Hypervisor).

Fixes: #4784 

