### PR TITLE
WIP CI: Restore removed cni plugin files from backup

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -274,6 +274,10 @@ start_cri_runtime_service() {
 
 	sudo systemctl status "${cri}" --no-pager || \
 		die "Unable to start the ${cri} service"
+	if [ ! -f /opt/cni/bin/flannel ]; then
+		info "Plugin \"flannel\" not found, restoring it from backup"
+		tar xvfz /opt/plugins-backup.tar.gz -C /
+	fi
 }
 
 main() {

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -125,6 +125,16 @@ fi
 
 pushd "$kubernetes_dir"
 info "Initialize the test environment"
+plugin_dir="/opt/cni/bin"
+if [ ! -f "${plugin_dir}/flannel" ]; then
+	die "Cannot start testing due to lack of plugin \"flannel\""
+fi
+if [ $(ls "${plugin_dir}" | wc -w) -gt 1 ]; then
+	info "Making backup for cni plugins..."
+	tar cvfz /opt/plugins-backup.tar.gz "${plugin_dir}"
+else
+	die "No plugins, but flannel"
+fi
 wait_init_retry="30"
 if ! bash ./init.sh; then
 	info "Environment initialization failed. Clean up and try again."


### PR DESCRIPTION
I would like to explain what brings me come to this code change to fix the issue. 

1. Is the issue reproducible?

&rightarrow; Yes, when we set the timeout from the current 60 secs to 10 secs ([init.sh#L161](https://github.com/kata-containers/tests/blob/main/integration/kubernetes/init.sh#L161)), the test reaches the timeout at the 1st try and the follow-up initialization of the cluster fails due to the issue of interest.

2. Are the plugin files alive after a separate run of [init.sh](https://github.com/kata-containers/tests/blob/main/integration/kubernetes/init.sh) and [cleanup_env.sh](https://github.com/kata-containers/tests/blob/main/integration/kubernetes/cleanup_env.sh) in the case where no timeout occurs? 

&rightarrow; Yes, plugin files are alive if a cluster is successfully created (running `init.sh`) and cleaned up (running `cleanup_env.sh`) separately.

3. When are the files removed?

&rightarrow; When the scripts are called from [jenkins_job_build.sh](https://github.com/kata-containers/tests/blob/main/.ci/jenkins_job_build.sh) in a single run (no manual intervention in-between). 
&rightarrow; The files are removed while the `containerd` service is stopped in the cleanup (due to the timeout for flannel). Even they are deleted when the cleanup is called while a cluster is fully functioning like:

```
NAMESPACE     NAME                                        READY   STATUS    RESTARTS   AGE
kube-system   coredns-64897985d-bdgdk                     1/1     Running   0          63s
kube-system   coredns-64897985d-m98pd                     1/1     Running   0          63s
kube-system   etcd-kata-ci-worker-01                      1/1     Running   0          87s
kube-system   kube-apiserver-kata-ci-worker-01            1/1     Running   0          87s
kube-system   kube-controller-manager-kata-ci-worker-01   1/1     Running   0          87s
kube-system   kube-flannel-ds-hjm6f                       1/1     Running   0          64s
kube-system   kube-proxy-xfgjb                            1/1     Running   0          64s
kube-system   kube-scheduler-kata-ci-worker-01            1/1     Running   0          87s
```

The code change is just to make backup for the cni plugins before the cluster creation and restore them if `flannel` is not found after the `containerd` service starts.

It is hard to verify this PR with the current CI because the timeout for flannel is too generous (60 secs). But it has been verified in the following scenario:

1. 1st run: set the timeout for flannel to 10 secs &rightarrow; cleanup is triggered
2. 2nd run: set the timeout to 60 secs &rightarrow; the test should end up with success if the plugins are in place ([test log](http://jenkins.katacontainers.io/job/kata-containers-2.0-tests-ubuntu-s390x-main-PR/1309/consoleText)). Otherwise, it hangs at the initialization phase and fails ([test log](http://jenkins.katacontainers.io/job/kata-containers-2.0-tests-ubuntu-s390x-main-PR/1307/consoleText)).

If you are interested at how the code changes for the scenario look like, see at https://gist.github.com/BbolroC/e4828d8f2b06ab35504867d19ab22155

Fixes: #5295

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>