### PR TITLE
metrics: Fix the jitter value

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -238,6 +238,6 @@ description = "measure container jitter using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
-midval = 0.023
+midval = 0.024
 minpercent = 60.0
 maxpercent = 50.0


### PR DESCRIPTION
This PR updates the jitter value that we have when we ran this
network metric on the kata metrics CI.

Fixes #5111

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>