### PR TITLE
Skip additional tests on cri-o CI

### DIFF
--- a/integration/cri-o/crio_skip_tests.sh
+++ b/integration/cri-o/crio_skip_tests.sh
@@ -87,6 +87,8 @@ declare -A command_skipCRIOTests=(
 )
 declare -A config_skipCRIOTests=(
 ['test "replace default runtime should succeed"']="config.bats case is not working: see `eval echo $url`"
+['test "choose different default runtime should succeed"']="config.bats case is not working: see `eval echo $url`"
+['test "runc not existing when default_runtime changed should succeed"']="config.bats case is not working: see `eval echo $url`"
 ['test "retain default runtime should succeed"']="config.bats case is not working: see `eval echo $url`"
 )
 declare -A config_migrate_skipCRIOTests=(


### PR DESCRIPTION
One of those tests is already skipped, but was renamed. The other is similar. In both cases, the integration test is checking the behaviour of cri-o with default runtimes, which is irrelevant for kata, where the runtime is different anyway.
Those tests need to be skipped.

Fixes: #5156

Signed-off-by: Julien Ropé <jrope@redhat.com>