### PR TITLE
confidential: Adjust Kubernetes confidential jobs for TDX capable CIs

### DIFF
--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -49,6 +49,24 @@ setup() {
 	clear_kernel_params
 	add_kernel_params \
 		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+
+	# In case the tests run behind a firewall where images needed to be fetched
+	# through a proxy.
+	local https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
+	if [ -n "$https_proxy" ]; then
+		echo "Enable agent https proxy"
+		add_kernel_params "agent.https_proxy=$https_proxy"
+
+		local local_dns=$(grep nameserver /etc/resolv.conf \
+			/run/systemd/resolve/resolv.conf  2>/dev/null \
+			|grep -v "127.0.0.53" | cut -d " " -f 2 | head -n 1)
+		local new_file="${BATS_FILE_TMPDIR}/$(basename ${pod_config})"
+		echo "New pod configuration with local dns: $new_file"
+		cp -f "${pod_config}" "${new_file}"
+		pod_config="$new_file"
+		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
+		cat "$pod_config"
+	fi
 	
 	copy_files_to_guest
 }

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -8,6 +8,7 @@ load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../confidential/lib.sh"
 
 test_tag="[cc][agent][kubernetes][containerd]"
+original_kernel_params=$(get_kernel_params)
 
 # Create the test pod.
 #
@@ -47,6 +48,7 @@ setup() {
 	echo "Reconfigure Kata Containers"
 	switch_image_service_offload on
 	clear_kernel_params
+	add_kernel_params "${original_kernel_params}"
 	add_kernel_params \
 		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
 
@@ -143,6 +145,7 @@ teardown() {
 	kubernetes_delete_cc_pod_if_exists "$sandbox_name" || true
 
 	clear_kernel_params
+	add_kernel_params "${original_kernel_params}"
 	switch_image_service_offload off
 	disable_full_debug
 }

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -9,6 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../confidential/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
 
 test_tag="[cc][agent][kubernetes][containerd]"
+original_kernel_params=$(get_kernel_params)
 
 setup() {
     start_date=$(date +"%Y-%m-%d %H:%M:%S")
@@ -25,6 +26,7 @@ setup() {
     echo "Reconfigure Kata Containers"
     switch_image_service_offload on
     clear_kernel_params
+    add_kernel_params "${original_kernel_params}"
 
     # In case the tests run behind a firewall where images needed to be fetched
     # through a proxy.
@@ -68,6 +70,7 @@ teardown() {
     kubernetes_delete_ssh_demo_pod_if_exists "$pod_id" || true
 
     clear_kernel_params
+    add_kernel_params "${original_kernel_params}"
     switch_image_service_offload off
     disable_full_debug
 }

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -25,6 +25,14 @@ setup() {
     echo "Reconfigure Kata Containers"
     switch_image_service_offload on
     clear_kernel_params
+
+    # In case the tests run behind a firewall where images needed to be fetched
+    # through a proxy.
+    local https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
+    if [ -n "$https_proxy" ]; then
+        echo "Enable agent https proxy"
+        add_kernel_params "agent.https_proxy=$https_proxy"
+    fi
 }
 
 @test "$test_tag Test can pull an encrypted image inside the guest with decryption key" {

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -150,7 +150,7 @@ assert_pod_fail() {
 
 setup_decryption_files_in_guest() {
     local rootfs_agent_config="/etc/agent-config.toml"
-    sudo -E AA_KBC_PARAMS="offline_fs_kbc::null" envsubst < ${katacontainers_repo_dir}/docs/how-to/data/confidential-agent-config.toml.in | sudo tee ${rootfs_agent_config}
+    sudo -E AA_KBC_PARAMS="offline_fs_kbc::null" HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}" envsubst < ${katacontainers_repo_dir}/docs/how-to/data/confidential-agent-config.toml.in | sudo tee ${rootfs_agent_config}
 	
     cp_to_guest_img "/tests/fixtures" "${rootfs_agent_config}"
     add_kernel_params \

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -80,7 +80,7 @@ kubernetes_create_cc_pod() {
 		return 1
 	fi
 
-    kubectl apply -f ${config_file}
+	kubectl apply -f ${config_file}
 	if ! pod_name=$(kubectl get pods -o jsonpath='{.items..metadata.name}'); then
 		echo "Failed to create the pod"
 		return 1

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -57,7 +57,6 @@ kubernetes_delete_cc_pod_if_exists() {
 # Parameters:
 #	$1 - the sandbox ID
 #	$2 - wait time in seconds. Defaults to 60. (optional)
-#	$3 - sleep time in seconds between checks. Defaults to 5. (optional)
 #
 kubernetes_wait_cc_pod_be_ready() {
 	local pod_name="$1"

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -56,12 +56,12 @@ kubernetes_delete_cc_pod_if_exists() {
 #
 # Parameters:
 #	$1 - the sandbox ID
-#	$2 - wait time in seconds. Defaults to 10. (optional)
+#	$2 - wait time in seconds. Defaults to 60. (optional)
 #	$3 - sleep time in seconds between checks. Defaults to 5. (optional)
 #
 kubernetes_wait_cc_pod_be_ready() {
 	local pod_name="$1"
-	local wait_time="${2:-30}"
+	local wait_time="${2:-60}"
 
 	kubectl wait --timeout=${wait_time}s --for=condition=ready pods/$pod_name
 }
@@ -115,7 +115,7 @@ checkout_doc_repo_dir() {
 
 kubernetes_create_ssh_demo_pod() {
 	checkout_doc_repo_dir
-	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --for=condition=ready pods/$pod
+	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --timeout=60s --for=condition=ready pods/$pod
 	kubectl get pod $pod
 }
 


### PR DESCRIPTION
This patch set is needed in order to get the current `cc-kubernetes` jobs passing in the TDX capable CI.

---

k8s: Make confidential tests aware of the proxy

Right now the confidential tests are not aware of the proxy, which leads
to failures on the TDX CI, as this CI runs inside Intel network.

Fixes: #5082

---

k8s: confidential: Use `kubernetes_create_cc_pod`

Instead of duplicating the code for creating and checking whether a
pod's been created, let's take advantage of the already present
`kubernetes_create_cc_pod` function.

---

k8s: confidential: Fix identation in `kubernetes_create_cc_pod`

We're using tabs instead of spaces in this file.

---

k8s: confidential: Increase the wait timeout to 60s

Let's double the wait timeout as I've noticed, in the internal TDX CI,
that pulling the image inside the guest may take longer than expected
due to our proxies.

In order to avoid random failures due to this, let's simply double the
amount of time and this will not have any side-effect on the other jobs.

---

k8s: confidential: Remove wrong documentation

`kubernetes_wait_cc_pod_be_ready` doesn't receive a third argument.

---

k8s: confidential: Respect original kernel_params

Let's make sure the original kernel parameters are respected, as those
are very much important for the TEE bases CIs, considering some of those
options are a must in order to have the VMs booting up.

Fixes: #5079

---