### PR TITLE
spell-check: Add crictl to dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -11,6 +11,7 @@ BusyBox/B
 ccloudvm/B
 codecov/B
 containerd/B
+crictl/B
 cri-o/B
 CRI-O/B
 DevStack/B


### PR DESCRIPTION
- Add crictl to the dictionary to avoid spell check and work around the link checker failing to parse the heading with backticks

Fixes: #5124
Signed-off-by: stevenhorsman <steven@uk.ibm.com>