### PR TITLE
tracing: Use a socat mirror

### DIFF
--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -726,7 +726,7 @@ install_socat()
 	# Required build dependency
 	sudo apt -y install yodl
 
-	local repo='git://repo.or.cz/socat'
+	local repo='https://github.com/3ndG4me/socat'
 
 	pushd "$tmpdir"
 


### PR DESCRIPTION
git://repo.or.cz/socat has been off for some time, let's switch to a
mirror maintained on GitHub and avoid our CI failing due to that.

Fixes: #4847

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>