### PR TITLE
CI: Fix snap call in jenkins job build script

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -223,7 +223,7 @@ test_snap_build() {
 		sudo apt install -y snapcraft
 		[ ! -d "${katacontainers_repo_dir}" ] && go get -d "${katacontainers_repo}" || true
 		pushd "${katacontainers_repo_dir}"
-		sudo snapcraft -d snap --destructive-mode
+		sudo snapcraft snap --debug --destructive-mode
 		# PREFIX is changed in snap build, change it back
 		PREFIX=
 		popd


### PR DESCRIPTION
`snap`/`snapcraft` has changed its debug handling recently which is
causing the `.ci/jenkins_job_build.sh` script to fail in the CI:

```
=> Installing the Snapcraft snap
==> Checking connectivity with the snap store
==> Installing the Snapcraft snap for ubuntu-20.04
snapcraft 7.0.4 from Canonical[32m✓[0m installed
=> Snap installation complete
Unpacking snapcraft (3.0ubuntu1.1) ...
Setting up snapcraft (3.0ubuntu1.1) ...
~/workspace/kata-containers-2.0-ubuntu-s390x-PR/go/src/github.com/kata-containers/kata-containers ~/workspace/kata-containers-2.0-ubuntu-s390x-PR/go/src/github.com/kata-containers/kata-containers ~/workspace/kata-containers-2.0-ubuntu-s390x-PR/go/src/github.com/kata-containers/tests
Usage: snapcraft [options] command [args]...
Try 'snapcraft pack -h' for help.

Error: unrecognized arguments: -d

[jenkins_job_build.sh:226] ERROR: sudo snapcraft -d snap --destructive-mode
```

Fixes: #4855.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>