### PR TITLE
tests: Skip nydus integration test

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -39,8 +39,9 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
 	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER"|"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
-		echo "INFO: Running nydus test"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
+		 echo "INFO: Skipping nydus test: Issue: https://github.com/kata-containers/tests/issues/4947"
+		#echo "INFO: Running nydus test"
+		#sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"


### PR DESCRIPTION
This PR skips the nydus integration test to allow unblock the kata CI
until the issue is resolved.

Fixes #4948

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>