### PR TITLE
ci: Remove duplicated kubernetes flag

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -97,7 +97,6 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="no"
 	;;
 "CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CC_CRI_CONTAINERD")
 	# This job only tests containerd + k8s
@@ -208,7 +207,6 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	export KUBERNETES="no"
 	;;
 "VIRTIOFS_EXPERIMENTAL")
 	init_ci_flags


### PR DESCRIPTION
This PR removes a duplicated kubernetes flag as by default the CI
will not install or test any kubernetes feature.

Fixes #4933

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>