### PR TITLE
metrics: Redirect output for FIO benchmark

### DIFF
--- a/metrics/storage/fio-k8s/cmd/fiotest/main.go
+++ b/metrics/storage/fio-k8s/cmd/fiotest/main.go
@@ -84,7 +84,7 @@ func (c fioTestConfig) run() (result fioResult, err error) {
 		}
 	}()
 
-	destDir := "/tmp/fio-jobs"
+	destDir := "/home/fio-jobs"
 	_, err = pod.Exec("mkdir " + destDir)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
This PR redirects the FIO output to /home directory instead of /tmp directory
to make sure we are not excercising memory.

Fixes #4886

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>