### PR TITLE
ci: Switch back to virtiofsd on s390x

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -238,8 +238,6 @@ run_unit_test() {
 
 run_main_test() {
 	"${ci_dir_name}/setup.sh"
-	# Use virtio-9p on s390x -- https://github.com/kata-containers/tests/issues/3998 for tracking
-	[ "$arch" = s390x ] && sudo -E "${GOPATH}/src/${tests_repo}/${cidir}/set_kata_config.sh" shared_fs virtio-9p
 
 	if [ "${CI_JOB}" == "VFIO" ]; then
 		pushd "${GOPATH}/src/${tests_repo}"


### PR DESCRIPTION
This is to revert the change at #4414 because
no error is found on the pod deletion on s390x any more. The error was reported at #3998.

NOTE: This should not be merged before https://github.com/kata-containers/kata-containers/pull/5523.

Fixes: #5221

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>