### PR TITLE
runk: add tests for `pause`/`resume` commands

### DIFF
--- a/integration/containerd/runk/runk-tests.sh
+++ b/integration/containerd/runk/runk-tests.sh
@@ -23,12 +23,7 @@ RUNK_BIN_PATH="/usr/local/bin/runk"
 TEST_IMAGE="docker.io/library/busybox:latest"
 CONTAINER_ID="id1"
 PID_FILE="${CONTAINER_ID}.pid"
-
-# runk can't work well on cgroup V2 environment now, so we temporarily skip this test
-if [ $(stat -f --format %T /sys/fs/cgroup) == "cgroup2fs" ]; then
-    echo "runk can't work well on cgroup V2 environment now, so we temporarily skip this test"
-    exit 0
-fi
+WORK_DIR="$(mktemp -d --tmpdir runk.XXXXX)"
 
 setup() {
     # can't find cargo when make runk below, so we install rust to make runk build correctly
@@ -49,7 +44,8 @@ install_runk() {
 
 test_runk() {
     echo "start container with runk"
-    sudo ctr run --pid-file ${PID_FILE} --rm -d --runc-binary ${RUNK_BIN_PATH} ${TEST_IMAGE} ${CONTAINER_ID}
+    # Bind mount ${WORK_DIR}:/tmp. Tests below will store files in this dir and check them when container is frozon.
+    sudo ctr run --pid-file ${PID_FILE} --rm -d --runc-binary ${RUNK_BIN_PATH} --mount type=bind,src=${WORK_DIR},dst=/tmp,options=rbind:rw ${TEST_IMAGE} ${CONTAINER_ID}
     read CID PID STATUS <<< $(sudo ctr t ls | grep ${CONTAINER_ID})
     [ ${PID} == $(cat ${PID_FILE}) ] || die "pid is not consistent"
     [ ${STATUS} == "RUNNING" ] || die "contianer status is not RUNNING"
@@ -62,6 +58,28 @@ test_runk() {
     sudo ctr t exec --detach --exec-id id1 ${CONTAINER_ID} sh
     # one line is the titles, and the other 2 lines are porcess info
     [ "3" == "$(sudo ctr t ps ${CONTAINER_ID} | wc -l)" ] || die "ps command failed"
+
+    echo "test pause and resume"
+    # The process outputs lines into /tmp/{CONTAINER_ID}, which can be read in host when it's frozon.
+    sudo ctr t exec --detach --exec-id id2 ${CONTAINER_ID} sh -c "while true; do echo hello >> /tmp/${CONTAINER_ID}; sleep 0.1; done"
+    # sleep for 1s to make sure the process outputs some lines
+    sleep 1
+    sudo ctr t pause ${CONTAINER_ID}
+    [ "PAUSED" == "$(sudo ctr t ls | grep ${CONTAINER_ID} | grep -o PAUSED)" ] || die "status is not PAUSED"
+    echo "container is paused"
+    local TMP_FILE="${WORK_DIR}/${CONTAINER_ID}"
+    local lines1=$(cat ${TMP_FILE} | wc -l)
+    # sleep for a while and check the lines are not changed.
+    sleep 1
+    local lines2=$(cat ${TMP_FILE} | wc -l)
+    [ ${lines1} == ${lines2} ] || die "paused container is still running"
+    sudo ctr t resume ${CONTAINER_ID}
+    [ "RUNNING" == "$(sudo ctr t ls | grep ${CONTAINER_ID} | grep -o RUNNING)" ] || die "status is not RUNNING"
+    echo "container is resumed"
+    # sleep for a while and check the lines are changed.
+    sleep 1
+    local lines3=$(cat ${TMP_FILE} | wc -l)
+    [ ${lines2} -lt ${lines3} ] || die "resumed container is not running"
 
     echo "kill the container and poll until it is stopped"
     sudo ctr t kill --signal SIGKILL --all ${CONTAINER_ID}
@@ -79,6 +97,7 @@ test_runk() {
 
 clean_up() {
     rm -f ${PID_FILE}
+    rm -rf ${WORK_DIR}
 }
 
 setup


### PR DESCRIPTION
Add test cases for `pause`/`resume` commands. It should work well on
both cgroup v1 and v2 environment. Exec a process which produces
massages into a file, pause it and check messages are not produced
anymore. Then resume it, and check whether messages are produced again.

Depends-on: github.com/kata-containers/kata-containers#4870

Fixes: #5014

Signed-off-by: Chen Yiyang <cyyzero@qq.com>