### PR TITLE
CI: Relax timeout threshold for flannel

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -158,7 +158,7 @@ configure_network() {
 		fi
 		local list_pods="kubectl get -n kube-system --selector app=flannel pods"
 		info "Wait for Flannel pods to show up"
-		waitForProcess "30" "10" \
+		waitForProcess "60" "10" \
 			"[ \$($list_pods 2>/dev/null | wc -l) -gt 0 ]"
 		local flannel_p
 		for flannel_p in $($list_pods \


### PR DESCRIPTION
The timeout threshold for flannel for s390x is a little bit tight. This is to relax it to 60 secs.

Fixes: #5288

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
(cherry picked from commit dff44db4f17867b453a0f2914085194c322796c2)