### PR TITLE
ci: ignore license header check for THIRD-PARTY file

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -468,6 +468,7 @@ static_check_license_headers()
 			--exclude="*.jpg" \
 			--exclude="*.json" \
 			--exclude="LICENSE*" \
+			--exclude="THIRD-PARTY" \
 			--exclude="*.md" \
 			--exclude="*.pb.go" \
 			--exclude="*pb_test.go" \


### PR DESCRIPTION
Third-party files may include a file named THIRD-PARTY,
this file should not be checked for license header anymore.

Fixes: #4833

Signed-off-by: Bin Liu <bin@hyper.sh>