### PR TITLE
metrics: Delete statefulset in Cassandra test

### DIFF
--- a/metrics/disk/cassandra_kubernetes/cassandra.sh
+++ b/metrics/disk/cassandra_kubernetes/cassandra.sh
@@ -179,6 +179,7 @@ function cassandra_cleanup() {
 	kubectl delete svc "$service_name"
 	kubectl delete pod -l app="$app_name"
 	kubectl delete storageclass block-local-storage
+	kubectl delete statefulsets "$app_name"
 
 	# Delete temporary yaml files
 	rm -f "$tmp_pv_yaml"


### PR DESCRIPTION
This PR removes the StatefulSet in the Cassandra k8s test for
the metrics tests.

Fixes #5051

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>