### PR TITLE
stable-3.0: update links to stable-3.0

### DIFF
--- a/.ci/ci-fast-return.sh
+++ b/.ci/ci-fast-return.sh
@@ -27,7 +27,7 @@ source "${cidir}/lib.sh"
 
 # If no branch specified, compare against the main branch.
 # The 'branch' var is required by the get_pr() lib functions.
-branch=${branch:-main}
+branch=${branch:-stable-3.0}
 
 # The YAML file containing our filename match patterns.
 yqfile_rootname="ci-fast-return.yaml"

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -12,7 +12,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 
 export katacontainers_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
-export kata_default_branch="${kata_default_branch:-main}"
+export kata_default_branch="${kata_default_branch:-stable-3.0}"
 export CI_JOB="${CI_JOB:-}"
 
 # Name of systemd service for the throttler

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -40,7 +40,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-main}
+branch=${branch:-stable-3.0}
 
 # Which static check functions to consider.
 handle_funcs="all"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/stable-3.0/integration/kubernetes)
+   - [Containerd](https://github.com/kata-containers/tests/tree/stable-3.0/integration/containerd)
 2. [Stability tests](./stability)
-3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
-4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
+3. [Metrics](https://github.com/kata-containers/tests/tree/stable-3.0/metrics)
+4. [VFIO](https://github.com/kata-containers/tests/tree/stable-3.0/functional/vfio)
 
 ## CI Content
 
@@ -164,7 +164,7 @@ possible tests.
 
 ## Write a new Unit Test
 
-See the [unit test advice documentation](https://github.com/kata-containers/kata-containers/blob/main/docs/Unit-Test-Advice.md).
+See the [unit test advice documentation](https://github.com/kata-containers/kata-containers/blob/stable-3.0/docs/Unit-Test-Advice.md).
 
 ## Run the Kata Containers tests
 
@@ -175,7 +175,7 @@ You need to install the following to run Kata Containers tests:
 - [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
-  [versions database](https://github.com/kata-containers/kata-containers/blob/main/versions.yaml).
+  [versions database](https://github.com/kata-containers/kata-containers/blob/stable-3.0/versions.yaml).
 
 - `make`.
 
@@ -183,7 +183,7 @@ You need to install the following to run Kata Containers tests:
 
 The recommended method to set up Kata Containers is to use the official and latest
 stable release. You can find the official documentation to do this in the
-[Kata Containers installation user guides](https://github.com/kata-containers/kata-containers/blob/main/docs/install/README.md).
+[Kata Containers installation user guides](https://github.com/kata-containers/kata-containers/blob/stable-3.0/docs/install/README.md).
 
 To try the latest commits of Kata use the CI scripts, which build and install from the
 `kata-containers` repositories, with the following steps:
@@ -213,7 +213,7 @@ $ export CI_JOB=CRI_CONTAINERD_K8S
 $ .ci/setup.sh
 ```
 In this case we are exporting the environment variables for the CRI_CONTAINERD_K8S Jenkins Job for more information
-of which CI_JOB needs to be used see the following https://github.com/kata-containers/tests/blob/main/.ci/ci_job_flags.sh.
+of which CI_JOB needs to be used see the following https://github.com/kata-containers/tests/blob/stable-3.0/.ci/ci_job_flags.sh.
 
 > **Limitation:** If the script fails for a reason and it is re-executed, it will execute
 all steps from the beginning and not from the failed step.

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -90,7 +90,7 @@ categories:
       Issue cannot be resolved (too hard/impossible, would be too slow,
       insufficient resources, etc).
     url: |
-      https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md
+      https://github.com/kata-containers/kata-containers/blob/stable-3.0/docs/Documentation-Requirements.md
 
   - name: new-contributor
     description: Small, self-contained tasks suitable for newcomers.
@@ -110,7 +110,7 @@ categories:
   - name: related
     description: |
       Related project. Base set can be generated from
-      https://github.com/kata-containers/kata-containers/blob/main/versions.yaml.
+      https://github.com/kata-containers/kata-containers/blob/stable-3.0/versions.yaml.
 
   - name: release
     description: Related to production of new versions.

--- a/cmd/history/history.sh
+++ b/cmd/history/history.sh
@@ -24,7 +24,7 @@ END=${END:-$(date -I -d "$defend")}
 
 # Where are we looking? Default to origin/master
 remote="${remote:-origin}"
-branch="${branch:-main}"
+branch="${branch:-stable-3.0}"
 
 repo_base="github.com/kata-containers"
 repos="${repos:-

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,7 +10,7 @@ description: |
   This file contains test specific version details.
   For other version details, see the main database:
 
-  https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
+  https://github.com/kata-containers/kata-containers/blob/stable-3.0/versions.yaml
 
 docker_images:
   description: "Docker hub images used for testing"


### PR DESCRIPTION
So that we run tests with the correct stable branch.
