### PR TITLE
metrics: Enable FIO read tests

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -64,6 +64,7 @@ run() {
 	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
 		start_kubernetes
 		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
+		bash storage/fio-k8s/fio-test-ci.sh
 		end_kubernetes
 		check_processes
 	fi

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -18,7 +18,7 @@ checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
 midval = 0.60
 minpercent = 25.0
-maxpercent = 15.0
+maxpercent = 25.0
 
 [[metric]]
 name = "memory-footprint"
@@ -73,6 +73,32 @@ minpercent = 10.0
 maxpercent = 10.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure read-io using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .readio.Result"
+checktype = "mean"
+midval = 7811072.0
+minpercent = 20.0
+maxpercent = 10.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure read-bw using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .readbw.Result"
+checktype = "mean"
+midval = 88479751.0
+minpercent = 25.0
+maxpercent = 10.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "measure container bandwidth using iperf3"
@@ -122,4 +148,4 @@ checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.023
 minpercent = 60.0
-maxpercent = 40.0
+maxpercent = 50.0

--- a/metrics/storage/fio-k8s/Makefile
+++ b/metrics/storage/fio-k8s/Makefile
@@ -24,5 +24,5 @@ test: build
 run: build
 	make -C $(MKFILE_DIR)/scripts/dax-compare-test/ run
 
-test-ci:
+test-ci: build
 	make -C $(MKFILE_DIR)/cmd/fiotest/ runci

--- a/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -x
+set -e
 
 # General env
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
@@ -28,7 +28,7 @@ function main() {
 
 	pushd "${FIO_PATH}"
 		echo "INFO: Running K8S FIO test"
-		sudo -E make test-ci
+		make test-ci
 	popd
 
 	test_result_file="${FIO_PATH}/cmd/fiotest/test-results/kata/randrw-sync.job/output.json"
@@ -40,11 +40,11 @@ function main() {
 	metrics_json_start_array
 	local json="$(cat << EOF
 	{
-		"read-io": {
+		"readio": {
 			"Result" : $read_io,
 			"Units" : "bytes"
 		},
-		"read-bw": {
+		"readbw": {
 			"Result" : $read_bw,
 			"Units" : "bytes/sec"
 		}


### PR DESCRIPTION
This PR enables FIO read tests to be measured at our kata metrics CI.

Fixes #4981

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>