### PR TITLE
tests: Remove skip for integration containerd shimv2 tests

### DIFF
--- a/integration/containerd/shimv2/shimv2-tests.sh
+++ b/integration/containerd/shimv2/shimv2-tests.sh
@@ -10,12 +10,6 @@
 source /etc/os-release || source /usr/lib/os-release
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
-if [ "$ID" == "centos" ] || [ "$ID" == sles ]; then
-	issue="https://github.com/kata-containers/tests/issues/1251"
-	echo "Skip shimv2 on $ID, see: $issue"
-	exit
-fi
-
 ${SCRIPT_PATH}/../../../.ci/install_cri_containerd.sh
 
 cni_bin_path="/opt/cni"


### PR DESCRIPTION
This PR removes the skip for some integration containerd shimv2 tests
as this is not longer a problem.

Fixes #4839

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>