### PR TITLE
static-checks: accept other http content encoding on url checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -529,7 +529,8 @@ check_url()
 
 	local ret
 
-	{ curl -sIL --max-time "$url_check_timeout_secs" --retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
+	{ curl -sIL -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
+		--retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
 
 	# A transitory error, or the URL is incorrect,
 	# but capture either way.


### PR DESCRIPTION
as it seems some github.com subdomains uses these

see: https://github.com/github/feedback/discussions/14773

Fixes: #4822
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>