### PR TITLE
metrics: Increase boot time value for qemu

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -16,9 +16,9 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.60
+midval = 0.69
 minpercent = 20.0
-maxpercent = 10.0
+maxpercent = 20.0
 
 [[metric]]
 name = "memory-footprint"


### PR DESCRIPTION
This PR increases the boot time value for qemu as it seems that
adding liburing to build qemu does that.

Fixes #4963
Depends-on: github.com/kata-containers/kata-containers#4646

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>