### PR TITLE
CCv0 | ci/lib: run kata-runtime as non-sudo in cp_to_guest_img()

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -270,7 +270,7 @@ cp_to_guest_img() {
 	rootfs_dir="$(mktemp -d)"
 
 	# Open the original initrd/image, inject the agent file
-	local image_path="$(sudo kata-runtime kata-env --json | jq -r .Image.Path)"
+	local image_path="$(kata-runtime kata-env --json | jq -r .Image.Path)"
 	if [ -f "$image_path" ]; then
 		if ! sudo mount -o loop,offset=$((512*6144)) "$image_path" \
 			"$rootfs_dir"; then


### PR DESCRIPTION
kata-runtime for CC might be installed in /opt/confidential-containers/bin so not in
PATH. Even if the caller of `cp_to_guest_img()` re-export `PATH=$PATH:/opt/confidential-containers/bin`
the `kata-runtime` won't be found because `sudo` doesn't export the current `PATH` into
the sub-process.

We don't need to run `kata-runtime kata-env` as privileged user. So let's avoid that mess
by simply not using `sudo`.

Fixes #5077
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>