### PR TITLE
    CCv0 | static-checks: Allow Merge commit to be >75 chars

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -45,7 +45,7 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^.{0,75}(\n.*)*$'
+        pattern: '^.{0,75}(\n.*)*$|^Merge pull request (?:kata-containers)?#[\d]+ from.*'
         error: 'Subject too long (max 75)'
         post_error: ${{ env.error_msg }}
 


### PR DESCRIPTION
Some generated merge commit messages are >75 chars
Allow these to not trigger the subject line length failure
    
Fixes: #5096
Signed-off-by: Megan-Wright <megan.wright@ibm.com>