### PR TITLE
Update CRI-O CI to be using the release-1.26 branch

### DIFF
--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -36,7 +36,7 @@ export CI_JOB="EXTERNAL_CRIO"
 export INSTALL_KATA="yes"
 export GO111MODULE=auto
 
-latest_release="1.24"
+latest_release="1.26"
 
 sudo bash -c "cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]

--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -121,10 +121,6 @@ cd "${katacontainers_repo_dir}"
 # Install yq
 ${GOPATH}/src/${tests_repo}/.ci/install_yq.sh
 
-# CRI-O switched to using go 1.18+
-golang_version="1.18.1"
-yq w -i versions.yaml languages.golang.meta.newest-version "${golang_version}"
-
 critools_version="${branch_release_number}.0"
 [ ${critools_version} == "1.24.0" ] && critools_version="1.24.2"
 echo "Using critools ${critools_version}"


### PR DESCRIPTION
cri-o: Remove hack to enforce golang 1.18+

This is not needed anymore as we've bumped the golang version in our CI
to use golang 1.19.2.

---

cri-o: Update to the release-1.26 when using main

Let's make sure we're testing against the latest commits from the CRI-O
side.

Fixes: #5265