### PR TITLE
metrics: Enable read percentile fio metrics

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -112,6 +112,32 @@ minpercent = 10.0
 maxpercent = 10.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure read 90 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .read90percentile.Result"
+checktype = "mean"
+midval = 56668.0
+minpercent = 50.0
+maxpercent = 50.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure read 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .read95percentile.Result"
+checktype = "mean"
+midval = 84454.0
+minpercent = 50.0
+maxpercent = 50.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "measure container cpu utilization using iperf3"

--- a/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -36,6 +36,8 @@ function main() {
 	metrics_json_init
 	local read_io=$(cat $test_result_file | grep io_bytes | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local read_bw=$(cat $test_result_file | grep bw_bytes | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+ 	local read_90_percentile=$(cat $test_result_file | grep 90.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local read_95_percentile=$(cat $test_result_file | grep 95.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 
 	metrics_json_start_array
 	local json="$(cat << EOF
@@ -47,6 +49,14 @@ function main() {
 		"readbw": {
 			"Result" : $read_bw,
 			"Units" : "bytes/sec"
+		},
+		"read90percentile": {
+			"Result" : $read_90_percentile,
+			"Units" : "ns"
+		},
+		"read95percentile": {
+			"Result" : $read_95_percentile,
+			"Units" : "ns"
 		}
 	}
 EOF


### PR DESCRIPTION
This PR enables the 90, 95 and 99 read percentile FIO metrics in
our kata metrics CI.

Fixes #4989

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>