### PR TITLE
metrics: Support sync engine configuration for FIO tests

### DIFF
--- a/metrics/storage/fio-k8s/configs/example-config/fio-jobs/randrw-sync.job
+++ b/metrics/storage/fio-k8s/configs/example-config/fio-jobs/randrw-sync.job
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Intel Corporation
+[global]
+name=sync
+filename=fio-file
+rw=randrw
+rwmixread=75
+ioengine=sync
+
+[randrw-sync]


### PR DESCRIPTION
This PR adds the support for sync engine configuration to gathered synchronous
FIO test results.

Fixes #4930

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>