### PR TITLE
spell-check: Add 'rustlang' to spell check dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -74,6 +74,8 @@ R/B
 rkt/B/B
 runc/B
 runV/B
+rustlang/B
+Rustlang/B
 SELinux/B
 SemaphoreCI/B
 snapcraft/B


### PR DESCRIPTION
Noticed CONTRIBUTING.md in the community repo was not passing spell
check due to "rustlang". "golang" is already in the dict, so added
"rustlang" to projects.txt dictionary.

Fixes #4917

Signed-off-by: Derek Lee <derlee@redhat.com>