### PR TITLE
virtiofsd: Do not install rust

### DIFF
--- a/.ci/install_virtiofsd.sh
+++ b/.ci/install_virtiofsd.sh
@@ -16,8 +16,6 @@ source "${cidir}/lib.sh"
 DESTDIR="${DESTDIR:-/}"
 
 main() {
-	bash "${cidir}/install_rust.sh" && source "$HOME/.cargo/env"
-
 	local buildscript="${katacontainers_repo_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh"
 
 	# Just in case the kata-containers repo is not cloned yet.


### PR DESCRIPTION
As the build of the virtiofsd was changed to be done inside a container as part of https://github.com/kata-containers/kata-containers/pull/5426, there's no need to install rust on the host.

Fixes: #5200
Depends-on: github.com/kata-containers/kata-containers#5426

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>