### PR TITLE
metrics: Remove pvc in cassandra metrics test

### DIFF
--- a/metrics/disk/cassandra_kubernetes/cassandra.sh
+++ b/metrics/disk/cassandra_kubernetes/cassandra.sh
@@ -176,6 +176,8 @@ function cassandra_start() {
 }
 
 function cassandra_cleanup() {
+	kubectl patch pvc block-loop-pvc -p '{"metadata":{"finalizers":null}}'
+	kubectl delete pvc block-loop-pvc --force
 	kubectl delete svc "$service_name"
 	kubectl delete pod -l app="$app_name"
 	kubectl delete storageclass block-local-storage


### PR DESCRIPTION
This PR adds the removal for PVC in the Cassandra metrics test, this
will avoid the issue that when we are removing the PVC it gets stuck
in "terminating" status for a while and will allow the final
unmount from the node so that PVC can be properly delete it.

FIxes #5075

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>