### PR TITLE
fc: fix uncompressed dir path

### DIFF
--- a/.ci/install_firecracker.sh
+++ b/.ci/install_firecracker.sh
@@ -32,8 +32,8 @@ install_fc() {
 	jailer_binary="jailer-${firecracker_version}-${arch}"
 	curl -fsL ${firecracker_repo}/releases/download/${firecracker_version}/${firecracker_binary}.tgz -o ${firecracker_binary}.tgz
 	tar -zxf ${firecracker_binary}.tgz
-	firecracker_binary_fullpath=release-${firecracker_version}/${firecracker_binary}
-	jailer_binary_fullpath=release-${firecracker_version}/${jailer_binary}
+	firecracker_binary_fullpath=release-${firecracker_version}-${arch}/${firecracker_binary}
+	jailer_binary_fullpath=release-${firecracker_version}-${arch}/${jailer_binary}
 	sudo -E install -m 0755 -D ${firecracker_binary_fullpath} /usr/bin/firecracker
 	sudo -E install -m 0755 -D ${jailer_binary_fullpath} /usr/bin/jailer
 }

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -38,9 +38,8 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
 	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER"|"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
-		 echo "INFO: Skipping nydus test: Issue: https://github.com/kata-containers/tests/issues/4947"
-		#echo "INFO: Running nydus test"
-		#sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
+		echo "INFO: Running nydus test"
+		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -38,8 +38,9 @@ case "${CI_JOB}" in
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make qat"
 		;;
 	"CRI_CONTAINERD"|"CRI_CONTAINERD_K8S"|"CRI_CONTAINERD_K8S_DEVMAPPER"|"CC_CRI_CONTAINERD"|"CC_CRI_CONTAINERD_CLOUD_HYPERVISOR")
-		echo "INFO: Running nydus test"
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
+		 echo "INFO: Skipping nydus test: Issue: https://github.com/kata-containers/tests/issues/4947"
+		#echo "INFO: Running nydus test"
+		#sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make nydus"
 		echo "INFO: Running stability test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
 		echo "INFO: Containerd checks"

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -48,7 +48,10 @@ function install_from_tarball() {
 	local url=$(get_version "externals.${package_name}.url")
 	local version=$(get_version "externals.${package_name}.version")
 	local tarball_url="${url}/releases/download/${version}/${binary_name}-${version}-$arch.tgz"
-
+	if [ "${package_name}" == "nydus" ]; then
+		local goarch="$(${dir_path}/../../.ci/kata-arch.sh --golang)"
+		tarball_url="${url}/releases/download/${version}/${binary_name}-${version}-linux-$goarch.tgz"
+	fi
 	echo "Download tarball from ${tarball_url}"
 	curl -Ls "$tarball_url" | sudo tar xfz - -C /usr/local/bin --strip-components=1
 }
@@ -87,6 +90,10 @@ function config_kata() {
 	else
 		sudo cp -a "${CLH_CONFIG_FILE}" "${SYSCONFIG_FILE}"
 	fi
+
+	echo "Enabling all debug options in file ${SYSCONFIG_FILE}"
+	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${SYSCONFIG_FILE}"
+	sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${SYSCONFIG_FILE}"
 
 	sudo sed -i 's|^shared_fs.*|shared_fs = "virtio-fs-nydus"|g' "${SYSCONFIG_FILE}"
 	sudo sed -i 's|^virtio_fs_daemon.*|virtio_fs_daemon = "/usr/local/bin/nydusd-virtiofs"|g' "${SYSCONFIG_FILE}"


### PR DESCRIPTION
In the latest FC releases, the asset we download and decompress
has the following syntax:

release-vX.X.X-ARCH/firecracker-vX.X.X-ARCH

until v0.25 there was no ARCH in the folder name. Since we are updating
the supported FC version, this patch fixes the script that installs the
firecracker binary and the jailer.

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>