### PR TITLE
virtiofsd: Do not install the C version of the daemon (x86_64)

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -53,8 +53,7 @@ case "${KATA_HYPERVISOR}" in
 	"cloud-hypervisor")
 		"${cidir}/install_cloud_hypervisor.sh"
 		echo "Installing experimental_qemu to install virtiofsd"
-		install_qemu
-		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh"
+		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh" || install_qemu
 		;;
 	"firecracker")
 		"${cidir}/install_firecracker.sh"


### PR DESCRIPTION
For x86_64, instead of installing both the C and the rust versions of
the daemon, let's just install the rust one as we have the tests passing
with it.

Fixes: #4788
Depends-on: github.com/kata-containers/kata-containers#4253

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>