### PR TITLE
metrics: Enable latency network measurement

### DIFF
--- a/.ci/run_metrics_PR_ci.sh
+++ b/.ci/run_metrics_PR_ci.sh
@@ -63,6 +63,7 @@ run() {
 
 	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
 		start_kubernetes
+		bash network/latency_kubernetes/latency-network.sh
 		bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
 		bash storage/fio-k8s/fio-test-ci.sh
 		end_kubernetes

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -47,6 +47,19 @@ minpercent = 5.0
 maxpercent = 5.0
 
 [[metric]]
+name = "latency"
+type = "json"
+description = "measure network latency"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"latency\".Results | .[] | .latency.Result"
+checktype = "mean"
+midval = 0.73
+minpercent = 10.0
+maxpercent = 10.0
+
+[[metric]]
 name = "blogbench"
 type = "json"
 description = "measure container average of blogbench write"


### PR DESCRIPTION
This PR enables the latency network measurements in our kata metrics
CI.

Fixes #4993

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>