### PR TITLE
ci: Remove duplicated kubernetes flag

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -182,7 +182,6 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
-	export KUBERNETES="no"
 	;;
 "EXTERNAL_CRIO")
 	init_ci_flags


### PR DESCRIPTION
This PR removes a duplicated kubernetes flag as by default
kubernetes is being set to no.

Fixes #4974

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>