### PR TITLE
ci: Update runc containerd runtime

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -22,7 +22,7 @@ cat << EOF | sudo tee /etc/containerd/config.toml
     [plugins.cri.containerd]
       [plugins.cri.containerd.runtimes]
         [plugins.cri.containerd.runtimes.runc]
-           runtime_type = "io.containerd.runc.v1"
+           runtime_type = "io.containerd.runc.v2"
            [plugins.cri.containerd.runtimes.runc.options]
              BinaryName = "${runc_path}"
              Root = ""

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -118,7 +118,7 @@ function config_containerd() {
       disable_snapshot_annotations = false
       [plugins.cri.containerd.runtimes]
       [plugins.cri.containerd.runtimes.runc]
-         runtime_type = "io.containerd.runc.v1"
+         runtime_type = "io.containerd.runc.v2"
          [plugins.cri.containerd.runtimes.runc.options]
            BinaryName = "${runc_path}"
            Root = ""


### PR DESCRIPTION
This PR updates the runc containerd runtime to use io.container.runc.v2
as we are using a containerd version > 1.4 and following the
https://github.com/containerd/containerd/blob/6b35307594841829c398ee8cf1100538867fcb82/docs/cri/config.md.

Fixes #4786

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>