### PR TITLE
cni: Remove extra `{` from the CNI config

### DIFF
--- a/.ci/configure_cni.sh
+++ b/.ci/configure_cni.sh
@@ -13,7 +13,6 @@ sudo mkdir -p ${cni_net_config_path}
 
 sudo sh -c 'cat >/etc/cni/net.d/10-mynet.conf <<-EOF
 {
-{
   "cniVersion": "1.0.0",
   "name": "containerd-net",
   "plugins": [


### PR DESCRIPTION
It's been introduced as part of b3fc9dade340d56001858ce153308978a8c90ac3 and for some reason it didn't break the CI on `main`, but caused some issues when rebasing that and running the `CoCo` tests.

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>