### PR TITLE
ci: install rust for runtime-rs

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -61,6 +61,7 @@ build_install_shim_v2(){
 	sudo -E PATH=$PATH make install
 	popd
 	if [ "$KATA_HYPERVISOR" == "dragonball" ]; then
+		bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
 		pushd "$runtime_rs_src_path"
 		make
 		sudo -E PATH=$PATH make install


### PR DESCRIPTION
When hypervisor is dragonball, it will compile runtime-rs with cargo.
So need to install rust environment first.

Signed-off-by: yqleng <yqleng@linux.alibaba.com>