### PR TITLE
runtime-rs: add upcall kernel patch into CI

### DIFF
--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -33,6 +33,10 @@ if [ "${TEE_TYPE:-}" == "sev" ]; then
 	KATA_BUILD_KERNEL_TYPE=sev
 fi
 
+if [ "${KATA_HYPERVISOR:-}" == "dragonball" ]; then
+	KATA_BUILD_KERNEL_TYPE=dragonball
+fi
+
 echo "Install Kata Containers Image"
 echo "rust image is default for Kata 2.0"
 "${cidir}/install_kata_image.sh" "${tag}"

--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -47,6 +47,8 @@ build_and_install_kernel() {
 		sev)
 			extra_opts="-x sev"
 			;;
+		dragonabll)
+			extra_opts="-e -t dragonball"
 	esac
 
 	# Always build and install the kernel version found locally
@@ -182,6 +184,9 @@ main() {
 			;;
 		sev)
 			install_kernel "${kernel_type}" $(get_version "assets.kernel.sev.tag")
+			;;
+		dragonball)
+			install_kernel "${kernel_type}" $(get_version "assets.dragonball-kernel-experimental.version")
 			;;
 		*)
 			info "kernel type '${kernel_type}' not supported"


### PR DESCRIPTION
upcall is a must feature for Dragonball to enable device hotplug, so in CI system we will add upcall patches into build kernel process to let Dragonball use the guest kernel with upcall server.

Depends-on: github.com/kata-containers/kata-containers#5712 

fixes: #5293

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>