### PR TITLE
metrics: Use clean_env_ctr function in memory script

### DIFF
--- a/metrics/density/memory_usage.sh
+++ b/metrics/density/memory_usage.sh
@@ -346,8 +346,7 @@ EOF
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
 
-	${CTR_EXE} t rm -f ${containers[@]}
-	${CTR_EXE} c rm ${containers[@]}
+	clean_env_ctr
 }
 
 save_config(){


### PR DESCRIPTION
This PR uses the clean_env_ctr function that is being implemented
in the common.sh script to make uniform its used across the scripts.

Fixes #5003

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>