### PR TITLE
common: Improve ctr cleanup

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -234,6 +234,7 @@ clean_env_ctr()
 	for i in "${containers[@]}"; do
 		task="$(sudo ctr task ls | grep -E "\<${i}\>" | cut -f1 -d" " || true)"
 		[ -n "${task}" ] && sudo ctr task kill "${task}"
+		[ -n "${task}" ] && sudo ctr tasks kill -s SIGKILL "${task}"
 	done
 
 	# do not stop if the command fails, it will be evaluated by waitForProcess


### PR DESCRIPTION
This PR improves the ctr cleanup function as it was seen than when we
are using RunC the current cleanup is not able to delete properly
the containers as we got an error saying that we can't delet
non stopped containers. This PR fixes that issue as it was tested
both on RunC and Kata and is working properly.

Fixes #4995

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>