### PR TITLE
metrics: Remove comment in Dockerfile for blogbench

### DIFF
--- a/metrics/storage/blogbench_dockerfile/Dockerfile.in
+++ b/metrics/storage/blogbench_dockerfile/Dockerfile.in
@@ -23,7 +23,6 @@ RUN apt-get update && \
 	curl -OkL "${BLOGBENCH_URL}/blogbench-${BLOGBENCH_VERSION}.tar.gz" && \
 	tar xzf "blogbench-${BLOGBENCH_VERSION}.tar.gz" -C /
 WORKDIR "/blogbench-${BLOGBENCH_VERSION}"
-#	cd "blogbench-${BLOGBENCH_VERSION}" && \
 RUN arch="$(uname -m)" && \
 	export arch && \
 	./configure --build="${arch}" && \


### PR DESCRIPTION
This PR removes a comment referring a command which is not longer used in the blogbench Dockerfile.

Fixes #5193

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>