### PR TITLE
ci: ignore license header check for files auto-generated by zbus xmlgen

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -463,6 +463,7 @@ static_check_license_headers()
 			--exclude="src/libs/protocols/protos/gogo/*.proto" \
 			--exclude="src/libs/protocols/protos/google/*.proto" \
 			--exclude="src/libs/*/test/texture/*" \
+			--exclude="src/agent/rustjail/src/cgroups/systemd/interface/*" \
 			-EL $extra_args "\<${pattern}\>" \
 			$files || true)
 


### PR DESCRIPTION
PR#5154 need some rust files auto-generated by zbus-xmlgen for communicating with D-Bus at kata agent. Those file should not be checked for license header anymore.

Fixes: #5122

Depends-on: github.com/kata-containers/kata-containers#5154

Signed-off-by: Yuan-Zhuo <yuanzhuo0118@outlook.com>