### PR TITLE
makefile: Add rule for fio test for kata CI

### DIFF
--- a/metrics/storage/fio-k8s/Makefile
+++ b/metrics/storage/fio-k8s/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Intel Corporation
+# Copyright (c) 2021-2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,3 +23,6 @@ test: build
 
 run: build
 	make -C $(MKFILE_DIR)/scripts/dax-compare-test/ run
+
+test-ci:
+	make -C $(MKFILE_DIR)/cmd/fiotest/ runci

--- a/metrics/storage/fio-k8s/cmd/fiotest/Makefile
+++ b/metrics/storage/fio-k8s/cmd/fiotest/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Intel Corporation
+# Copyright (c) 2021-2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,3 +19,6 @@ gomod:
 	 go mod edit -replace=github.com/kata-containers/tests/metrics/exec=../../pkg/exec
 	 go mod edit -replace=github.com/kata-containers/tests/metrics/env=../../pkg/env
 	 go mod tidy
+
+runci: build
+	$(MKFILE_DIR)/fio-k8s --debug --fio.size 10M --output-dir test-results --test-name kata $(MKFILE_DIR)/../../configs/example-config/


### PR DESCRIPTION
This PR will add a new rule that will help us to run the FIO test
in the metrics kata CI.

Fixes #4950

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>