### PR TITLE
metrics: Enable cpu utilization with iperf3

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -88,6 +88,19 @@ maxpercent = 10.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container cpu utilization using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .cpu.Result"
+checktype = "mean"
+midval = 99.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "measure container jitter using iperf3"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall


### PR DESCRIPTION
This PR enables the cpu utilization when running the network metrics
using iperf3 benchmark.

Fixes #4889

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>