### PR TITLE
metrics: Add iperf3 parallel measurements

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -17,7 +17,7 @@ description = "measure container lifecycle timings"
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.60
-minpercent = 15.0
+minpercent = 25.0
 maxpercent = 15.0
 
 [[metric]]
@@ -101,6 +101,19 @@ maxpercent = 10.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container parallel bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
+checktype = "mean"
+midval = 50241301733.29
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "measure container jitter using iperf3"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
@@ -108,5 +121,5 @@ description = "measure container jitter using iperf3"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.023
-minpercent = 50.0
+minpercent = 60.0
 maxpercent = 40.0


### PR DESCRIPTION
This PR adds iperf3 parallel measurements which measures the
bandwidth of simultaneos connections make to the server.

Fixes #4899

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>