### PR TITLE
Adjust the tests code to k8s v1.25.x

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -156,7 +156,7 @@ configure_network() {
 			info "Restart the CRI-O service due to $issue"
 			sudo systemctl restart crio
 		fi
-		local list_pods="kubectl get -n kube-system --selector app=flannel pods"
+		local list_pods="kubectl get -n kube-flannel --selector app=flannel pods"
 		info "Wait for Flannel pods to show up"
 		waitForProcess "30" "10" \
 			"[ \$($list_pods 2>/dev/null | wc -l) -gt 0 ]"
@@ -164,11 +164,11 @@ configure_network() {
 		for flannel_p in $($list_pods \
 			-o jsonpath='{.items[*].metadata.name}'); do
 			info "Wait for pod $flannel_p be ready"
-			if ! kubectl wait -n kube-system --for=condition=Ready \
+			if ! kubectl wait -n kube-flannel --for=condition=Ready \
 				"pod/$flannel_p"; then
 				info "Flannel pod $flannel_p failed to start"
 				echo "[DEBUG] Pod ${flannel_p}:" 1>&2
-				kubectl describe -n kube-system "pod/$flannel_p"
+				kubectl describe -n kube-flannel "pod/$flannel_p"
 			fi
 		done
 	fi

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -30,11 +30,6 @@ untaint_node() {
 	# Enable the master node to be able to schedule pods.
 	local node_name="$(hostname | awk '{print tolower($0)}')"
 	local get_taints="kubectl get 'node/${node_name}' -o jsonpath='{.spec.taints}'"
-	if eval $get_taints | grep -q 'NoSchedule'; then
-		info "Taint 'NoSchedule' is found. Untaint the node so pods can be scheduled."
-		kubectl taint nodes "${node_name}" \
-			node-role.kubernetes.io/master:NoSchedule-
-	fi
 	if eval $get_taints | grep -q 'control-plane'; then
 		info "Taint 'control-plane' is found. Untaint the node so pods can be scheduled."
 		kubectl taint nodes "${node_name}" \

--- a/versions.yaml
+++ b/versions.yaml
@@ -43,10 +43,10 @@ externals:
   description: "Third-party projects used specifically for testing"
 
   flannel:
-    url: "https://github.com/coreos/flannel"
-    version: "v0.14.0"
+    url: "https://github.com/flannel-io/flannel"
+    version: "v0.20.1"
     # yamllint disable-line rule:line-length
-    kube-flannel_url: "https://raw.githubusercontent.com/coreos/flannel/v0.14.0/Documentation/kube-flannel.yml"
+    kube-flannel_url: "https://raw.githubusercontent.com/flannel-io/flannel/v0.20.1/Documentation/kube-flannel.yml"
 
   xurls:
     description: |


### PR DESCRIPTION
versions: Update flannel to its latest release

Let's bump flannel to its v0.20.1 release as we're bumping k8s to its
v1.25.x, and the version of flannel being used relies on
PodSecurityPolicy, which is now deprecated.

---

integration: Adapt kubernetes/init.sh to k8s v1.25.x

We can drop the NoSchedule taint as it's not used with v1.25.x, while
we use the `control-plane` label instead.

Fixes: #5263

---

