### PR TITLE
k8s: Increase default timeout for CC tests

### DIFF
--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -36,6 +36,7 @@ setup() {
     setup_decryption_files_in_guest
     kubernetes_create_ssh_demo_pod
 
+    sleep 1
     local pod_ip_address=$(kubectl get service ccv0-ssh -o jsonpath="{.spec.clusterIP}")
     ssh-keygen -lf <(ssh-keyscan ${pod_ip_address} 2>/dev/null)
 

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -41,11 +41,11 @@ kubernetes_delete_cc_pod_if_exists() {
 #
 # Parameters:
 #	$1 - the sandbox ID
-#	$2 - wait time in seconds. Defaults to 60. (optional)
+#	$2 - wait time in seconds. Defaults to 120. (optional)
 #
 kubernetes_wait_cc_pod_be_ready() {
 	local pod_name="$1"
-	local wait_time="${2:-60}"
+	local wait_time="${2:-120}"
 
 	kubectl wait --timeout=${wait_time}s --for=condition=ready pods/$pod_name
 }
@@ -99,7 +99,7 @@ checkout_doc_repo_dir() {
 
 kubernetes_create_ssh_demo_pod() {
 	checkout_doc_repo_dir
-	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --timeout=60s --for=condition=ready pods/$pod
+	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --timeout=120s --for=condition=ready pods/$pod
 	kubectl get pod $pod
 }
 


### PR DESCRIPTION
For CC test cases, image will be pulled inside guest and the test cases may run behind firewall, launch time may not stable, increase the wait timeout to avoid random failure due to timeout.

Fixes: #5144

Signed-off-by: Wang, Arron <arron.wang@intel.com>