### PR TITLE
metrics: Fix readbw FIO limit for clh

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -133,7 +133,7 @@ description = "measure read-bw using fio"
 # within (inclusive)
 checkvar = ".\"fio\".Results | .[] | .readbw.Result"
 checktype = "mean"
-midval = 88479751.0
+midval = 81568051.0
 minpercent = 25.0
 maxpercent = 25.0
 


### PR DESCRIPTION
This PR fixes the readbw FIO limit for clh due to the golang bump to 1.19

Fixes #5272

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>