### PR TITLE
tests: skip s390x cosign tests

### DIFF
--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -250,6 +250,13 @@ setup_offline_fs_kbc_signature_files_in_guest() {
 }
 
 setup_cosign_signatures_files() {
+
+	# Currently (kata-containers#5582) the support or cosign in image-rs introduce a dependency on
+	# the `ring` crate, so we can't support these features on s390x
+	if [ "$(uname -m)" == "s390x" ]; then
+		skip "Cannot run test on s390x"
+	fi
+
 	# Enable signature verification via kata-configuration by removing the param that disables it
 	remove_kernel_param "agent.enable_signature_verification"
 


### PR DESCRIPTION
cosign support brought in a dependency that doesn't work on s390x so skip those tests for this architecture

Fixes: https://github.com/kata-containers/tests/issues/5241
Depends-on: github.com/https://github.com/kata-containers/kata-containers/pull/5600
Signed-off-by: stevenhorsman <steven@uk.ibm.com>