### PR TITLE
runtime-rs: enable k8s-empty-dirs.bats test

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -60,7 +60,7 @@ else
 	"k8s-nginx-connectivity.bats" \
 	"k8s-hugepages.bats")
 	# TODO: runtime-rs doesn't support the following test cases, and will be fixed/improved in the future:
-	# k8s-block-volume.bats, k8s-cpu-ns.bats, k8s-empty-dirs.bats, k8s-expose-ip.bats,
+	# k8s-block-volume.bats, k8s-cpu-ns.bats, k8s-expose-ip.bats,
 	# k8s-hugepages.bats, k8s-liveness-probes.bats, k8s-nginx-connectivity.bats,
 	# k8s-pid-ns.bats, k8s-ro-volume.bats
 	if [ "$KATA_HYPERVISOR" == "dragonball" ]; then
@@ -70,6 +70,7 @@ else
                 "k8s-copy-file.bats" \
                 "k8s-credentials-secrets.bats" \
                 "k8s-custom-dns.bats" \
+                "k8s-empty-dirs.bats" \
                 "k8s-env.bats" \
                 "k8s-exec.bats" \
                 "k8s-inotify.bats" \


### PR DESCRIPTION
Enable k8s-empty-dirs.bats for runtime-rs.

Fixes: #5160

Depends-on:github.com/kata-containers/kata-containers#5282

Signed-off-by: Bin Liu <bin@hyper.sh>