### PR TITLE
tracing: Temporarily disable tests

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -58,8 +58,9 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
 		echo "INFO: Running kata-monitor test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
-		echo "INFO: Running tracing test"
-		sudo -E PATH="$PATH" bash -c "make tracing"
+		echo "INFO: Skiping tracing test and agent shutdown test: Issue: https://github.com/kata-containers/tests/issues/4847"
+		# echo "INFO: Running tracing test"
+		# sudo -E PATH="$PATH" bash -c "make tracing"
 		if [[ "${CI_JOB}" =~ CC_CRI_CONTAINERD ]]; then
 			echo "INFO: Running Confidential Container tests"
 			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"


### PR DESCRIPTION
Disable agent shutdown test and tracing test due to the socat repo being
down, which is affecting the CI. An attempt at using a mirror repo
failed because the version did not support VSOCK, which is required for
the agent shutdown test.

Fixes #4847

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>

I commented the relevant lines out following the format for the disable PMEM test.