### PR TITLE
ci: change commit body line limit from 72 to 150

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -73,8 +73,8 @@ jobs:
         #
         # - A SoB comment can be any length (as it is unreasonable to penalise
         #   people with long names/email addresses :)
-        pattern: '^.+(\n([a-zA-Z].{0,72}|[^a-zA-Z\n].*|[^\s\n]*|Signed-off-by:.*|))+$'
-        error: 'Body line too long (max 72)'
+        pattern: '^.+(\n([a-zA-Z].{0,150}|[^a-zA-Z\n].*|[^\s\n]*|Signed-off-by:.*|))+$'
+        error: 'Body line too long (max 150)'
         post_error: ${{ env.error_msg }}
 
     - name: Check Fixes


### PR DESCRIPTION
When this github action was ported over from kata-containers, I changed
the body length limit to 72 to match the community contribution
documentation. However, in the kata-containers repo it was changed back
to 150 after 72 was decided to be too short.

The community contribution documentation is being changed to 150, so
this should be changed to be consistent.

Fixes #4913

Signed-of-by: Derek Lee <derlee@redhat.com>