### PR TITLE
virtiofsd: install standalone virtiofsd for non-x86_64

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -52,15 +52,16 @@ echo "Install runtime"
 case "${KATA_HYPERVISOR}" in
 	"cloud-hypervisor")
 		"${cidir}/install_cloud_hypervisor.sh"
-		echo "Installing experimental_qemu to install virtiofsd"
-		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh" || install_qemu
+		echo "Installing virtiofsd"
+		"${cidir}/install_virtiofsd.sh"
 		;;
 	"firecracker")
 		"${cidir}/install_firecracker.sh"
 		;;
 	"qemu")
 		install_qemu
-		[ "${arch}" == "x86_64" ] && "${cidir}/install_virtiofsd.sh"
+		echo "Installing virtiofsd"
+		"${cidir}/install_virtiofsd.sh"
 		;;
 	*)
 		die "${KATA_HYPERVISOR} not supported for CI install"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -120,13 +120,6 @@ build_and_install_qemu() {
 
 	echo "Install QEMU"
 	sudo -E make install
-	# qemu by default installs virtiofsd under libexec
-	# x86_64 is using the rust version of QEMU
-	if [[ ${ARCH} != "x86_64" ]]; then
-		sudo mkdir -p /usr/libexec/kata-qemu/
-		sudo ln -sf ${PREFIX}/libexec/qemu/virtiofsd /usr/libexec/kata-qemu/virtiofsd
-		ls -l /usr/libexec/kata-qemu/virtiofsd || return 1
-	fi
 	popd
 }
 

--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -14,6 +14,8 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 main() {
+	bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
+
 	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
 	# Just in case the kata-containers repo is not cloned yet.

--- a/.ci/ppc64le/lib_install_qemu_ppc64le.sh
+++ b/.ci/ppc64le/lib_install_qemu_ppc64le.sh
@@ -42,10 +42,5 @@ build_and_install_qemu() {
 
         sudo ln -sf $(command -v ${BUILT_QEMU}) "/usr/bin/qemu-system-${QEMU_ARCH}"
 
-        echo "Link virtiofsd to /usr/libexec/kata-qemu/virtiofsd"
-        ls -l $(pwd)/build/tools/virtiofsd/virtiofsd || return 1
-        sudo mkdir -p /usr/libexec/kata-qemu/
-        sudo ln -sf $(pwd)/build/tools/virtiofsd/virtiofsd /usr/libexec/kata-qemu/virtiofsd
-        ls -l /usr/libexec/kata-qemu/virtiofsd || return 1
         popd
 }


### PR DESCRIPTION
As rust based virtiofsd is supported to build on non-x86_64, use it
as the default virtiofsd.

Fixes: #4795
Depends-on: github.com/kata-containers/kata-containers#4276
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>