### PR TITLE
CCv0 | kubernetes/lib: fix regex in retrieve_sandbox_id()

### DIFF
--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -97,7 +97,7 @@ kubernetes_create_cc_pod() {
 # Retrieve the sandbox ID 
 #
 retrieve_sandbox_id() {
-	sandbox_id=$(ps -ef | grep containerd-shim-kata-v2 | egrep -o "id [^,][^,].* " | awk '{print $2}')
+	sandbox_id=$(ps -ef | grep containerd-shim-kata-v2 | egrep -o "\s\-id [a-z0-9]+" | awk '{print $2}')
 }
 
 # Check out the doc repo if required


### PR DESCRIPTION
In retrieve_sandbox_id() the output of `ps -ef` is parsed, the regex looks for
occurencies of "id". Currently the regex expect an extra space after the
id number which can lead to not getting the id.

This commit changed the regex used to a more accurate one.

Fixes https://github.com/kata-containers/tests/issues/5077
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>