### PR TITLE
stable-2.5 | ci: Add support for ubuntu 22.04

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -11,6 +11,7 @@ set -e
 
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 export RUNTIME="containerd-shim-kata-v2"
 
@@ -49,9 +50,14 @@ case "${CI_JOB}" in
 		echo "INFO: Running vcpus test"
 		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make vcpus"
 		echo "INFO: Skipping pmem test: Issue: https://github.com/kata-containers/tests/issues/3223"
-		echo "INFO: Running stability test with sandbox_cgroup_only"
-		export TEST_SANDBOX_CGROUP_ONLY=true
-		sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
+		if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+			issue="https://github.com/kata-containers/tests/issues/4922"
+			echo "INFO: Skipping stability test with sandbox_cgroup_only as they are not working with cgroupsv2 see $issue"
+		else
+			echo "INFO: Running stability test with sandbox_cgroup_only"
+			export TEST_SANDBOX_CGROUP_ONLY=true
+			sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make stability"
+		fi
 		# echo "INFO: Running pmem integration test"
 		# sudo -E PATH="$PATH" CRI_RUNTIME="containerd" bash -c "make pmem"
 		echo "INFO: Running ksm test"

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -37,7 +37,7 @@ declare -A packages=( \
 	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev thin-provisioning-tools" \
 	[bison_binary]="bison" \
 	[libudev-dev]="libudev-dev" \
-	[build_tools]="build-essential python pkg-config zlib1g-dev" \
+	[build_tools]="build-essential pkg-config zlib1g-dev" \
 	[crio_dependencies_for_ubuntu]="libdevmapper-dev util-linux" \
 	[metrics_dependencies]="smem jq" \
 	[cri-containerd_dependencies]="btrfs-progs libseccomp-dev libapparmor-dev make gcc pkg-config" \
@@ -57,6 +57,12 @@ if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 20.04" | bc -q)" == 
 	packages[vfio_test]="pciutils driverctl"
 fi
 
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	packages[build_tools]+=" python2"
+else
+	packages[build_tools]+=" python"
+fi
+
 if [ "$(uname -m)" == "x86_64" ] && [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 18.04" | bc -q)" == "1" ]; then
 	packages[qemu_dependencies]+=" libpmem-dev"
 fi
@@ -73,12 +79,17 @@ rust_agent_pkgs+=("automake")
 rust_agent_pkgs+=("autoconf")
 rust_agent_pkgs+=("m4")
 rust_agent_pkgs+=("libc6-dev")
-rust_agent_pkgs+=("libstdc++-8-dev")
 rust_agent_pkgs+=("coreutils")
 rust_agent_pkgs+=("binutils")
 rust_agent_pkgs+=("debianutils")
 rust_agent_pkgs+=("gcc")
 rust_agent_pkgs+=("git")
+
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	rust_agent_pkgs+=("libstdc++-10-dev")
+else
+	rust_agent_pkgs+=("libstdc++-8-dev")
+fi
 
 # ppc64le and s390x have no musl targets in Rust, hence, do not install musl there
 [ "$(arch)" != "ppc64le" ] && [ "$(arch)" != "s390x" ] && rust_agent_pkgs+=("musl" "musl-dev" "musl-tools")

--- a/functional/kata-monitor/run.sh
+++ b/functional/kata-monitor/run.sh
@@ -15,6 +15,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "/etc/os-release" || source "/usr/lib/os-release"
+
 [ -n "${BASH_VERSION:-}" ] && set -o errtrace
 [ -n "${DEBUG:-}" ] && set -o xtrace
 
@@ -39,6 +41,12 @@ CURRENT_TASK=""
 
 FALSE=1
 TRUE=0
+
+issue="https://github.com/kata-containers/tests/issues/4922"
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	echo "Skip kata monitor test is not working with cgroupsv2 see $issue"
+	exit 0
+fi
 
 trap error_with_msg ERR
 

--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -42,6 +42,8 @@ set -o errtrace
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../.ci/lib.sh"
+source "/etc/os-release" || source "/usr/lib/os-release"
+issue="https://github.com/kata-containers/tests/issues/4922"
 
 CTR_RUNTIME=${CTR_RUNTIME:-"io.containerd.kata.v2"}
 
@@ -221,6 +223,11 @@ kata_cfg_file=
 
 # Set in setup() based on KATA_HYPERVISOR
 hypervisor_binary=
+
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+        echo "Skip tracing test is not working with cgroupsv2 see $issue"
+        exit 0
+fi
 
 #-------------------------------------------------------------------------------
 

--- a/functional/tracing/tracing-test.sh
+++ b/functional/tracing/tracing-test.sh
@@ -10,6 +10,8 @@ set -o pipefail
 set -o errtrace
 
 script_name=${0##*/}
+source "/etc/os-release" || source "/usr/lib/os-release"
+issue="https://github.com/kata-containers/tests/issues/4922"
 
 # Set to true if all tests pass
 success="false"
@@ -49,6 +51,11 @@ container_id="tracing-test"
 jaeger_server=${jaeger_server:-localhost}
 jaeger_ui_port=${jaeger_ui_port:-16686}
 jaeger_docker_container_name="jaeger"
+
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	echo "Skip tracing test is not working with cgroupsv2 see $issue"
+	exit 0
+fi
 
 # Cleanup will remove Jaeger container and
 # disable tracing.

--- a/functional/vcpus/default_vcpus_test.sh
+++ b/functional/vcpus/default_vcpus_test.sh
@@ -15,6 +15,7 @@ set -o errtrace
 dir_path=$(dirname "$0")
 source "${dir_path}/../../lib/common.bash"
 source "${dir_path}/../../.ci/lib.sh"
+source "/etc/os-release" || source "/usr/lib/os-release"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 name="${name:-default_vcpus}"
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
@@ -23,9 +24,15 @@ PAYLOAD_ARGS="${PAYLOAD_ARGS:-nproc | grep 4}"
 RUNTIME_CONFIG_PATH="${RUNTIME_CONFIG_PATH:-}"
 TEST_INITRD="${TEST_INITRD:-no}"
 issue="github.com/kata-containers/tests/issues/3303"
+second_issue="https://github.com/kata-containers/tests/issues/4922"
 
 if [ "$TEST_INITRD" == "yes" ]; then
 	echo "Skip vcpu test is not working $issue"
+	exit 0
+fi
+
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	echo "Skip vcpu test is not working with cgroupsv2 see $second_issue"
 	exit 0
 fi
 

--- a/integration/ksm/ksm_test.sh
+++ b/integration/ksm/ksm_test.sh
@@ -14,12 +14,18 @@ set -e
 dir_path=$(dirname "$0")
 source "${dir_path}/../../lib/common.bash"
 source "${dir_path}/../../metrics/lib/common.bash"
+source "/etc/os-release" || source "/usr/lib/os-release"
 
 KATA_KSM_THROTTLER="${KATA_KSM_THROTTLER:-yes}"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 IMAGE="${IMAGE:-quay.io/prometheus/busybox:latest}"
 WAIT_TIME="60"
 
+issue="https://github.com/kata-containers/tests/issues/4922"
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	echo "Skip ksm test is not working with cgroupsv2 see $issue"
+	exit 0
+fi
 function setup() {
 	restart_containerd_service
 	check_processes

--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -6,8 +6,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../.ci/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+source "/etc/os-release" || source "/usr/lib/os-release"
+issue="https://github.com/kata-containers/tests/issues/4922"
 
 setup() {
+	[ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ] && skip "hugepages test is not working with cgroupsv2 see $issue"  
 	extract_kata_env
 
 	pod_name="hugepage-pod"
@@ -44,6 +47,8 @@ setup() {
 }
 
 @test "Hugepages" {
+	[ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ] && skip "hugepages test is not working with cgroupsv2 see $issue"
+
 	# Create pod
 	kubectl create -f "${pod_config_dir}/test_hugepage.yaml"
 
@@ -76,6 +81,8 @@ setup() {
 }
 
 teardown() {
+	[ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ] && skip "hugepages test is not working with cgroupsv2 see $issue"
+
 	echo "$old_pages" > "/sys/kernel/mm/hugepages/$hugepages_sysfs_dir/nr_hugepages"
 
 	rm "$pod_config_dir/test_hugepage.yaml"

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -14,6 +14,7 @@ set -o errtrace
 dir_path=$(dirname "$0")
 source "${dir_path}/../../lib/common.bash"
 source "${dir_path}/../../.ci/lib.sh"
+source "/etc/os-release" || source "/usr/lib/os-release"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 need_restore_kata_config=false
@@ -27,6 +28,12 @@ containerd_config_backup="/tmp/containerd.config.toml"
 
 # test image for container
 IMAGE="${IMAGE:-ghcr.io/dragonflyoss/image-service/alpine:nydus-latest}"
+
+issue="https://github.com/kata-containers/tests/issues/4922"
+if [ "${NAME}" == "Ubuntu" ] && [ "$(echo "${VERSION_ID} >= 22.04" | bc -q)" == "1" ]; then
+	echo "Skip nydus tests are not working with cgroupsv2 see $issue"
+	exit 0
+fi
 
 if [ "$KATA_HYPERVISOR" != "qemu" ] && [ "$KATA_HYPERVISOR" != "cloud-hypervisor" ]; then
 	echo "Skip nydus test for $KATA_HYPERVISOR, it only works for QEMU/CLH now."


### PR DESCRIPTION
This PR adds the suppor for ubuntu 22.04 in order to have it
in our kata CI.

Fixes #4901
Depends-on: github.com/kata-containers/kata-containers#4397

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>
(cherry picked from commit ba1dd8521df9f177bee8874bf03ebf2033ab29c8)