### PR TITLE
metrics: Enable cassandra benchmark in metrics CI

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -64,6 +64,7 @@ run() {
 	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
 		start_kubernetes
 		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
+		bash disk/cassandra_kubernetes/cassandra.sh
 		end_kubernetes
 		check_processes
 	fi

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -73,6 +73,58 @@ minpercent = 10.0
 maxpercent = 10.0
 
 [[metric]]
+name = "cassandra"
+type = "json"
+description = "measure write op rate with cassandra"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"cassandra\".Results | .[] | .Write-Op-rate.Result"
+checktype = "mean"
+midval = 9293.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "cassandra"
+type = "json"
+description = "measure latency mean with cassandra"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"cassandra\".Results | .[] | .Write-Latency-Mean.Result"
+checktype = "mean"
+midval = 21.4
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "cassandra"
+type = "json"
+description = "measure read op rate with cassandra"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"cassandra\".Results | .[] | .Read-Op-rate.Result"
+checktype = "mean"
+midval = 6135.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
+name = "cassandra"
+type = "json"
+description = "measure read latency mean with cassandra"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"cassandra\".Results | .[] | .Read-Latency-Mean.Result"
+checktype = "mean"
+midval = 8.0
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "measure container bandwidth using iperf3"


### PR DESCRIPTION
This PR enables the cassandra benchmark with kubernetes in our
metrics kata CI.

Fixes #4911

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>