### PR TITLE
tests: Replace go get containerd for git clone

### DIFF
--- a/.ci/install_cri_containerd.sh
+++ b/.ci/install_cri_containerd.sh
@@ -9,6 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -o errtrace
+set -x
 
 source /etc/os-release || source /usr/lib/os-release
 
@@ -39,10 +40,12 @@ install_from_source() {
 	echo "Trying to install containerd from source"
 	(
 		containerd_repo=$(get_version "externals.containerd.url")
-		go get "${containerd_repo}"
-		cd "${GOPATH}/src/${containerd_repo}" >>/dev/null
+		pushd "${GOPATH}/src/github.com"
+		git clone "https://${containerd_repo}"
+		popd
 
-		add_repo_to_git_safe_directory "${GOPATH}/src/${containerd_repo}"
+		cd "${GOPATH}/src/github.com/containerd" >>/dev/null
+		add_repo_to_git_safe_directory "${GOPATH}/src/github.com/containerd"
 
 		git fetch
 		git checkout "${containerd_tarball_version}"

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -457,9 +457,11 @@ main() {
 	# make sure cri-containerd test install the proper critest version its testing
 	rm -f "${CRITEST}"
 
-	go get ${cri_containerd_repo}
-	pushd "${GOPATH}/src/${cri_containerd_repo}"
+	pushd "${GOPATH}/src/github.com"
+	git clone https://${cri_containerd_repo}
+	popd
 
+	pushd "${GOPATH}/src/github.com/containerd"
 	git reset HEAD
 	git checkout ${containerd_tarball_version}
 	cp "${SCRIPT_PATH}/container_restart_test.go.patch" ./integration/container_restart_test.go


### PR DESCRIPTION
This PR replaces the go get containerd repo for git clone in order to avoid the failures relating with the vendoring and unblock the current CI problems.

Fixes #5253

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>