### PR TITLE
ci: Simplify aa_kbc_params setting

### DIFF
--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -84,14 +84,7 @@ setup() {
 			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
 	fi
 
-	# In case the tests run behind a firewall where images needed to be fetched
-	# through a proxy. With measured rootfs enabled, we can not set proxy through
-	# agent config file.
-	local https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
-	if [ -n "$https_proxy" ]; then
-		echo "Enable agent https proxy"
-		add_kernel_params "agent.https_proxy=$https_proxy"
-	fi
+	setup_http_proxy
 	switch_measured_rootfs_verity_scheme none
 }
 

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -29,6 +29,8 @@ setup() {
     switch_image_service_offload on
     clear_kernel_params
     add_kernel_params "${original_kernel_params}"
+
+    setup_http_proxy
     switch_measured_rootfs_verity_scheme none
 }
 

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -133,7 +133,7 @@ assert_pod_fail() {
 }
 
 setup_decryption_files_in_guest() {
-    setup_offline_fs_kbc_agent_config_in_guest
+	add_kernel_params "agent.aa_kbc_params=offline_fs_kbc::null"
 
     curl -Lo "${HOME}/aa-offline_fs_kbc-keys.json" https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
     cp_to_guest_img "etc" "${HOME}/aa-offline_fs_kbc-keys.json" 


### PR DESCRIPTION
Now we can pass in aa_kbc_params via command line, we don't need to mess about with the agent-config.toml file

Depends-on: github.com/kata-containers/kata-containers#5533
Fixes: #5226
Signed-off-by: stevenhorsman <steven@uk.ibm.com>