### PR TITLE
ci: Set-up sig verification config for tests

### DIFF
--- a/functional/sev/run.sh
+++ b/functional/sev/run.sh
@@ -59,7 +59,7 @@ run_kbs() {
 calculate_measurement_and_add_to_kbs() {
   local kernel_path="$(kata-runtime kata-env --json | jq -r .Kernel.Path)"
   local initrd_path="$(kata-runtime kata-env --json | jq -r .Initrd.Path)"
-  local append="tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 console=hvc0 console=hvc1 quiet panic=1 nr_cpus=1 agent.config_file=/etc/agent-config.toml"
+  local append="tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 console=hvc0 console=hvc1 quiet panic=1 nr_cpus=1 agent.config_file=/etc/agent-config.toml agent.enable_signature_verification=false"
 
   # Generate digest from sev-snp-measure output - this also inserts measurement values inside OVMF image
   measurement=$(~/.local/bin/sev-snp-measure --mode=sev --output-format=base64 \

--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -116,6 +116,24 @@ clear_kernel_params() {
 		"$RUNTIME_CONFIG_PATH"
 }
 
+# Remove parameters in the 'kernel_params' property on kata's configuration.toml
+#
+# Parameters:
+#	$1 - parameter name
+#
+# Environment variables:
+#	RUNTIME_CONFIG_PATH - path to kata's configuration.toml. If it is not
+#			      export then it will figure out the path via
+#			      `kata-runtime env` and export its value.
+#
+remove_kernel_param() {
+	local param_name="${1}"
+	load_runtime_config_path
+
+	sudo sed -i "/kernel_params = /s/$param_name=[^[:space:]\"]*//g" \
+		"$RUNTIME_CONFIG_PATH"
+}
+
 # Enable the agent console so that one can open a shell with the guest VM.
 #
 # Environment variables:
@@ -222,6 +240,10 @@ setup_common_signature_files_in_guest() {
 }
 
 setup_offline_fs_kbc_signature_files_in_guest() {
+	# Enable signature verification via kata-configuration by removing the param that disables it
+	remove_kernel_param "agent.enable_signature_verification"
+
+	# Set-up required files in guest image
 	setup_common_signature_files_in_guest
 	add_kernel_params "agent.aa_kbc_params=offline_fs_kbc::null"
 	cp_to_guest_img "etc" "${SHARED_FIXTURES_DIR}/offline-fs-kbc/aa-offline_fs_kbc-resources.json"

--- a/integration/containerd/confidential/agent_image.bats
+++ b/integration/containerd/confidential/agent_image.bats
@@ -31,10 +31,8 @@ setup() {
 	assert_pod_fail
 }
 
-@test "$test_tag Test can pull an unencrypted image inside the guest" {
+@test "$test_tag Test can pull an unencrypted image inside the guest without signature config" {
 	local container_config="${FIXTURES_DIR}/container-config.yaml"
-
-	setup_signature_files
 
 	create_test_pod
 


### PR DESCRIPTION
Update tests that need the signature verification to be enabled, by removing the default kernel_param that disables it

Depends-on: github.com/kata-containers/kata-containers#5552
Fixes: #5228
Signed-off-by: stevenhorsman <steven@uk.ibm.com>