### PR TITLE
ci: add sudo when compile runtime-rs and enable k8s-seccomp.bats

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -63,7 +63,7 @@ build_install_shim_v2(){
 	if [ "$KATA_HYPERVISOR" == "dragonball" ]; then
 		bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
 		pushd "$runtime_rs_src_path"
-		make
+		sudo -E PATH=$PATH make
 		sudo -E PATH=$PATH make install
 		popd
 	fi

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -61,7 +61,7 @@ else
 	# TODO: runtime-rs doesn't support the following test cases, and will be fixed/improved in the future:
 	# k8s-block-volume.bats, k8s-copy-file.bats, k8s-cpu-ns.bats, k8s-empty-dirs.bats, k8s-expose-ip.bats,
 	# k8s-hugepages.bats, k8s-inotify.bats, k8s-liveness-probes.bats, k8s-nginx-connectivity.bats,
-	# k8s-pid-ns.bats, k8s-ro-volume.bats, k8s-seccomp.bats
+	# k8s-pid-ns.bats, k8s-ro-volume.bats
 	if [ "$KATA_HYPERVISOR" == "dragonball" ]; then
                 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
                 "k8s-caps.bats" \
@@ -85,6 +85,7 @@ else
                 "k8s-qos-pods.bats" \
                 "k8s-replication.bats" \
                 "k8s-scale-nginx.bats" \
+		"k8s-seccomp.bats" \
                 "k8s-sysctls.bats" \
                 "k8s-security-context.bats" \
                 "k8s-shared-volume.bats" \


### PR DESCRIPTION
add sudo when compile runtime-rs and enable the case: k8s-seccomp.bats
because it's already fixed: https://github.com/kata-containers/kata-containers/pull/4692

Signed-off-by: yqleng <yqleng@linux.alibaba.com>