### PR TITLE
metrics: Remove persistent volume in Cassandra

### DIFF
--- a/metrics/disk/cassandra_kubernetes/cassandra.sh
+++ b/metrics/disk/cassandra_kubernetes/cassandra.sh
@@ -178,6 +178,8 @@ function cassandra_start() {
 function cassandra_cleanup() {
 	kubectl patch pvc block-loop-pvc -p '{"metadata":{"finalizers":null}}'
 	kubectl delete pvc block-loop-pvc --force
+	kubectl patch pv block-loop-pv -p '{"metadata":{"finalizers":null}}'
+	kubectl delete pv block-loop-pv --force
 	kubectl delete svc "$service_name"
 	kubectl delete pod -l app="$app_name"
 	kubectl delete storageclass block-local-storage


### PR DESCRIPTION
This PR removes the persistent volume that we have in our
Cassandra metrics test.

Fixes #5098

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>