### PR TITLE
ci: Add skopeo guard to config change

### DIFF
--- a/integration/containerd/confidential/agent_image.bats
+++ b/integration/containerd/confidential/agent_image.bats
@@ -34,8 +34,10 @@ setup() {
 @test "$test_tag Test can pull a unencrypted signed image from a protected registry" {
 	local container_config="${FIXTURES_DIR}/container-config.yaml"
 
-	add_kernel_params \
-		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		add_kernel_params \
+			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	fi
 
 	create_test_pod
 
@@ -45,8 +47,10 @@ setup() {
 @test "$test_tag Test cannot pull an unencrypted unsigned image from a protected registry" {
 	local container_config="${FIXTURES_DIR}/container-config_unsigned-protected.yaml"
 
-	add_kernel_params \
-		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		add_kernel_params \
+			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	fi
 
 	create_test_pod
 
@@ -61,8 +65,10 @@ setup() {
 @test "$test_tag Test can pull an unencrypted unsigned image from an unprotected registry" {
 	local container_config="${FIXTURES_DIR}/container-config_unsigned-unprotected.yaml"
 
-	add_kernel_params \
-		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		add_kernel_params \
+			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	fi
 
 	create_test_pod
 
@@ -72,8 +78,10 @@ setup() {
 @test "$test_tag Test unencrypted signed image with unknown signature is rejected" {
 	local container_config="${FIXTURES_DIR}/container-config_signed-protected-other.yaml"
 
-	add_kernel_params \
-		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		add_kernel_params \
+			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	fi
 
 	create_test_pod
 

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -49,8 +49,10 @@ setup() {
 	switch_image_service_offload on
 	clear_kernel_params
 	add_kernel_params "${original_kernel_params}"
-	add_kernel_params \
-		"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		add_kernel_params \
+			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
+	fi
 
 	# In case the tests run behind a firewall where images needed to be fetched
 	# through a proxy.


### PR DESCRIPTION
- To try and minimise the kernel_params changes that we do, only add the `agent.container_policy_file` if we need it for skopeo. This means it shouldn't trigger in the operator CI

Fixes: #5137
Signed-off-by: stevenhorsman <steven@uk.ibm.com>