### PR TITLE
k8s: Add an integration test for checking process leak

### DIFF
--- a/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2022 AntGroup Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	pod_name="busybox"
+	first_container_name="first-test-container"
+
+	get_pod_config_dir
+}
+
+@test "Check PID namespaces" {
+	# Create the pod
+	kubectl create -f "${pod_config_dir}/initcontainer-shareprocesspid.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+
+	# Check PID from first container
+	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \
+		-- ps | grep "tail" || true)
+	# Verify that the tail process didn't exist
+	[ -z $first_pid_container ] || die "found processes pid: $first_pid_container" 
+}
+
+teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+}

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -34,6 +34,7 @@ else
 	"k8s-expose-ip.bats" \
 	"k8s-inotify.bats" \
 	"k8s-job.bats" \
+	"k8s-kill-all-process-in-container.bats" \
 	"k8s-limit-range.bats" \
 	"k8s-liveness-probes.bats" \
 	"k8s-memory.bats" \

--- a/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
+++ b/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 AntGroup Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  terminationGracePeriodSeconds: 0
+  shareProcessNamespace: true
+  runtimeClassName: kata
+  initContainers:
+  - name: first
+    image: quay.io/prometheus/busybox:latest
+    command: [ "sh", "-c", "echo 'nohup tail -f /dev/null  >/dev/null 2>&1 &' > /init.sh && chmod +x /init.sh && /init.sh" ]
+  containers:
+  - name: first-test-container
+    image: quay.io/prometheus/busybox:latest
+    env:
+    - name: CONTAINER_NAME
+      value: "first-test-container"
+    command:
+        - sleep
+        - "300"


### PR DESCRIPTION
When a container terminated in shared process pidns pod,
we should check whether all of the processes especially the
daemon process created in a container had terminated.

Fixes: #4936

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>