### PR TITLE
versions: Update nginx version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -18,7 +18,7 @@ docker_images:
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     url: "https://hub.docker.com/_/nginx/"
-    version: "1.15-alpine"
+    version: "1.17-alpine"
 
   registry:
     description: "Registry component for x86_64 and ARM"


### PR DESCRIPTION
This PR updates the nginx version that we are using for our tests in
the kata CI.

Fixes #4940

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>