### PR TITLE
metrics: delete space in command string

### DIFF
--- a/metrics/storage/fio-k8s/pkg/k8s/k8s.go
+++ b/metrics/storage/fio-k8s/pkg/k8s/k8s.go
@@ -52,7 +52,7 @@ func (p *Pod) Run() (err error) {
 
 func (p *Pod) Delete() (err error) {
 	log.Debugf("Delete pod %s", p.YamlPath)
-	_, err = exec.ExecCmd(" kubectl delete --ignore-not-found -f "+p.YamlPath, Debug)
+	_, err = exec.ExecCmd("kubectl delete --ignore-not-found -f "+p.YamlPath, Debug)
 	return errors.Wrapf(err, "Failed to delete pod %s", p.YamlPath)
 }
 


### PR DESCRIPTION
Delete the prefix space when calling external command.

Fixes: #4998

Signed-off-by: Bin Liu <bin@hyper.sh>