### PR TITLE
CCv0 | CI: build and install artifacts with kata-deploy

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -21,6 +21,10 @@ main() {
 
 	[ "${KATA_BUILD_CC}" == "yes" ] || \
 		sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
+
+	if [ "${TEE_TYPE:-}" == "tdx" ]; then
+		"${cidir}/install_td_shim.sh"
+	fi
 }
 
 main "$@"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -13,17 +13,14 @@ set -o errtrace
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+# Whether build for confidential containers or not.
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
+
 main() {
-	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+	build_static_artifact_and_install "cloud-hypervisor"
 
-	# Just in case the kata-containers repo is not cloned yet.
-	clone_katacontainers_repo
-
-	pushd $katacontainers_repo_dir
-	sudo -E PATH=$PATH bash ${buildscript} --build=cloud-hypervisor
-	sudo tar -xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
-	sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
-	popd
+	[ "${KATA_BUILD_CC}" == "yes" ] || \
+		sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
 }
 
 main "$@"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -58,9 +58,6 @@ case "${KATA_HYPERVISOR}" in
 		"${cidir}/install_cloud_hypervisor.sh"
 		echo "Installing virtiofsd"
 		"${cidir}/install_virtiofsd.sh"
-		if [ "${TEE_TYPE}" == "tdx" ]; then
-			"${cidir}/install_td_shim.sh"
-		fi
 		;;
 	"firecracker")
 		"${cidir}/install_firecracker.sh"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -69,9 +69,6 @@ case "${KATA_HYPERVISOR}" in
 		install_qemu
 		echo "Installing virtiofsd"
 		"${cidir}/install_virtiofsd.sh"
-		if [ "${TEE_TYPE}" == "tdx" ]; then
-			"${cidir}/install_tdvf.sh"
-		fi
 		;;
 	"dragonball")
 		echo "Kata Hypervisor is dragonball"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -24,6 +24,7 @@ AGENT_INIT="${AGENT_INIT:-${TEST_INITRD:-no}}"
 TEST_INITRD="${TEST_INITRD:-no}"
 build_method="${BUILD_METHOD:-distro}"
 EXTRA_PKGS="${EXTRA_PKGS:-}"
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 
 build_rust_image() {
 	osbuilder_path="${GOPATH}/src/${rust_agent_repo}/tools/osbuilder"
@@ -48,12 +49,8 @@ build_rust_image() {
 				[[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
 			fi
 			distro="${osbuilder_distro:-ubuntu}"
-			if [ ${KATA_BUILD_CC} == "yes" ]; then
-				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" AA_KBC="${AA_KBC:-}" UMOCI=yes make -e "image"
-			else
-				sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
-					make -e "${target_image}"
-			fi
+			sudo -E USE_DOCKER="${use_docker:-}" DISTRO="${distro}" EXTRA_PKGS="${EXTRA_PKGS}" \
+				make -e "${target_image}"
 			;;
 		"dracut")
 			sudo -E BUILD_METHOD="dracut" make -e "${target_image}"
@@ -73,8 +70,22 @@ build_rust_image() {
 	popd
 }
 
+build_image_for_cc () {
+	[ "${TEST_INITRD}" != "yes" ] || \
+		die "Build of initrd image for Confidential Containers is still unsupported."
+
+	[ "${osbuilder_distro:-ubuntu}" == "ubuntu" ] || \
+		die "The only supported image for Confidential Containers is Ubuntu"
+
+	build_static_artifact_and_install "rootfs-image"
+}
+
 main() {
-	build_rust_image
+	if [ ${KATA_BUILD_CC} == "yes" ]; then
+		build_image_for_cc
+	else
+		build_rust_image
+	fi
 }
 
 main

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -18,6 +18,7 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 PREFIX="${PREFIX:-/usr}"
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 kernel_dir="${DESTDIR:-}${PREFIX}/share/kata-containers"
 
 kernel_packaging_dir="${katacontainers_repo_dir}/tools/packaging/kernel"
@@ -56,6 +57,30 @@ build_and_install_kernel() {
 	"${kernel_packaging_dir}/build-kernel.sh" -v "${kernel_version}" ${extra_opts} "build"
 	sudo -E PATH="$PATH" "${kernel_packaging_dir}/build-kernel.sh" -v "${kernel_version}" ${extra_opts} "install"
 	popd >> /dev/null
+}
+
+build_and_install_kernel_for_cc() {
+	local kernel_type="${1:-}"
+	local artifact="kernel"
+
+	case "$kernel_type" in
+		tdx|sev)
+			artifact="${kernel_type}-${artifact}"
+			;;
+		vanilla) ;;
+		*)
+			die_unsupported_kernel_type "$kernel_type"
+			;;
+	esac
+
+	build_static_artifact_and_install "${artifact}"
+}
+
+die_unsupported_kernel_type() {
+	local kernel_type="${1:-}"
+
+	info "kernel type '${kernel_type}' not supported"
+	usage 1
 }
 
 # $1 kernel_binary: binary to install could be vmlinux or vmlinuz
@@ -107,6 +132,11 @@ install_kernel() {
 	[ -n "${kernel_version}" ] || die "kernel version is empty"
 
 	info "Installing '${kernel_type}' kernel"
+
+	if [ "$KATA_BUILD_CC" == "yes" ]; then
+		build_and_install_kernel_for_cc "$kernel_type"
+		return
+	fi
 
 	kernel_version=${kernel_version#v}
 	local latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-${kernel_type}-$(arch)-nightly/${cached_artifacts_path}"
@@ -184,8 +214,7 @@ main() {
 			install_kernel "${kernel_type}" $(get_version "assets.kernel.sev.tag")
 			;;
 		*)
-			info "kernel type '${kernel_type}' not supported"
-			usage 1
+			die_unsupported_kernel_type "$kernel_type"
 			;;
 	esac
 }

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -73,7 +73,7 @@ build_and_install_qemu_for_cc() {
 		tdx)
 			artifact="${qemu_type}-${artifact}"
 
-			build_static_artifact_and_install "tdx-tdvf"
+			"${cidir}/install_tdvf.sh"
 			;;
 		vanilla) ;;
 		*)

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -17,6 +17,7 @@ source "${cidir}/../lib/common.bash"
 source /etc/os-release || source /usr/lib/os-release
 
 PREFIX=${PREFIX:-/usr}
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 
 CURRENT_QEMU_VERSION=""
@@ -62,6 +63,25 @@ uncompress_static_qemu() {
 build_and_install_static_qemu() {
 	build_static_qemu
 	uncompress_static_qemu "${KATA_TESTS_CACHEDIR}/${QEMU_TAR}"
+}
+
+# Build QEMU for Confidential Containers.
+build_and_install_qemu_for_cc() {
+	local artifact="qemu"
+
+	case "${qemu_type}" in
+		tdx)
+			artifact="${qemu_type}-${artifact}"
+
+			build_static_artifact_and_install "tdx-tdvf"
+			;;
+		vanilla) ;;
+		*)
+			die_unsupported_qemu_type "$qemu_type"
+			;;
+	esac
+
+	build_static_artifact_and_install "$artifact"
 }
 
 install_cached_qemu() {
@@ -120,6 +140,13 @@ build_and_install_qemu() {
 	popd
 }
 
+die_unsupported_qemu_type() {
+	local qemu_type="${1:-}"
+
+	info "qemu type '${qemu_type}' not supported"
+	usage 1
+}
+
 #Load specific configure file
 if [ -f "${cidir}/${QEMU_ARCH}/lib_install_qemu_${QEMU_ARCH}.sh" ]; then
 	source "${cidir}/${QEMU_ARCH}/lib_install_qemu_${QEMU_ARCH}.sh"
@@ -136,6 +163,11 @@ run() {
 
 			if [ -n "${FORCE_BUILD_QEMU:-}" ]; then
 				build_and_install_qemu
+			elif [ "${KATA_BUILD_CC}" == "yes" ]; then
+				# Let's always build QEMU for Confidential
+				# Containers to avoid potential issues due to
+				# installation on different prefix.
+				build_and_install_qemu_for_cc
 			elif [ "$CURRENT_QEMU_VERSION" == "$cached_qemu_version" ]; then
 				# Let's check if the current sha256sum matches
 				# with the cached, otherwise build QEMU locally
@@ -201,6 +233,7 @@ main() {
 		esac
 	done
 
+	export qemu_type
 	case "${qemu_type}" in
 		tdx)
 			CURRENT_QEMU_VERSION=$(get_version "assets.hypervisor.qemu.tdx.tag")
@@ -213,8 +246,7 @@ main() {
 			qemu_latest_build_url="${jenkins_url}/job/kata-containers-2.0-qemu-$(uname -m)/${cached_artifacts_path}"
 			;;
 		*)
-			info "qemu type '${qemu_type}' not supported"
-			usage 1
+			die_unsupported_qemu_type "$qemu_type"
 			;;
 	esac
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -14,10 +14,14 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
 MACHINETYPE="${MACHINETYPE:-q35}"
 METRICS_CI="${METRICS_CI:-}"
+if [ "$KATA_BUILD_CC" == "yes" ]; then
+	PREFIX="${PREFIX:-/opt/confidential-containers}"
+fi
 PREFIX="${PREFIX:-/usr}"
 DESTDIR="${DESTDIR:-/}"
 TEST_INITRD="${TEST_INITRD:-}"
@@ -55,6 +59,18 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 clone_katacontainers_repo
 
 build_install_shim_v2(){
+	if [ "$KATA_BUILD_CC" == "yes" ]; then
+		build_static_artifact_and_install "shim-v2"
+
+		local bin_dir="/usr/bin"
+		if [ "$PREFIX" != "$bin_dir" ]; then
+			for target_file in $PREFIX/bin/*; do
+				sudo ln --force -s "$target_file" "$bin_dir"
+			done
+		fi
+		return
+	fi
+
 	pushd "$runtime_src_path"
 	make
 	sudo -E PATH=$PATH make install
@@ -114,11 +130,14 @@ case "${KATA_HYPERVISOR}" in
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"
 		;;
 	"qemu")
-		if [ "$TEE_TYPE" == "tdx" ]; then
-			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-tdx.toml"
-		else
-			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
-		fi
+		case "$TEE_TYPE" in
+			"tdx")
+				enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-tdx.toml"
+				;;
+			*)
+				enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
+				;;
+		esac
 
 		if [ "$arch" == "x86_64" ]; then
 			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2

--- a/.ci/install_td_shim.sh
+++ b/.ci/install_td_shim.sh
@@ -14,16 +14,12 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 main() {
-	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+	build_static_artifact_and_install "tdx-td-shim"
 
-	# Just in case the kata-containers repo is not cloned yet.
-	clone_katacontainers_repo
-
-	pushd $katacontainers_repo_dir
-	sudo -E PATH=$PATH bash ${buildscript} --build=cc-tdx-td-shim
-	sudo tar -xvJpf build/kata-static-cc-tdx-td-shim.tar.xz -C /
-	sudo ln -sf /opt/confidential-containers/share/td-shim /usr/share/td-shim
-	popd
+	if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
+		sudo ln -sf /opt/confidential-containers/share/td-shim \
+			/usr/share/td-shim
+	fi
 }
 
 main "$@"

--- a/.ci/install_tdvf.sh
+++ b/.ci/install_tdvf.sh
@@ -14,16 +14,11 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 main() {
-	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+	build_static_artifact_and_install "tdx-tdvf"
 
-	# Just in case the kata-containers repo is not cloned yet.
-	clone_katacontainers_repo
-
-	pushd $katacontainers_repo_dir
-	sudo -E PATH=$PATH bash ${buildscript} --build=cc-tdx-tdvf
-	sudo tar -xvJpf build/kata-static-cc-tdx-tdvf.tar.xz -C /
-	sudo ln -sf /opt/confidential-containers/share/tdvf /usr/share/tdvf
-	popd
+        if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
+		sudo ln -sf /opt/confidential-containers/share/tdvf /usr/share/tdvf
+	fi
 }
 
 main "$@"

--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -14,26 +14,21 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 DESTDIR="${DESTDIR:-/}"
+KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 
 main() {
 	bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
 
-	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
+	build_static_artifact_and_install "virtiofsd"
 
-	# Just in case the kata-containers repo is not cloned yet.
-	clone_katacontainers_repo
-
-	pushd $katacontainers_repo_dir
-	sudo -E PATH=$PATH bash ${buildscript} --build=virtiofsd
-	sudo tar -xvJpf build/kata-static-virtiofsd.tar.xz -C "${DESTDIR}"
 	# Kata CI requires the link but this isn't true to all scenarios,
 	# for example, on OpenShift CI everything should be installed under
 	# /opt/kata. So do not try to create the link unless the directory
 	# exist.
-	[ -d "${DESTDIR}/usr/libexec" ] && \
+	if [ -d "${DESTDIR}/usr/libexec" -a "${KATA_BUILD_CC}" == "no" ]; then
 		sudo ln -sf "${DESTDIR}/opt/kata/libexec/virtiofsd" \
 			"${DESTDIR}/usr/libexec/virtiofsd"
-	popd
+	fi
 }
 
 main "$@"


### PR DESCRIPTION
Adapted the CI build and installation scripts to use kata-deploy. As a rule, they will run `make cc-<artifact>-tarball` then uncompress the resulting tarball on '/'. The variable `KATA_BUILD_CC=yes` should be exported (it is on the CC jobs) and the installation will live under `/opt/confidential-containers`.

Important: the cache for QEMU and Kernel are ignored as for making it work properly it would need a major refactoring on the code and the creation on new cache jobs.
 
Fixes #4893