### PR TITLE
ci: add sev build option for kernel

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -44,6 +44,9 @@ build_and_install_kernel() {
 		tdx)
 			extra_opts="-s -x tdx"
 			;;
+		sev)
+			extra_opts="-x sev"
+			;;
 	esac
 
 	# Always build and install the kernel version found locally
@@ -142,7 +145,7 @@ Usage:
 Options:
     -d          : Enable bash debug.
     -h          : Display this help.
-    -t <kernel> : kernel type, such as vanilla, experimental, tdx.
+    -t <kernel> : kernel type, such as vanilla, experimental, tdx, sev.
 EOF
 	exit "$exit_code"
 }
@@ -176,6 +179,9 @@ main() {
 			;;
 		tdx)
 			install_kernel "${kernel_type}" $(get_version "assets.kernel.tdx.tag")
+			;;
+		sev)
+			install_kernel "${kernel_type}" $(get_version "assets.kernel.sev.tag")
 			;;
 		*)
 			info "kernel type '${kernel_type}' not supported"


### PR DESCRIPTION
Adding another case to the CI's kernel builder for sev.

Depends on https://github.com/kata-containers/kata-containers/pull/4180 this PR in kata for additions to the kernel builder for efi_secret which is needed for SEV.

Fixes #4837
Signed-off-by: Alex Carter [alex.carter@ibm.com](mailto:alex.carter@ibm.com)

@fitzthum @larrydewey @ryansavino