### PR TITLE
CCv0: ci: Ignore license header check for *.bin files

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -439,6 +439,7 @@ static_check_license_headers()
 			--exclude="*.md" \
 			--exclude="*.pb.go" \
 			--exclude="*pb_test.go" \
+			--exclude="*.bin" \
 			--exclude="*.png" \
 			--exclude="*.pub" \
 			--exclude="*.service" \


### PR DESCRIPTION
`*.bin` files are binary and cannot include a license or copyright header; skip them, similarly to other binary files (`*.jpg`, `*.png`, etc.).

Fixes: #5207

Signed-off-by: Dov Murik <dovmurik@linux.ibm.com>
