### PR TITLE
CCv0: Add uid to the crictl pod-config yaml

### DIFF
--- a/functional/kata-monitor/run.sh
+++ b/functional/kata-monitor/run.sh
@@ -96,6 +96,7 @@ create_sandbox_json() {
 {
 	"metadata": {
 		"name": "nginx-$uid_name_suffix",
+		"uid": "$uid_name_suffix",
 		"namespace": "default",
 		"attempt": 1
 	},

--- a/integration/containerd/confidential/fixtures/pod-config.yaml.in
+++ b/integration/containerd/confidential/fixtures/pod-config.yaml.in
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 metadata:
-#  name: ${crictl_sandbox_name}
+  #  name: ${crictl_sandbox_name}
   name: kata-cc-busybox-sandbox
+  uid: ${UUIDGEN}
+  namespace: default
 dns_config:
   servers:
     - 8.8.8.8

--- a/integration/containerd/confidential/lib.sh
+++ b/integration/containerd/confidential/lib.sh
@@ -11,6 +11,18 @@ set -e
 source "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
 FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures"
 
+# Inject a unique id into the pod-config yaml template.
+#
+# Global variables exported:
+#	$pod_config          - path to default pod configuration file.
+#
+get_pod_config() {
+	if [ ! -f "${FIXTURES_DIR}/pod-config.yaml" ]; then
+    	sudo -E UUIDGEN="$(uuidgen)" envsubst < ${FIXTURES_DIR}/pod-config.yaml.in | sudo tee "${FIXTURES_DIR}/pod-config.yaml"
+	fi
+    export pod_config="${FIXTURES_DIR}/pod-config.yaml"
+}
+
 # Delete the containers alongside the Pod.
 #
 # Parameters:

--- a/integration/containerd/confidential/tests_common.sh
+++ b/integration/containerd/confidential/tests_common.sh
@@ -18,7 +18,7 @@ load "${BATS_TEST_DIRNAME}/../../confidential/lib.sh"
 setup_common() {
 	export test_start_time="$(date +"%Y-%m-%d %H:%M:%S")"
 	export sandbox_name="kata-cc-busybox-sandbox"
-	export pod_config="${FIXTURES_DIR}/pod-config.yaml"
+	get_pod_config
 
 	echo "Delete any existing ${sandbox_name} pod"
 	crictl_delete_cc_pod_if_exists "$sandbox_name"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -198,6 +198,8 @@ testContainerStart() {
 	cat << EOF > "${pod_yaml}"
 metadata:
   name: busybox-sandbox1
+  uid: $(uuidgen)
+  namespace: default
 EOF
 
 	#TestContainerSwap has created its own container_yaml.

--- a/integration/nydus/nydus-sandbox.yaml
+++ b/integration/nydus/nydus-sandbox.yaml
@@ -1,5 +1,6 @@
 metadata:
   attempt: 1
   name: nydus-sandbox
+  uid: nydus-uid
   namespace: default
 log_directory: /tmp

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -139,6 +139,8 @@ function setup() {
 
 function run_test() {
 	sudo -E crictl pull "${IMAGE}"
+	# Inject a unique id into pod sandbox
+	sudo sed -i "s/nydus-uid/$(uuidgen)/g" $dir_path/nydus-sandbox.yaml
 	pod=$(sudo -E crictl runp -r kata $dir_path/nydus-sandbox.yaml)
 	echo "Pod $pod created"
 	cnt=$(sudo -E crictl create $pod $dir_path/nydus-container.yaml $dir_path/nydus-sandbox.yaml)


### PR DESCRIPTION
CCv0: Add uid to the crictl pod-config yaml to fix the crictl 1.24.1 compatibility problems

Fixes: #4875 

Signed-off-by: stevenhorsman <steven@uk.ibm.com>