### PR TITLE
ci: Don't look for the C version of virtiofsd (x86_64)

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -56,7 +56,9 @@ uncompress_static_qemu() {
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
 	sudo tar -xf "${qemu_tar_location}" -C /
 	# verify installed binaries existance
-	ls /usr/libexec/kata-qemu/virtiofsd || return 1
+	if [[ ${ARCH} != "x86_64" ]]; then
+		ls /usr/libexec/kata-qemu/virtiofsd || return 1
+	fi
 	ls /usr/bin/qemu-system-x86_64 || return 1
 }
 
@@ -119,9 +121,12 @@ build_and_install_qemu() {
 	echo "Install QEMU"
 	sudo -E make install
 	# qemu by default installs virtiofsd under libexec
-	sudo mkdir -p /usr/libexec/kata-qemu/
-	sudo ln -sf ${PREFIX}/libexec/qemu/virtiofsd /usr/libexec/kata-qemu/virtiofsd
-	ls -l /usr/libexec/kata-qemu/virtiofsd || return 1
+	# x86_64 is using the rust version of QEMU
+	if [[ ${ARCH} != "x86_64" ]]; then
+		sudo mkdir -p /usr/libexec/kata-qemu/
+		sudo ln -sf ${PREFIX}/libexec/qemu/virtiofsd /usr/libexec/kata-qemu/virtiofsd
+		ls -l /usr/libexec/kata-qemu/virtiofsd || return 1
+	fi
 	popd
 }
 


### PR DESCRIPTION
For some reason it was not caught by the CI before, but the install_qemu
script looks for the virtiofsd in the location where it should be if
built and installed via QEMU.

This is not needed anymore, at least for x86_64, as we're using the rust
version of virtiofsd.

Fixes: #4791

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>