### PR TITLE
Adapt Openshift CI for the virtiofsd-rs

### DIFF
--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -13,6 +13,8 @@ set -o errtrace
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+DESTDIR="${DESTDIR:-/}"
+
 main() {
 	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
@@ -21,8 +23,14 @@ main() {
 
 	pushd $katacontainers_repo_dir
 	sudo -E PATH=$PATH bash ${buildscript} --build=virtiofsd
-	sudo tar -xvJpf build/kata-static-virtiofsd.tar.xz -C /
-	sudo ln -sf /opt/kata/libexec/virtiofsd /usr/libexec/virtiofsd
+	sudo tar -xvJpf build/kata-static-virtiofsd.tar.xz -C "${DESTDIR}"
+	# Kata CI requires the link but this isn't true to all scenarios,
+	# for example, on OpenShift CI everything should be installed under
+	# /opt/kata. So do not try to create the link unless the directory
+	# exist.
+	[ -d "${DESTDIR}/usr/libexec" ] && \
+		sudo ln -sf "${DESTDIR}/opt/kata/libexec/virtiofsd" \
+			"${DESTDIR}/usr/libexec/virtiofsd"
 	popd
 }
 

--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -152,6 +152,8 @@ yum install -y dracut
 
 "${cidir}/install_runtime.sh"
 
+"${cidir}/install_virtiofsd.sh"
+
 # The resulting kata installation will be merged in rhcos filesystem, and
 # symlinks are troublesome. So instead let's convert them to in-place files.
 for ltarget in $(find ${DESTDIR} -type l); do


### PR DESCRIPTION
This fixes the scripts so that virtiofsd (rust) is proper installed in the OpenShift CI environment.

Fixes #4798 