### PR TITLE
fc: fix uncompressed dir path

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -32,8 +32,8 @@ install_fc() {
 	jailer_binary="jailer-${firecracker_version}-${arch}"
 	curl -fsL ${firecracker_repo}/releases/download/${firecracker_version}/${firecracker_binary}.tgz -o ${firecracker_binary}.tgz
 	tar -zxf ${firecracker_binary}.tgz
-	firecracker_binary_fullpath=release-${firecracker_version}/${firecracker_binary}
-	jailer_binary_fullpath=release-${firecracker_version}/${jailer_binary}
+	firecracker_binary_fullpath=release-${firecracker_version}-${arch}/${firecracker_binary}
+	jailer_binary_fullpath=release-${firecracker_version}-${arch}/${jailer_binary}
 	sudo -E install -m 0755 -D ${firecracker_binary_fullpath} /usr/bin/firecracker
 	sudo -E install -m 0755 -D ${jailer_binary_fullpath} /usr/bin/jailer
 }


### PR DESCRIPTION
In the latest FC releases, the asset we download and decompress has the following syntax:

release-vX.X.X-ARCH/firecracker-vX.X.X-ARCH

until v0.25 there was no ARCH in the folder name. Since we are updating the supported FC version, this patch fixes the script that installs the firecracker binary and the jailer.

Depends-on: github.com/kata-containers/kata-containers#4735
Fixes: #4967

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>