### PR TITLE
metrics: Enable write FIO percentiles

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -73,6 +73,32 @@ minpercent = 10.0
 maxpercent = 10.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure write 90 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
+checktype = "mean"
+midval = 80384.0
+minpercent = 50.0
+maxpercent = 50.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure write 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
+checktype = "mean"
+midval = 84480.0
+minpercent = 50.0
+maxpercent = 50.0
+
+[[metric]]
 name = "blogbench"
 type = "json"
 description = "measure container average of blogbench read"

--- a/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -40,6 +40,8 @@ function main() {
 	local read_95_percentile=$(cat $test_result_file | grep 95.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local write_io=$(cat $test_result_file | grep io_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local write_bw=$(cat $test_result_file | grep bw_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local write_90_percentile=$(cat $test_result_file | grep 90.000000 | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local write_95_percentile=$(cat $test_result_file | grep 95.000000 | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 
 	metrics_json_start_array
 	local json="$(cat << EOF
@@ -67,6 +69,14 @@ function main() {
 		"writebw": {
 			"Result" : $write_bw,
 			"Units" : "bytes/sec"
+		},
+		"write90percentile": {
+			"Result" : $write_90_percentile,
+			"Units" : "ns"
+		},
+		"write95percentile": {
+			"Result" : $write_95_percentile,
+			"Units" : "ns"
 		}
 	}
 EOF


### PR DESCRIPTION
This PR enables write FIO percentiles in our kata metrics CI.

Fixes #5018

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>