### PR TITLE
github-actions: Remove man-db from add-pr-sizing-label

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -33,6 +33,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_PR_SIZE_TOKEN }}
         run: |
           pr=${{ github.event.number }}
+          
+          sudo apt -y remove --purge man-db
           sudo apt -y install diffstat patchutils
 
           pr-add-size-label.sh -p "$pr"


### PR DESCRIPTION
Removes man-db from add-pr-sizing-label action because it sometimes
errors and fails. This does not always occur, but as man-db shouldn't be
needed for any reason, it's probably useful just to remove it.

Same as #4864 in kata-containers/kata-containers

Fixes #5057

Signed-off-by: Derek Lee <derlee@redhat.com>