### PR TITLE
openshift-ci: fix build of QEMU

### DIFF
--- a/.ci/openshift-ci/qemu-build-pre.sh
+++ b/.ci/openshift-ci/qemu-build-pre.sh
@@ -32,4 +32,5 @@ sed -i -e 's#\(ARG QEMU_VERSION\).*#\1="'${qemu_version}'"#' static-build/qemu/D
 sed -i -e 's#\(ARG PREFIX\).*#\1="'${prefix}'"#' static-build/qemu/Dockerfile.ci
 sed -i -e 's/\(ARG QEMU_TARBALL\).*/\1="kata-static-qemu.tar.gz"/' static-build/qemu/Dockerfile.ci
 sed -i -e 's#\(ARG QEMU_DESTDIR\).*#\1="/tmp/qemu-static"#' static-build/qemu/Dockerfile.ci
+sed -i -e 's#\(ARG HYPERVISOR_NAME\).*#\1="kata-qemu"#' static-build/qemu/Dockerfile.ci
 popd


### PR DESCRIPTION
On OpenShift CI the tools/packaging/static-build/qemu/Dockerfile have some arguments (ARG) replaced. It is missing the replacement of HYPERVISOR_NAME, that has drive to the qemu build to fail.

Fixes #5173
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>