### PR TITLE
ci: Add test cases for measured boot image/rootfs

### DIFF
--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -44,6 +44,31 @@ switch_image_service_offload() {
 	esac
 }
 
+# Toggle between different measured rootfs verity schemes during tests.
+#
+# Parameters:
+#	$1: "none" to disable or "dm-verity" to enable measured boot.
+#
+# Environment variables:
+#	RUNTIME_CONFIG_PATH - path to kata's configuration.toml. If it is not
+#			      export then it will figure out the path via
+#			      `kata-runtime env` and export its value.
+#
+switch_measured_rootfs_verity_scheme() {
+	# Load the RUNTIME_CONFIG_PATH variable.
+	load_runtime_config_path
+
+	case "$1" in
+		"dm-verity"|"none")
+			sudo sed -i -e 's/scheme=.* cc_rootfs/scheme='"$1"' cc_rootfs/g' \
+				"$RUNTIME_CONFIG_PATH"
+			;;
+		*)
+			die "Unknown option '$1'"
+			;;
+	esac
+}
+
 # Add parameters to the 'kernel_params' property on kata's configuration.toml
 #
 # Parameters:
@@ -220,3 +245,11 @@ setup_offline_fs_kbc_agent_config_in_guest() {
 	add_kernel_params "agent.config_file=/tests/fixtures/$(basename ${rootfs_agent_config})"
 }
 
+setup_signature_files() {
+	echo "setup signature files"
+	if [ "${SKOPEO:-}" = "yes" ]; then
+		setup_skopeo_signature_files_in_guest
+	else
+		setup_offline_fs_kbc_signature_files_in_guest
+	fi
+}

--- a/integration/containerd/confidential/asserts.sh
+++ b/integration/containerd/confidential/asserts.sh
@@ -66,3 +66,12 @@ assert_logs_contain() {
 	cmd+=" --since \"$test_start_time\" -n 100000"
 	eval $cmd | grep "$message"
 }
+
+# Try to create a pod when it is expected to fail.
+#
+# Note: the global $sandbox_name and $pod_config should be set already.
+#
+assert_pod_fail() {
+	echo "Attempt to create the pod but it should fail"
+	! crictl_create_cc_pod "$pod_config" || /bin/false
+}

--- a/integration/containerd/confidential/tests_common.sh
+++ b/integration/containerd/confidential/tests_common.sh
@@ -64,6 +64,7 @@ setup_common() {
 		sed -i -e 's/8.8.8.8/'${local_dns}'/' "${pod_config}"
 		cat "$pod_config"
 	fi
+	switch_measured_rootfs_verity_scheme none
 }
 
 # Common teardown for tests. Use alongside setup_common().

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -29,6 +29,7 @@ setup() {
     switch_image_service_offload on
     clear_kernel_params
     add_kernel_params "${original_kernel_params}"
+    switch_measured_rootfs_verity_scheme none
 }
 
 @test "$test_tag Test can pull an encrypted image inside the guest with decryption key" {


### PR DESCRIPTION
Measured Boot Image/Rootfs feature will broken current test cases since these test cases will modify the rootfs.
Add two new test cases for measured boot.

Fixes: #5214
Depends-on: github.com/kata-containers/kata-containers#5136

Signed-off-by: Wang, Arron <arron.wang@intel.com>