### PR TITLE
ci: set SEV TEE_TYPE

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -28,6 +28,10 @@ if [ "${TEE_TYPE:-}" == "tdx" ]; then
 	KATA_BUILD_QEMU_TYPE="${KATA_BUILD_QEMU_TYPE:-tdx}"
 fi
 
+if [ "${TEE_TYPE:-}" == "sev" ]; then
+	KATA_BUILD_KERNEL_TYPE=sev
+fi
+
 echo "Install Kata Containers Image"
 echo "rust image is default for Kata 2.0"
 "${cidir}/install_kata_image.sh" "${tag}"


### PR DESCRIPTION
SEV tests need kata to be configured based on the selected TEE TYPE. This change ensures that the correct kernel build is made based on previous functionality from #4838

Fixes: #4896

Signed-off-by: Alex Carter <alex.carter@ibm.com>