### PR TITLE
docs: Include read and write percentile measurements

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -89,6 +89,7 @@ Tests relating to networking. General items could include:
 - latency
 - jitter
 - parallel bandwidth
+- write and read percentiles 
 
 For further details see the [network tests documentation](network).
 


### PR DESCRIPTION
This PR includes the read and write percentile measurments that we
currently have when we run FIO in our metrics Kata CI.

Fixes #5109

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>