### PR TITLE
CI: Prevent removing cni plugins for retry on baremetal

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -11,6 +11,8 @@ set -o pipefail
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
+info "Clean up bare metal env"
+keep_cni_bin="${1:-false}"
 iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 
 # The kubeadm reset process does not reset or clean up iptables rules
@@ -26,7 +28,9 @@ sudo -E rm -rf "$HOME/.kube"
 
 # Remove existing CNI configurations and binaries.
 sudo sh -c 'rm -rf /var/lib/cni'
-sudo sh -c 'rm -rf /opt/cni/bin/*'
+if [ "${keep_cni_bin}" = "false" ]; then
+	sudo sh -c 'rm -rf /opt/cni/bin/*'
+fi
 
 #cleanup stale file under /run
 sudo sh -c 'rm -rf /run/flannel'

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -15,6 +15,7 @@ CRI_RUNTIME="${CRI_RUNTIME:-crio}"
 
 main () {
 	local cri_runtime_socket=""
+	local keep_cni_bin="${1:-false}"
 
 	case "${CRI_RUNTIME}" in
 	containerd)
@@ -48,7 +49,7 @@ main () {
 
 	# if CI run in bare-metal, we need a set of extra clean
 	if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
-		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
+		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh ${keep_cni_bin}"
 	fi
 
 	info "Check no kata processes are left behind after reseting kubernetes"

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -128,7 +128,7 @@ info "Initialize the test environment"
 wait_init_retry="30"
 if ! bash ./init.sh; then
 	info "Environment initialization failed. Clean up and try again."
-	if ! bash ./cleanup_env.sh; then
+	if ! bash ./cleanup_env.sh "true"; then
 		die "Failed on cleanup, it won't retry. Bailing out..."
 	else
 		# trap on exit should be added only if cleanup_env.sh returned


### PR DESCRIPTION
This is to prevent [cleanup_bare_metal_env.sh](https://github.com/kata-containers/tests/blob/main/integration/kubernetes/cleanup_bare_metal_env.sh) from deleting cni plugin files on baremetal if it is triggered to re-initialize a k8s cluster.

You can find a detailed discussion in #5297.

The changes are verified to work with a [test](http://jenkins.katacontainers.io/job/kata-containers-2.0-tests-ubuntu-s390x-main-PR/1312/).

Fixes: #5295

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>