### PR TITLE
metrics: Create a common for kubernetes

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -62,7 +62,10 @@ run() {
 	bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 
 	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
+		start_kubernetes
 		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
+		end_kubernetes
+		check_processes
 	fi
 
 	popd

--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -18,6 +18,7 @@ DOCKER_EXE="${DOCKER_EXE:-docker}"
 CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+TEST_REPO="${TEST_REPO:-github.com/kata-containers/tests}"
 
 KSM_BASE="/sys/kernel/mm/ksm"
 KSM_ENABLE_FILE="${KSM_BASE}/run"
@@ -344,6 +345,20 @@ wait_ksm_settle(){
 		sleep 1
 	done
 	echo "Timed out after ${1}s waiting for KSM to settle"
+}
+
+function start_kubernetes() {
+	info "Start k8s"
+	pushd "${GOPATH}/src/${TEST_REPO}/integration/kubernetes"
+	bash ./init.sh
+	popd
+}
+
+function end_kubernetes() {
+	info "End k8s"
+	pushd "${GOPATH}/src/${TEST_REPO}/integration/kubernetes"
+	bash ./cleanup_env.sh
+	popd
 }
 
 common_init


### PR DESCRIPTION
This PR adds the start and end kubernetes functions to the common script
for metrics as these functions will be used in other metrics benchmarks
that will use kubernetes.

Fixes #4904

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>