### PR TITLE
ci: fix snap cli option

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -223,7 +223,7 @@ test_snap_build() {
 		sudo apt install -y snapcraft
 		[ ! -d "${katacontainers_repo_dir}" ] && go get -d "${katacontainers_repo}" || true
 		pushd "${katacontainers_repo_dir}"
-		sudo snapcraft -d snap --destructive-mode
+		sudo snapcraft snap --debug --destructive-mode
 		# PREFIX is changed in snap build, change it back
 		PREFIX=
 		popd


### PR DESCRIPTION
Change the snap command to use `--debug`
after the version change.

Fixes: #4851

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>