### PR TITLE
tracing: Disable test qemu-devmapper job

### DIFF
--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -788,6 +788,11 @@ setup()
 		exit 0
 	}
 
+	[ "${CI_JOB:-}" = "CRI_CONTAINERD_K8S_DEVMAPPER" ] && {
+		info "Exiting to limit number of jobs that run tests related to tracing."
+		exit 0
+	}
+
 	"${SCRIPT_PATH}/../../.ci/install_rust.sh" && source "$HOME/.cargo/env"
 
 	trap cleanup EXIT

--- a/functional/tracing/tracing-test.sh
+++ b/functional/tracing/tracing-test.sh
@@ -421,6 +421,11 @@ main()
                 exit 0
         }
 
+	[ "${CI_JOB:-}" = "CRI_CONTAINERD_K8S_DEVMAPPER" ] && {
+		info "Exiting to limit number of jobs that run tests related to tracing."
+		exit 0
+	}
+
 	case "$cmd" in
 		clean) success="true"; cleanup; exit 0;;
 		help|-h|-help|--help) usage; exit 0;;


### PR DESCRIPTION
We do not need to run the tracing test on more than one CI job
(jenkins-ci-ubuntu-20-04), disable for additional job.

Fixes #4845

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>