### PR TITLE
versions: bump golangci-lint

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -281,8 +281,7 @@ static_check_go_arch_specific()
 		info "Installing ${linter}"
 
 		local linter_url=$(get_test_version "externals.golangci-lint.url")
-		# local linter_version=$(get_test_version "externals.golangci-lint.version")
-		local linter_version="v1.45.2" # this work for tests repo
+		local linter_version=$(get_test_version "externals.golangci-lint.version")
 
 		info "Forcing ${linter} version ${linter_version}"
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "${linter_version}"

--- a/cmd/check-markdown/add_test.go
+++ b/cmd/check-markdown/add_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ const (
 )
 
 func createFile(file, contents string) error {
-	return ioutil.WriteFile(file, []byte(contents), testFileMode)
+	return os.WriteFile(file, []byte(contents), testFileMode)
 }
 
 // makeDirs creates two directories below the specified base directory: one is
@@ -137,7 +136,7 @@ func TestDocAddLink(t *testing.T) {
 func TestDocLinkAddrToPath(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 
 	cwd, err := os.Getwd()

--- a/cmd/check-markdown/link_test.go
+++ b/cmd/check-markdown/link_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ import (
 // constructor) and categorise() called. If not set, the constructor will be
 // used.
 func createLinkAndCategorise(assert *assert.Assertions, createLinkManually bool) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 
 	cwd, err := os.Getwd()
@@ -142,7 +141,7 @@ func TestLinkCategorise(t *testing.T) {
 func TestLinkHandleImplicitREADME(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 

--- a/cmd/check-markdown/parse.go
+++ b/cmd/check-markdown/parse.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	bf "gopkg.in/russross/blackfriday.v2"
@@ -36,7 +36,7 @@ func (d *Doc) parse() error {
 
 // parseMarkdown parses the documents markdown.
 func (d *Doc) parseMarkdown() error {
-	bytes, err := ioutil.ReadFile(d.Name)
+	bytes, err := os.ReadFile(d.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Upgrade golangci-lint since we have upgraded golang to 1.19

Fixes: #5259

Signed-off-by: Bin Liu <bin@hyper.sh>