### PR TITLE
Clean up .ci/install_runtime.sh

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -139,20 +139,6 @@ else
 	echo "Metrics run - do not enable all debug options in file ${runtime_config_path}"
 fi
 
-# Ensure vhost_vsock module is loaded as it is required for vsock
-# agent <-> runtime communication.
-# On OpenShift CI the vhost module should not be loaded on build time.
-if [ "$OPENSHIFT_CI" == "false" ]; then
-	vsock_module="vhost_vsock"
-	echo "Check if ${vsock_module} is loaded"
-	if lsmod | grep -q "\<${vsock_module}\>" ; then
-		echo "Module ${vsock_module} is already loaded"
-	else
-		echo "Load ${vsock_module} module"
-		sudo modprobe "${vsock_module}"
-	fi
-fi
-
 # Enable experimental features if KATA_EXPERIMENTAL_FEATURES is set to true
 if [ "$KATA_EXPERIMENTAL_FEATURES" = true ]; then
 	echo "Enable runtime experimental features"

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -16,7 +16,6 @@ source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
-MACHINETYPE="${MACHINETYPE:-q35}"
 METRICS_CI="${METRICS_CI:-}"
 PREFIX="${PREFIX:-/usr}"
 DESTDIR="${DESTDIR:-/}"
@@ -156,11 +155,6 @@ if [ "$USE_VSOCK" == "yes" ]; then
 			sudo modprobe "${vsock_module}"
 		fi
 	fi
-fi
-
-if [ "$MACHINETYPE" == "q35" ]; then
-	echo "Use machine_type q35"
-	sudo sed -i -e 's|machine_type = "pc"|machine_type = "q35"|' "${runtime_config_path}"
 fi
 
 # Enable experimental features if KATA_EXPERIMENTAL_FEATURES is set to true

--- a/.ci/openshift-ci/build_install.sh
+++ b/.ci/openshift-ci/build_install.sh
@@ -119,12 +119,6 @@ export TEST_INITRD="yes"
 # Build a dracut-based image.
 export BUILD_METHOD="dracut"
 
-# Configure to use vsock.
-export USE_VSOCK="yes"
-
-# Configure the QEMU machine type.
-export MACHINETYPE="q35"
-
 # Enable SELinux.
 export FEATURE_SELINUX="yes"
 


### PR DESCRIPTION
The `.ci/install_runtime.sh` script does perform some changes in the `configuration.toml` which are no longer needed. Let's clean up the script then.

Fixes https://github.com/kata-containers/tests/issues/5040