### PR TITLE
ci: check if VC_POD_DIR exists before checking the files in VC_POD_DIR

### DIFF
--- a/stability/soak_parallel_rm.sh
+++ b/stability/soak_parallel_rm.sh
@@ -90,11 +90,13 @@ check_all_running() {
 
 		# if this is kata-runtime, check how many pods virtcontainers thinks we have
 		if [[ "$RUNTIME" == "containerd-shim-kata-v2" ]]; then
-			num_vc_pods=$(sudo ls -1 ${VC_POD_DIR} | wc -l)
+			if [ -d "${VC_POD_DIR}" ]; then
+				num_vc_pods=$(sudo ls -1 ${VC_POD_DIR} | wc -l)
 
-			if (( ${how_many_running} != ${num_vc_pods} )); then
-				echo "Wrong number of pods in $VC_POD_DIR (${how_many_running} != ${num_vc_pods}) - stopping)"
-				((goterror++))
+				if (( ${how_many_running} != ${num_vc_pods} )); then
+					echo "Wrong number of pods in $VC_POD_DIR (${how_many_running} != ${num_vc_pods}) - stopping)"
+					((goterror++))
+				fi
 			fi
 		fi
 	fi


### PR DESCRIPTION
The case 'soak_parallel_rm.sh' will check the files in VC_POD_DIR.
However, for a brand new test machine, the path VC_POD_DIR doesn't
exist.

Signed-off-by: yqleng <yqleng@linux.alibaba.com>