### PR TITLE
test: Add a exec test case for terminated successfully

### DIFF
--- a/integration/kubernetes/k8s-exec.bats
+++ b/integration/kubernetes/k8s-exec.bats
@@ -30,6 +30,10 @@ setup() {
 	# kubectl exec -it "$pod_name" -- ls -tl /
 	kubectl exec "$pod_name" -- date
 
+	# Test if the exec cmd exit successfully when the exec's stdout/stderr
+	# didn't closed.
+	kubectl exec "$pod_name" -- sh -c 'tail -f /dev/null &'
+
 	## Case for stdin
 	kubectl exec -i "$pod_name" -- sh <<-EOF
 echo abc > /tmp/abc.txt


### PR DESCRIPTION
When an exec forked some daemon process which would inherit
its stdio fds, thus when the exec main process exited, its
io stream wouldn't terminated, even at this case, we should
make sure the exec terminated successfully without hang there.

Fixes: #4972

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>