### PR TITLE
stable 2.4 | Fix QEMU cache resolution

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -482,7 +482,7 @@ get_pr_changed_file_details()
 # Gets a list of files and/or directories to build a SHA-256 from their contents.
 # Returns the SHA-256 hash if succeeded, otherwise an empty string.
 sha256sum_from_files() {
-	local files_in=${1:-}
+	local files_in=${@:-}
 	local files=""
 	local shasum=""
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
-2. [Stability tests](https://github.com/kata-containers/tests/tree/main/integration/stability)
-3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
-4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
+   - [Kubernetes](./integration/kubernetes)
+   - [Containerd](./integration/containerd)
+2. [Stability tests](./integration/stability)
+3. [Metrics](./metrics)
+4. [VFIO](./functional/vfio)
 
 ## CI Content
 


### PR DESCRIPTION
Fix the problem of getting the QEMU from cache (main branch)

* ci/lib.sh: fix sha256sum_from_files() not picking all files
* README: fix broken urls
