### PR TITLE
CC | ci: Enable s390x auth reg e2e tests

### DIFF
--- a/integration/containerd/confidential/fixtures/container-config_authenticated.yaml
+++ b/integration/containerd/confidential/fixtures/container-config_authenticated.yaml
@@ -5,5 +5,5 @@
 metadata:
   name: kata-cc-nginx-authenticated
 image:
-  image: quay.io/kata-containers/confidential-containers-auth:nginx
+  image: quay.io/kata-containers/confidential-containers-auth:test
 log_path: kata-cc.0.log

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -23,7 +23,7 @@ image_unsigned_protected="quay.io/kata-containers/confidential-containers:unsign
 image_unsigned_unprotected="quay.io/prometheus/busybox:latest"
 
 ## Authenticated Image
-image_authenticated="quay.io/kata-containers/confidential-containers-auth:nginx"
+image_authenticated="quay.io/kata-containers/confidential-containers-auth:test"
 
 original_kernel_params=$(get_kernel_params)
 # Allow to configure the runtimeClassName on pod configuration.


### PR DESCRIPTION
Switch test image to use the multi-arch protected image

Fixes: #5291
Signed-off-by: stevenhorsman <steven@uk.ibm.com>