### PR TITLE
ci: Remove unused variable for KATA_OBS_REPO

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -56,8 +56,6 @@ tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 lib_script="${GOPATH}/src/${tests_repo}/lib/common.bash"
 source "${lib_script}"
 
-export KATA_OBS_REPO_BASE="http://download.opensuse.org/repositories/home:/katacontainers:/releases:/$(arch):/master"
-
 # Jenkins master URL
 jenkins_url="http://jenkins.katacontainers.io"
 # Path where cached artifacts are found.


### PR DESCRIPTION
This PR removes an unused variable for KATA_OBS_REPO which belonged
to a reference that we used in kata 1.x but not longer at kata 2.x

Fixes #4869

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>