### PR TITLE
CC | Revert #5048 as it exposed proxy issues with the kata-deploy builds

### DIFF
--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -13,14 +13,17 @@ set -o errtrace
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-# Whether build for confidential containers or not.
-KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
-
 main() {
-	build_static_artifact_and_install "cloud-hypervisor"
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
-	[ "${KATA_BUILD_CC}" == "yes" ] || \
-		sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH bash ${buildscript} --build=cloud-hypervisor
+	sudo tar -xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /
+	sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
+	popd
 }
 
 main "$@"

--- a/.ci/install_cloud_hypervisor.sh
+++ b/.ci/install_cloud_hypervisor.sh
@@ -21,10 +21,6 @@ main() {
 
 	[ "${KATA_BUILD_CC}" == "yes" ] || \
 		sudo ln -sf /opt/kata/bin/cloud-hypervisor /usr/bin/cloud-hypervisor
-
-	if [ "${TEE_TYPE:-}" == "tdx" ]; then
-		"${cidir}/install_td_shim.sh"
-	fi
 }
 
 main "$@"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -69,6 +69,9 @@ case "${KATA_HYPERVISOR}" in
 		install_qemu
 		echo "Installing virtiofsd"
 		"${cidir}/install_virtiofsd.sh"
+		if [ "${TEE_TYPE}" == "tdx" ]; then
+			"${cidir}/install_tdvf.sh"
+		fi
 		;;
 	"dragonball")
 		echo "Kata Hypervisor is dragonball"

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -58,6 +58,9 @@ case "${KATA_HYPERVISOR}" in
 		"${cidir}/install_cloud_hypervisor.sh"
 		echo "Installing virtiofsd"
 		"${cidir}/install_virtiofsd.sh"
+		if [ "${TEE_TYPE}" == "tdx" ]; then
+			"${cidir}/install_td_shim.sh"
+		fi
 		;;
 	"firecracker")
 		"${cidir}/install_firecracker.sh"

--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -73,7 +73,7 @@ build_and_install_qemu_for_cc() {
 		tdx)
 			artifact="${qemu_type}-${artifact}"
 
-			"${cidir}/install_tdvf.sh"
+			build_static_artifact_and_install "tdx-tdvf"
 			;;
 		vanilla) ;;
 		*)

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -14,14 +14,10 @@ cidir=$(dirname "$0")
 
 source "${cidir}/lib.sh"
 source /etc/os-release || source /usr/lib/os-release
-KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 KATA_EXPERIMENTAL_FEATURES="${KATA_EXPERIMENTAL_FEATURES:-}"
 MACHINETYPE="${MACHINETYPE:-q35}"
 METRICS_CI="${METRICS_CI:-}"
-if [ "$KATA_BUILD_CC" == "yes" ]; then
-	PREFIX="${PREFIX:-/opt/confidential-containers}"
-fi
 PREFIX="${PREFIX:-/usr}"
 DESTDIR="${DESTDIR:-/}"
 TEST_INITRD="${TEST_INITRD:-}"
@@ -59,18 +55,6 @@ NEW_RUNTIME_CONFIG="${PKGDEFAULTSDIR}/configuration.toml"
 clone_katacontainers_repo
 
 build_install_shim_v2(){
-	if [ "$KATA_BUILD_CC" == "yes" ]; then
-		build_static_artifact_and_install "shim-v2"
-
-		local bin_dir="/usr/bin"
-		if [ "$PREFIX" != "$bin_dir" ]; then
-			for target_file in $PREFIX/bin/*; do
-				sudo ln --force -s "$target_file" "$bin_dir"
-			done
-		fi
-		return
-	fi
-
 	pushd "$runtime_src_path"
 	make
 	sudo -E PATH=$PATH make install
@@ -130,14 +114,11 @@ case "${KATA_HYPERVISOR}" in
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-fc.toml"
 		;;
 	"qemu")
-		case "$TEE_TYPE" in
-			"tdx")
-				enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-tdx.toml"
-				;;
-			*)
-				enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
-				;;
-		esac
+		if [ "$TEE_TYPE" == "tdx" ]; then
+			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-tdx.toml"
+		else
+			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
+		fi
 
 		if [ "$arch" == "x86_64" ]; then
 			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2

--- a/.ci/install_td_shim.sh
+++ b/.ci/install_td_shim.sh
@@ -14,12 +14,16 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 main() {
-	build_static_artifact_and_install "tdx-td-shim"
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
-	if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
-		sudo ln -sf /opt/confidential-containers/share/td-shim \
-			/usr/share/td-shim
-	fi
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH bash ${buildscript} --build=cc-tdx-td-shim
+	sudo tar -xvJpf build/kata-static-cc-tdx-td-shim.tar.xz -C /
+	sudo ln -sf /opt/confidential-containers/share/td-shim /usr/share/td-shim
+	popd
 }
 
 main "$@"

--- a/.ci/install_tdvf.sh
+++ b/.ci/install_tdvf.sh
@@ -14,11 +14,16 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 main() {
-	build_static_artifact_and_install "tdx-tdvf"
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
-        if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
-		sudo ln -sf /opt/confidential-containers/share/tdvf /usr/share/tdvf
-	fi
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH bash ${buildscript} --build=cc-tdx-tdvf
+	sudo tar -xvJpf build/kata-static-cc-tdx-tdvf.tar.xz -C /
+	sudo ln -sf /opt/confidential-containers/share/tdvf /usr/share/tdvf
+	popd
 }
 
 main "$@"

--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -14,21 +14,26 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
 DESTDIR="${DESTDIR:-/}"
-KATA_BUILD_CC="${KATA_BUILD_CC:-no}"
 
 main() {
 	bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
 
-	build_static_artifact_and_install "virtiofsd"
+	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
+	# Just in case the kata-containers repo is not cloned yet.
+	clone_katacontainers_repo
+
+	pushd $katacontainers_repo_dir
+	sudo -E PATH=$PATH bash ${buildscript} --build=virtiofsd
+	sudo tar -xvJpf build/kata-static-virtiofsd.tar.xz -C "${DESTDIR}"
 	# Kata CI requires the link but this isn't true to all scenarios,
 	# for example, on OpenShift CI everything should be installed under
 	# /opt/kata. So do not try to create the link unless the directory
 	# exist.
-	if [ -d "${DESTDIR}/usr/libexec" -a "${KATA_BUILD_CC}" == "no" ]; then
+	[ -d "${DESTDIR}/usr/libexec" ] && \
 		sudo ln -sf "${DESTDIR}/opt/kata/libexec/virtiofsd" \
 			"${DESTDIR}/usr/libexec/virtiofsd"
-	fi
+	popd
 }
 
 main "$@"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -153,38 +153,6 @@ function build() {
 	build_version "${github_project}" "${make_target}" "${version}"
 }
 
-# Build the artifact tarball using kata-deploy build scripts then uncompress
-# it.
-#
-# Parameters:
-#	$1 - artifact name. For example, qemu, qemu-tdx, rootfs-image,
-#	     and so on.
-#
-# Environment variables:
-#       KATA_BUILD_CC - adjust the make targets if building for Confidential
-#			Containers.
-#	DESTDIR - where to uncompress the tarball, by default is '/'.
-#
-function build_static_artifact_and_install() {
-	local artifact="${1:-}"
-	local destdir="${DESTDIR:-/}"
-	local make_target="${artifact}-tarball"
-	local tarball="kata-static-${artifact}.tar.xz"
-
-	# Use different target for Confidential Containers.
-	if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
-		make_target="cc-${make_target}"
-		tarball="kata-static-cc-${artifact}.tar.xz"
-	fi
-
-	clone_katacontainers_repo
-
-	pushd "$katacontainers_repo_dir" >/dev/null
-	sudo -E PATH=$PATH make "$make_target"
-	sudo tar -xvJpf "build/${tarball}" -C "${destdir}"
-	popd >/dev/null
-}
-
 function get_dep_from_yaml_db(){
 	local versions_file="$1"
 	local dependency="$2"


### PR DESCRIPTION
This is, unfortunately, needed as `make kata-tarball` (and similars) are
not currently working as expected behind a proxy.

See: https://github.com/kata-containers/kata-containers/issues/5077

Once that one is fixed, we can revert this commit.