### PR TITLE
metrics: Enable write io and bw for FIO metrics

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -56,7 +56,7 @@ description = "measure network latency"
 checkvar = ".\"latency\".Results | .[] | .latency.Result"
 checktype = "mean"
 midval = 0.73
-minpercent = 10.0
+minpercent = 20.0
 maxpercent = 10.0
 
 [[metric]]
@@ -96,7 +96,7 @@ checkvar = ".\"fio\".Results | .[] | .readio.Result"
 checktype = "mean"
 midval = 7811072.0
 minpercent = 20.0
-maxpercent = 10.0
+maxpercent = 20.0
 
 [[metric]]
 name = "fio"
@@ -109,7 +109,34 @@ checkvar = ".\"fio\".Results | .[] | .readbw.Result"
 checktype = "mean"
 midval = 88479751.0
 minpercent = 25.0
+maxpercent = 25.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure write-io using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .writeio.Result"
+checktype = "mean"
+midval = 2674688.0
+minpercent = 20.0
 maxpercent = 10.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure write-bw using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .writebw.Result"
+checktype = "mean"
+midval = 35543338.0
+minpercent = 40.0
+maxpercent = 30.0
+
 
 [[metric]]
 name = "network-iperf3"
@@ -135,7 +162,7 @@ checkvar = ".\"fio\".Results | .[] | .read90percentile.Result"
 checktype = "mean"
 midval = 56668.0
 minpercent = 50.0
-maxpercent = 50.0
+maxpercent = 60.0
 
 [[metric]]
 name = "fio"
@@ -148,7 +175,7 @@ checkvar = ".\"fio\".Results | .[] | .read95percentile.Result"
 checktype = "mean"
 midval = 84454.0
 minpercent = 50.0
-maxpercent = 50.0
+maxpercent = 60.0
 
 [[metric]]
 name = "network-iperf3"

--- a/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -38,6 +38,8 @@ function main() {
 	local read_bw=$(cat $test_result_file | grep bw_bytes | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
  	local read_90_percentile=$(cat $test_result_file | grep 90.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local read_95_percentile=$(cat $test_result_file | grep 95.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local write_io=$(cat $test_result_file | grep io_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local write_bw=$(cat $test_result_file | grep bw_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 
 	metrics_json_start_array
 	local json="$(cat << EOF
@@ -57,6 +59,14 @@ function main() {
 		"read95percentile": {
 			"Result" : $read_95_percentile,
 			"Units" : "ns"
+		},
+		"writeio": {
+			"Result" : $write_io,
+			"Units" : "bytes"
+		},
+		"writebw": {
+			"Result" : $write_bw,
+			"Units" : "bytes/sec"
 		}
 	}
 EOF


### PR DESCRIPTION
This PR enables the write io and bw using FIO to collect this
data in our kata CI.

Fixes #5005

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>