### PR TITLE
CCv0 | Allow to run cc-kubernetes tests from operator CI

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -12,7 +12,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export katacontainers_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
-export kata_default_branch="${kata_default_branch:-main}"
+export kata_default_branch="${kata_default_branch:-CCv0}"
 export CI_JOB="${CI_JOB:-}"
 
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -9,6 +9,7 @@
 set -e
 
 source "${BATS_TEST_DIRNAME}/../../../lib/common.bash"
+source "${BATS_TEST_DIRNAME}/../../../.ci/lib.sh"
 FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures"
 
 # Currently the agent can only check images signature if using skopeo.
@@ -149,8 +150,11 @@ assert_pod_fail() {
 
 setup_decryption_files_in_guest() {
     local rootfs_agent_config="/etc/agent-config.toml"
+
+    clone_katacontainers_repo
+
     sudo -E AA_KBC_PARAMS="offline_fs_kbc::null" HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}" envsubst < ${katacontainers_repo_dir}/docs/how-to/data/confidential-agent-config.toml.in | sudo tee ${rootfs_agent_config}
-	
+
     cp_to_guest_img "/tests/fixtures" "${rootfs_agent_config}"
     add_kernel_params \
 	    "agent.config_file=/tests/fixtures/$(basename ${rootfs_agent_config})"


### PR DESCRIPTION
This is a couple of fixes to allow us to run the cc-kubernetes tests (integration/kubernetes/confidential/agent_image_encrypted.bats) from the CI for the operator.

Fixes #5077 