### PR TITLE
Dragonball CI: add support for several k8s CI

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -60,9 +60,7 @@ else
 	"k8s-nginx-connectivity.bats" \
 	"k8s-hugepages.bats")
 	# TODO: runtime-rs doesn't support the following test cases, and will be fixed/improved in the future:
-	# k8s-block-volume.bats, k8s-cpu-ns.bats, k8s-expose-ip.bats,
-	# k8s-hugepages.bats, k8s-liveness-probes.bats, k8s-nginx-connectivity.bats,
-	# k8s-pid-ns.bats, k8s-ro-volume.bats
+	# k8s-block-volume.bats, k8s-cpu-ns.bats, k8s-hugepages.bats, k8s-pid-ns.bats, k8s-ro-volume.bats
 	if [ "$KATA_HYPERVISOR" == "dragonball" ]; then
                 K8S_TEST_UNION=("k8s-attach-handlers.bats" \
                 "k8s-caps.bats" \
@@ -73,9 +71,11 @@ else
                 "k8s-empty-dirs.bats" \
                 "k8s-env.bats" \
                 "k8s-exec.bats" \
+                "k8s-expose-ip.bats" \
                 "k8s-inotify.bats" \
                 "k8s-job.bats" \
                 "k8s-limit-range.bats" \
+                "k8s-liveness-probes.bats" \
                 "k8s-memory.bats" \
                 "k8s-nested-configmap-secret.bats" \
                 "k8s-number-cpus.bats" \
@@ -89,11 +89,12 @@ else
                 "k8s-qos-pods.bats" \
                 "k8s-replication.bats" \
                 "k8s-scale-nginx.bats" \
-		"k8s-seccomp.bats" \
+                "k8s-seccomp.bats" \
                 "k8s-sysctls.bats" \
                 "k8s-security-context.bats" \
                 "k8s-shared-volume.bats" \
                 "k8s-volume.bats" \
+                "k8s-nginx-connectivity.bats" \
                 )
         fi
 fi


### PR DESCRIPTION
add k8s-expose-ip.bats, k8s-liveness-probes.bats and
k8s-nginx-connectivity.bats k8s CI tests into Dragonball CI.

fixes: https://github.com/kata-containers/tests/issues/5237

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>