### PR TITLE
ci: Remove duplicated flags in clh jobs

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -162,26 +162,20 @@ case "${CI_JOB}" in
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
 	;;
-"CLOUD-HYPERVISOR-K8S-CONTAINERD")
+"CLOUD-HYPERVISOR-K8S-CONTAINERD"|"CLOUD-HYPERVISOR-K8S-CONTAINERD-DEVMAPPER"|"EXTERNAL_CLOUD_HYPERVISOR")
 	init_ci_flags
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="cloud-hypervisor"
 	export KUBERNETES="yes"
-	;;
-"CLOUD-HYPERVISOR-K8S-CONTAINERD-DEVMAPPER")
-	init_ci_flags
-	export CRI_CONTAINERD="yes"
-	export CRI_RUNTIME="containerd"
-	export KATA_HYPERVISOR="cloud-hypervisor"
-	export KUBERNETES="yes"
-	export USE_DEVMAPPER="true"
-	;;
-"EXTERNAL_CLOUD_HYPERVISOR")
-	init_ci_flags
-	export CRI_CONTAINERD="yes"
-	export CRI_RUNTIME="containerd"
-	export KATA_HYPERVISOR="cloud-hypervisor"
+	case "${CI_JOB}" in
+		"CLOUD-HYPERVISOR-K8S-CONTAINERD-DEVMAPPER")
+			export USE_DEVMAPPER="true"
+			;;
+		"EXTERNAL_CLOUD_HYPERVISOR")
+			export KUBERNETES="no"
+			;;
+	esac
 	;;
 "EXTERNAL_CRIO")
 	init_ci_flags


### PR DESCRIPTION
This PR removes duplicated flags in some of the clh jobs as they repeat in order to make easier to read the ci_init_flags script.

Fixes #5166

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>