### PR TITLE
sev: update expected kernel params to include signature param

### DIFF
--- a/functional/sev/run.sh
+++ b/functional/sev/run.sh
@@ -59,7 +59,7 @@ run_kbs() {
 calculate_measurement_and_add_to_kbs() {
   local kernel_path="$(kata-runtime kata-env --json | jq -r .Kernel.Path)"
   local initrd_path="$(kata-runtime kata-env --json | jq -r .Initrd.Path)"
-  local append="tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 console=hvc0 console=hvc1 quiet panic=1 nr_cpus=1 agent.config_file=/etc/agent-config.toml"
+  local append="tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 console=hvc0 console=hvc1 quiet panic=1 nr_cpus=1 agent.config_file=/etc/agent-config.toml agent.enable_signature_verification"
 
   # Generate digest from sev-snp-measure output - this also inserts measurement values inside OVMF image
   measurement=$(~/.local/bin/sev-snp-measure --mode=sev --output-format=base64 \


### PR DESCRIPTION
include new parameter turning off signaure verification.

I think this will work although there is a chance the ordering of the parameters is wrong.

@fidencio @stevenhorsman @ryansavino

Signed-off-by: Tobin Feldman-Fitzthum <tobin@ibm.com>