### PR TITLE
metrics: Defined general variables

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -19,6 +19,7 @@ CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 TEST_REPO="${TEST_REPO:-github.com/kata-containers/tests}"
+JSON_HOST="${JSON_HOST:-}"
 
 KSM_BASE="/sys/kernel/mm/ksm"
 KSM_ENABLE_FILE="${KSM_BASE}/run"

--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -9,6 +9,9 @@
 declare -a json_result_array
 declare -a json_array_array
 
+JSON_TX_ONELINE="${JSON_TX_ONELINE:-}"
+JSON_URL="${JSON_URL:-}"
+
 # Generate a timestamp in nanoseconds since 1st Jan 1970
 timestamp_ns() {
 	local t


### PR DESCRIPTION
This PR defines general variables that are being used in the metrics CI to avoid the failure of undefined variable while running a benchmark locally.

Fixes #5309

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>