### PR TITLE
CC | ci: Use TDX specific guest image for QEMU CI

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -139,14 +139,15 @@ case "${CI_JOB}" in
 	export CRI_CONTAINERD="yes"
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
-	if [[ "${CI_JOB}" =~ CLOUD_HYPERVISOR ]]; then
-		export KATA_HYPERVISOR="cloud-hypervisor"
-	fi
 	export KATA_BUILD_CC="yes"
-	export AA_KBC="offline_fs_kbc"
+	export AA_KBC="eaa_kbc"
 	export TEE_TYPE="tdx"
 	export KATA_BUILD_KERNEL_TYPE="tdx"
 	export KATA_BUILD_QEMU_TYPE="tdx"
+	if [[ "${CI_JOB}" =~ CLOUD_HYPERVISOR ]]; then
+		export KATA_HYPERVISOR="cloud-hypervisor"
+		export AA_KBC="offline_fs_kbc"
+	fi
 	;;
 "CC_CRI_CONTAINERD_K8S_TDX_QEMU"|"CC_CRI_CONTAINERD_K8S_SE_QEMU"|"CC_CRI_CONTAINERD_K8S_TDX_CLOUD_HYPERVISOR"|"CC_SKOPEO_CRI_CONTAINERD_K8S_TDX_QEMU"|"CC_SKOPEO_CRI_CONTAINERD_K8S_TDX_CLOUD_HYPERVISOR")
 	# This job only tests containerd + k8s
@@ -157,16 +158,20 @@ case "${CI_JOB}" in
 	export KUBERNETES="yes"
 	export AA_KBC="offline_fs_kbc"
 	export KATA_BUILD_CC="yes"
-	if [[ "${CI_JOB}" =~ CLOUD_HYPERVISOR ]]; then
-		export KATA_HYPERVISOR="cloud-hypervisor"
-	fi
 	if [[ "${CI_JOB}" =~ TDX ]]; then
 		export TEE_TYPE="tdx"
 		export KATA_BUILD_KERNEL_TYPE="tdx"
 		export KATA_BUILD_QEMU_TYPE="tdx"
+		export AA_KBC="eaa_kbc"
 	elif [[ "${CI_JOB}" =~ _SE_ ]]; then
 		export TEE_TYPE="se"
 	fi
+
+	if [[ "${CI_JOB}" =~ CLOUD_HYPERVISOR ]]; then
+		export KATA_HYPERVISOR="cloud-hypervisor"
+		export AA_KBC="offline_fs_kbc"
+	fi
+
 	if [[ "${CI_JOB}" =~ SKOPEO ]]; then
 		export UMOCI=yes
 		export SKOPEO=yes

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -80,7 +80,14 @@ build_image_for_cc () {
 		[ "${osbuilder_distro:-ubuntu}" == "ubuntu" ] || \
 			die "The only supported image for Confidential Containers is Ubuntu"
 
-		build_static_artifact_and_install "rootfs-image"
+		if [ "${TEE_TYPE}" == "tdx" ] && [ "${KATA_HYPERVISOR}" == "qemu" ]; then
+			# Cloud Hypervisor is still using `offline_fs_kbc`, so it has to
+			# use the generic image.  QEMU, on the other hand, is using
+			# `eaa_kbc` and it requires the `tdx-rootfs-image`.
+			build_static_artifact_and_install "tdx-rootfs-image"
+		else
+			build_static_artifact_and_install "rootfs-image"
+		fi
 	fi
 }
 

--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -319,11 +319,17 @@ setup_signature_files() {
 # through a proxy. 
 # Note: With measured rootfs enabled, we can not set proxy through
 # agent config file.
-setup_http_proxy() {
+setup_proxy() {
 	local https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
 	if [ -n "$https_proxy" ]; then
 		echo "Enable agent https proxy"
 		add_kernel_params "agent.https_proxy=$https_proxy"
+	fi
+
+	local no_proxy="${NO_PROXY:-${no_proxy:-}}"
+	if [ -n "${no_proxy}" ]; then
+		echo "Enable agent no proxy"
+		add_kernel_params "agent.no_proxy=${no_proxy}"
 	fi
 }
 

--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -283,8 +283,19 @@ setup_cosign_signatures_files() {
 	remove_kernel_param "agent.enable_signature_verification"
 
 	# Set-up required files in guest image
-	add_kernel_params "agent.aa_kbc_params=offline_fs_kbc::null"
-	cp_to_guest_img "etc" "${SHARED_FIXTURES_DIR}/cosign/offline-fs-kbc/aa-offline_fs_kbc-resources.json"
+	case "${AA_KBC:-}" in
+		"offline_fs_kbc")
+			add_kernel_params "agent.aa_kbc_params=offline_fs_kbc::null"
+			cp_to_guest_img "etc" "${SHARED_FIXTURES_DIR}/cosign/offline-fs-kbc/aa-offline_fs_kbc-resources.json"
+			;;
+		"eaa_kbc")
+			# EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+			# by the service, as well as the one configured in the Kata Containers rootfs.
+			add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+			;;
+		*)
+			;;
+	esac
 }
 
 setup_signature_files() {

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -208,6 +208,10 @@ assert_logs_contain() {
 }
 
 @test "$test_tag Test cannot pull an image from an authenticated registry with incorrect credentials" {
+	if [ "${AA_KBC}" = "eaa_kbc" ]; then
+		skip "As the test requires changing verdictd configuration and restarting its service"
+	fi
+
 	REGISTRY_CREDENTIAL_ENCODED="QXJhbmRvbXF1YXl0ZXN0YWNjb3VudHRoYXRkb2VzbnRleGlzdDpwYXNzd29yZAo=" setup_credentials_files "quay.io/kata-containers/confidential-containers-auth"
 
 	pod_config="$(new_pod_config "${image_authenticated}")"

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -199,7 +199,13 @@ assert_logs_contain() {
 
 
 @test "$test_tag Test pull an unencrypted unsigned image from an authenticated registry with correct credentials" {
-	setup_credentials_files "quay.io/kata-containers/confidential-containers-auth"
+	if [ "${AA_KBC}" = "offline_fs_kbc" ]; then
+		setup_credentials_files "quay.io/kata-containers/confidential-containers-auth"
+	elif [ "${AA_KBC}" = "eaa_kbc" ]; then
+		# EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+		# by the service, as well as the one configured in the Kata Containers rootfs.
+		add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+	fi
 
 	pod_config="$(new_pod_config "${image_authenticated}")"
 	echo $pod_config

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -93,7 +93,7 @@ setup() {
 			"agent.container_policy_file=/etc/containers/quay_verification/quay_policy.json"
 	fi
 
-	setup_http_proxy
+	setup_proxy
 	switch_measured_rootfs_verity_scheme none
 }
 

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -35,8 +35,13 @@ setup() {
 }
 
 @test "$test_tag Test can pull an encrypted image inside the guest with decryption key" {
-
-    setup_decryption_files_in_guest
+    if [ "${AA_KBC}" = "offline_fs_kbc" ]; then
+        setup_decryption_files_in_guest
+    elif [ "${AA_KBC}" = "eaa_kbc" ]; then
+        # EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+        # by the service, as well as the one configured in the Kata Containers rootfs.
+        add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+    fi
     kubernetes_create_ssh_demo_pod
 
     sleep 1

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -30,7 +30,7 @@ setup() {
     clear_kernel_params
     add_kernel_params "${original_kernel_params}"
 
-    setup_http_proxy
+    setup_proxy
     switch_measured_rootfs_verity_scheme none
 }
 

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -83,6 +83,7 @@ checkout_doc_repo_dir() {
 
 kubernetes_create_ssh_demo_pod() {
 	checkout_doc_repo_dir
+	[ "${AA_KBC:-}" == "eaa_kbc" ] && sed -i 's#katadocker/ccv0-ssh#katadocker/ssh-demo-eaa-kbc#g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
 	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --timeout=120s --for=condition=ready pods/$pod
 	kubectl get pod $pod
 }


### PR DESCRIPTION
Let's ensure we use the TDX specific image with the QEMU CI, as it uses the eaa_kbc as the aa_kbc.  For Cloud Hypervisor we still stick to using offline_fs_kbc and the "default" image as attestation is not yet implemented on its side.

Fixes: #5233

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>