### PR TITLE
ci: Stop looking for virtiofsd files when installing QEMU

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -56,9 +56,6 @@ uncompress_static_qemu() {
 	[ -n "$qemu_tar_location" ] || die "provide the location of the QEMU compressed file"
 	sudo tar -xf "${qemu_tar_location}" -C /
 	# verify installed binaries existance
-	if [[ ${ARCH} != "x86_64" ]]; then
-		ls /usr/libexec/kata-qemu/virtiofsd || return 1
-	fi
 	ls /usr/bin/qemu-system-x86_64 || return 1
 }
 


### PR DESCRIPTION
As we're currently installing the standalone rust version of virtiofsd
for all the architectures, we can stop looking for the virtiofsd that
comes with QEMU, as we also stopped building it for all the
architectures.

Fixes: #4811
Depends-on: github.com/kata-containers/kata-containers#4308

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>