### PR TITLE
metrics: Delete iperf3 server and client pods

### DIFF
--- a/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -226,6 +226,7 @@ function iperf3_start_deployment() {
 }
 
 function iperf3_deployment_cleanup() {
+	kubectl delete pod "$server_pod_name" "$client_pod_name"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
 	if [ -z "${CI_JOB}" ]; then


### PR DESCRIPTION
This PR deletes the iperf3 server and client pods in
order to leave properly clean the environment after
running the network iperf3 tests.

Fixes #5000

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>