### PR TITLE
metrics: Add asynchronous job FIO configuration

### DIFF
--- a/metrics/storage/fio-k8s/configs/example-config/fio-jobs/randrw-async.job
+++ b/metrics/storage/fio-k8s/configs/example-config/fio-jobs/randrw-async.job
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Intel Corporation
+[global]
+name=io_uring
+filename=fio-file
+rw=randrw
+rwmixread=75
+ioengine=io_uring
+
+[randrw-io_uring]


### PR DESCRIPTION
This PR adds the asynchronous job FIO configuration using as
an engine io_uring.

Fixes #4945

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>