### PR TITLE
ci: Add generic user agent to check_url

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -492,8 +492,9 @@ check_url()
 	local invalid_file=$(printf "%s/%d" "$invalid_urls_dir" "$$")
 
 	local ret
+	local user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
 
-	{ curl -sIL -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
+	{ curl -sIL -A "$user_agent" -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
 		--retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
 
 	# A transitory error, or the URL is incorrect,


### PR DESCRIPTION
~~Adds a user agent of '/' to the check_url curl.~~

https://amd.com has a denylist for certain user-agents including the
lack of a user-agent

'/' is the shortest string that gets past the denylist

~~To avoid being non-generic, I opted not to use any real user-agent.
In other projects, 'curl' is used as the user-agent, however, this is
denylisted by amd.com.~~

The denylist also seems to keep a running list of browser versions it
finds acceptable if the browser is mentioned (i.e.the string
Firefox/71.0 works if it is in the user-agent, but not Firefox/ or
Firefox/70.0. ~~Because of this, I opted not to include any real browsers.~~

~~As far as I can tell from the issue the only site that the project had
problems with was https://amd.com, which does not currently denylist
just '/'. I did not see '/' in any of the publicly available denylists
I looked at.~~

Further thought may need to be put into this if other websites we add
have different filtering parameters.

Fixes #4401

Signed-off-by: Derek Lee <derlee@redhat.com>