### PR TITLE
metrics: Fix limits values

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -68,7 +68,7 @@ description = "measure container average of blogbench write"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
-midval = 898.0
+midval = 805.0
 minpercent = 10.0
 maxpercent = 10.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -107,7 +107,7 @@ description = "measure container average of blogbench read"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .read.Result"
 checktype = "mean"
-midval = 55700.0
+midval = 49802.0
 minpercent = 10.0
 maxpercent = 10.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -173,7 +173,7 @@ description = "measure container bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .bandwidth.Result"
 checktype = "mean"
-midval = 42241350194.0
+midval = 37613781147.0
 minpercent = 10.0
 maxpercent = 10.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -238,6 +238,6 @@ description = "measure container jitter using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
-midval = 0.024
+midval = 0.025
 minpercent = 60.0
 maxpercent = 50.0

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.60
+midval = 0.70
 minpercent = 25.0
 maxpercent = 25.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -225,7 +225,7 @@ description = "measure container parallel bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
 checktype = "mean"
-midval = 50241301733.29
+midval = 44243050018.0
 minpercent = 10.0
 maxpercent = 10.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -55,7 +55,7 @@ description = "measure container average of blogbench write"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
-midval = 907.0
+midval = 800.0
 minpercent = 10.0
 maxpercent = 10.0
 

--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -68,7 +68,7 @@ description = "measure container average of blogbench read"
 # within (inclusive)
 checkvar = ".\"blogbench\".Results | .[] | .read.Result"
 checktype = "mean"
-midval = 55011.88
+midval = 49725.0
 minpercent = 10.0
 maxpercent = 10.0
 


### PR DESCRIPTION
This will fixed the metrics limits after they were affected by the golang bump to 1.19

e4406df1 metrics: Fix iperf3 bandwidth limit for clh
da102334 metrics: Fix blogbench write value for clh
278bf987 metrics: Fix read blogbench limit for qemu
11c9578d metrics: Fix write blogbench limit for qemu
447785f4  metrics: Fix boot time value for clh
75775446 metrics: Fix parallel bandwidth for clh
57bf2d64 metrics: Fix blogbench read value for clh
68d4780d metrics: Fix value for network jitter for clh
