### PR TITLE
ci: Update help message in manage ctr mgr script

### DIFF
--- a/cmd/container-manager/manage_ctr_mgr.sh
+++ b/cmd/container-manager/manage_ctr_mgr.sh
@@ -20,7 +20,7 @@ tag=""
 usage(){
 	cat << EOF
 This script helps you install the correct version of docker
-to use with Clear Containers.
+to use with Kata Containers.
 WARNING: Using this tool with -f flag, will overwrite any docker configuration that you may
 have modified.
 Usage: $SCRIPT_NAME [docker] [configure|info|install|remove] <options>


### PR DESCRIPTION
This PR updates the help message to reference Kata Containers
instead of Clear Containers when the mange ctr mgr script
is being used.

Fixes #5066

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>