### PR TITLE
CCv0: Kubernetes CC pod creation with encrypted image

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -118,6 +118,7 @@ case "${CI_JOB}" in
 				export SKOPEO=yes
 			fi
 			if [[ "${CI_JOB}" =~ K8S ]]; then
+				export AA_KBC="offline_fs_kbc"
 				export KUBERNETES=yes
 			fi
 			;;

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -49,7 +49,7 @@ build_rust_image() {
 			fi
 			distro="${osbuilder_distro:-ubuntu}"
 			if [ ${CCV0} == "yes" ]; then
-				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" UMOCI=yes make -e "image"
+				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" AA_KBC="${AA_KBC:-}" UMOCI=yes make -e "image"
 			else
 				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
 					make -e "${target_image}"

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,9 @@ cc-containerd:
 # Run the Confidential Containers tests for kubernetes.
 cc-kubernetes:
 	bash -f .ci/install_bats.sh
-	K8S_TEST_UNION="confidential/agent_image.bats" \
+	K8S_TEST_UNION="confidential/agent_image.bats confidential/agent_image_encrypted.bats" \
 	bash integration/kubernetes/run_kubernetes_tests.sh
-	
+
 log-parser:
 	make -C cmd/log-parser
 

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -9,22 +9,6 @@ load "${BATS_TEST_DIRNAME}/../../confidential/lib.sh"
 
 test_tag="[cc][agent][kubernetes][containerd]"
 
-# Currently the agent can only check images signature if using skopeo.
-# There isn't a way to probe the agent to determine if skopeo is present
-# or not, so we need to rely on build variables. If we are running under
-# CI then we assume the variables are properly exported, otherwise we
-# should skip testing.
-#
-skip_if_skopeo_not_present () {
-	if [ "${CI:-}" == "true" ]; then
-		if [ "${SKOPEO:-no}" == "no" ]; then
-			skip "Skopeo seems not installed in guest"
-		fi
-	else
-		skip "Cannot determine skopeo is installed in guest"
-	fi
-}
-
 # Create the test pod.
 #
 # Note: the global $sandbox_name, $pod_config should be set
@@ -44,14 +28,6 @@ create_test_pod() {
 	echo "Create the test sandbox"
 	echo "Pod config is: "$pod_config
 	kubernetes_create_cc_pod $pod_config
-}
-
-assert_pod_fail() {
-	local container_config="$1"
-	echo "In assert_pod_fail: "$container_config
-
-	echo "Attempt to create the container but it should fail"
-	! kubernetes_create_cc_pod "$container_config" || /bin/false
 }
 
 setup() {

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Copyright (c) 2022 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../confidential/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
+
+test_tag="[cc][agent][kubernetes][containerd]"
+
+setup() {
+    start_date=$(date +"%Y-%m-%d %H:%M:%S")
+
+    pod_id=$(kubectl get pods -o jsonpath='{.items..metadata.name}')
+    if [ -n ${pod_id} ]; then
+	    kubernetes_delete_ssh_demo_pod_if_exists "$pod_id"
+    fi
+    
+    echo "Prepare containerd for Confidential Container"
+    SAVED_CONTAINERD_CONF_FILE="/etc/containerd/config.toml.$$"
+    configure_cc_containerd "$SAVED_CONTAINERD_CONF_FILE"
+
+    echo "Reconfigure Kata Containers"
+    switch_image_service_offload on
+    clear_kernel_params
+}
+
+@test "$test_tag Test can pull an encrypted image inside the guest with decryption key" {
+    skip_if_skopeo_not_present 
+
+    setup_decryption_files_in_guest
+    kubernetes_create_ssh_demo_pod
+
+    local pod_ip_address=$(kubectl get service ccv0-ssh -o jsonpath="{.spec.clusterIP}")
+    ssh-keygen -lf <(ssh-keyscan ${pod_ip_address} 2>/dev/null)
+
+    ssh -i ${doc_repo_dir}/demos/ssh-demo/ccv0-ssh root@${pod_ip_address} -o StrictHostKeyChecking=accept-new exit
+}
+
+@test "$test_tag Test cannot pull an encrypted image inside the guest without decryption key" {
+    skip_if_skopeo_not_present 
+
+    checkout_doc_repo_dir
+    assert_pod_fail "k8s-cc-ssh.yaml" 
+}
+
+teardown() {
+    # Print the logs and cleanup resources.
+    echo "-- Kata logs:"
+    sudo journalctl -xe -t kata --since "$start_date"
+
+    # Allow to not destroy the environment if you are developing/debugging
+    # tests.
+    if [[ "${CI:-false}" == "false" && "${DEBUG:-}" == true ]]; then
+    	echo "Leaving changes and created resources untoughted"
+    	return
+    fi
+
+    pod_id=$(kubectl get pods -o jsonpath='{.items..metadata.name}')
+    kubernetes_delete_ssh_demo_pod_if_exists "$pod_id" || true
+
+    clear_kernel_params
+    switch_image_service_offload off
+    disable_full_debug
+}

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -11,6 +11,22 @@ set -e
 source "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
 FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures"
 
+# Currently the agent can only check images signature if using skopeo.
+# There isn't a way to probe the agent to determine if skopeo is present
+# or not, so we need to rely on build variables. If we are running under
+# CI then we assume the variables are properly exported, otherwise we
+# should skip testing.
+#
+skip_if_skopeo_not_present () {
+	if [ "${CI:-}" == "true" ]; then
+		if [ "${SKOPEO:-no}" == "no" ]; then
+			skip "Skopeo seems not installed in guest"
+		fi
+	else
+		skip "Cannot determine skopeo is installed in guest"
+	fi
+}
+
 # Delete the containers alongside the Pod.
 #
 # Parameters:
@@ -82,4 +98,64 @@ kubernetes_create_cc_pod() {
 #
 retrieve_sandbox_id() {
 	sandbox_id=$(ps -ef | grep containerd-shim-kata-v2 | egrep -o "id [^,][^,].* " | awk '{print $2}')
+}
+
+# Check out the doc repo if required
+checkout_doc_repo_dir() {
+    local doc_repo=github.com/confidential-containers/documentation
+    export doc_repo_dir="${GOPATH}/src/${doc_repo}"    
+    mkdir -p $(dirname ${doc_repo_dir}) && sudo chown -R ${USER}:${USER} $(dirname ${doc_repo_dir})
+    if [ ! -d "${doc_repo_dir}" ]; then
+        git clone https://${doc_repo} "${doc_repo_dir}"
+        # Update runtimeClassName from kata-cc to kata
+        sudo sed -i -e 's/\([[:blank:]]*runtimeClassName: \).*/\1kata/g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
+        chmod 600 ${doc_repo_dir}/demos/ssh-demo/ccv0-ssh
+    fi
+}
+
+kubernetes_create_ssh_demo_pod() {
+	checkout_doc_repo_dir
+	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --for=condition=ready pods/$pod
+	kubectl get pod $pod
+}
+
+connect_to_ssh_demo_pod() {
+	local doc_repo=github.com/confidential-containers/documentation
+	local doc_repo_dir="${GOPATH}/src/${doc_repo}"    
+	local ssh_command="ssh -i ${doc_repo_dir}/demos/ssh-demo/ccv0-ssh root@$(kubectl get service ccv0-ssh -o jsonpath="{.spec.clusterIP}")"
+	echo "Issuing command '${ssh_command}'"
+	${ssh_command}
+}
+
+kubernetes_delete_ssh_demo_pod_if_exists() {
+	local sandbox_name="$1"
+	if [ -n "$(kubectl get pods $sandbox_name)" ]; then
+		kubernetes_delete_ssh_demo_pod ${sandbox_name}
+	fi
+}
+
+kubernetes_delete_ssh_demo_pod() {
+	checkout_doc_repo_dir
+	kubectl delete -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
+	kubectl wait pod/$1 --for=delete --timeout=-30s
+}
+
+assert_pod_fail() {
+	local container_config="$1"
+	echo "In assert_pod_fail: "$container_config
+
+	echo "Attempt to create the container but it should fail"
+	! kubernetes_create_cc_pod "$container_config" || /bin/false
+}
+
+setup_decryption_files_in_guest() {
+    local rootfs_agent_config="/etc/agent-config.toml"
+    sudo -E AA_KBC_PARAMS="offline_fs_kbc::null" envsubst < ${katacontainers_repo_dir}/docs/how-to/data/confidential-agent-config.toml.in | sudo tee ${rootfs_agent_config}
+	
+    cp_to_guest_img "/tests/fixtures" "${rootfs_agent_config}"
+    add_kernel_params \
+	    "agent.config_file=/tests/fixtures/$(basename ${rootfs_agent_config})"
+
+    curl -Lo "${HOME}/aa-offline_fs_kbc-keys.json" https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+    cp_to_guest_img "etc" "${HOME}/aa-offline_fs_kbc-keys.json" 
 }


### PR DESCRIPTION
Add tests to pull an encrypted image and create a CC pod with Kubernetes

Fixes: #4685
Signed-off-by: Megan Wright <megan.wright@ibm.com>
Co-authored-by: Georgina Kinge <georgina.kinge@ibm.com>