### PR TITLE
metrics: Add init_env to latency test

### DIFF
--- a/metrics/network/latency_kubernetes/latency-network.sh
+++ b/metrics/network/latency_kubernetes/latency-network.sh
@@ -21,6 +21,7 @@ function remove_tmp_file() {
 trap remove_tmp_file EXIT
 
 function main() {
+	init_env
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
 


### PR DESCRIPTION
This PR adds the init_env function to latency test to verify that some dependencies are installed as well to get the test banner.

Fixes #5117

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>