### PR TITLE
versions: Update cni plugins version

### DIFF
--- a/.ci/install_cni_plugins.sh
+++ b/.ci/install_cni_plugins.sh
@@ -10,7 +10,7 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-plugins_version=$(get_version "externals.cni-plugins.commit")
+plugins_version=$(get_version "externals.cni-plugins.version")
 echo "Retrieve CNI plugins repository"
 go get -d github.com/containernetworking/plugins || true
 pushd $GOPATH/src/github.com/containernetworking/plugins

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -317,6 +317,16 @@ main() {
 	info "Clean up any leftover CNI configuration"
 	cleanup_cni_configuration
 
+	if [ "$CRI_RUNTIME" == crio ]; then
+		crio_repository="github.com/cri-o/cri-o"
+		crio_repository_path="$GOPATH/src/${crio_repository}"
+		cni_directory="/etc/cni/net.d"
+		if [ ! -d "${cni_directory}" ]; then
+			sudo mkdir -p "${cni_directory}"
+		fi
+		sudo cp "${crio_repository_path}/contrib/cni/10-crio-bridge.conf" "${cni_directory}"
+	fi
+
 	info "Start ${CRI_RUNTIME} service"
 	start_cri_runtime_service "${CRI_RUNTIME}" "${cri_runtime_socket}"
 


### PR DESCRIPTION
This PR updates the cni plugins version that is being used in the
kata CI.

Fixes #5087
Depends-on: https://github.com/kata-containers/kata-containers/pull/5040

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>