### PR TITLE
CC | confidential: Adjust switch_image_service_offload()

### DIFF
--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -29,11 +29,11 @@ switch_image_service_offload() {
 
 	case "$1" in
 		"on")
-			sudo sed -i -e 's/^# *\(service_offload\).*=.*$/\1 = true/g' \
+			sudo sed -i -e 's/^\(service_offload\).*=.*$/\1 = true/g' \
 				"$RUNTIME_CONFIG_PATH"
 			;;
 		"off")
-			sudo sed -i -e 's/^\(service_offload\).*=.*$/#\1 = false/g' \
+			sudo sed -i -e 's/^\(service_offload\).*=.*$/\1 = false/g' \
 				"$RUNTIME_CONFIG_PATH"
 
 			;;


### PR DESCRIPTION
Due to the changes introduced as part of
https://github.com/kata-containers/kata-containers/pull/4565, we should
adjust the regular expression used for switching the configuration on.

Fixes: #4894

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>