### PR TITLE
agent shutdown: tracing: Re-enable tests

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -58,9 +58,8 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make ksm"
 		echo "INFO: Running kata-monitor test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make monitor"
-		echo "INFO: Skiping tracing test and agent shutdown test: Issue: https://github.com/kata-containers/tests/issues/4847"
-		# echo "INFO: Running tracing test"
-		# sudo -E PATH="$PATH" bash -c "make tracing"
+		echo "INFO: Running tracing test"
+		sudo -E PATH="$PATH" bash -c "make tracing"
 		if [[ "${CI_JOB}" =~ CC_CRI_CONTAINERD ]]; then
 			echo "INFO: Running Confidential Container tests"
 			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make cc-containerd"


### PR DESCRIPTION
The socat repo is accessible again; re-enable agent shutdown and tracing
tests.

Fixes #4859

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>