### PR TITLE
Dragonball: add dragonball to check-spelling dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -17,6 +17,7 @@ DevStack/B
 Django/B
 Docker/B
 dracut/B
+Dragonball/B
 Facebook/B
 fio/B
 Fluentd/B


### PR DESCRIPTION
We need to add Dragonball to spell check dict so that Kata CI could be
familar with Dragonball :)

Fixes: #4923

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>