### PR TITLE
k8s: Untaint control-plane nodes

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -34,6 +34,11 @@ untaint_node() {
 		kubectl taint nodes "${node_name}" \
 			node-role.kubernetes.io/master:NoSchedule-
 	fi
+	if eval $get_taints | grep -q 'control-plane'; then
+		info "Taint 'control-plane' is found. Untaint the node so pods can be scheduled."
+		kubectl taint nodes "${node_name}" \
+			node-role.kubernetes.io/control-plane-
+	fi
 }
 
 wait_pods_ready()


### PR DESCRIPTION
kubeadm adds this new taint on kubernetes 1.24+.

Fixes: #4815

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>