### PR TITLE
metrics: Delete daemonset from network metrics

### DIFF
--- a/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -227,6 +227,7 @@ function iperf3_start_deployment() {
 
 function iperf3_deployment_cleanup() {
 	kubectl delete pod "$server_pod_name" "$client_pod_name"
+	kubectl delete ds iperf3-clients 
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
 	if [ -z "${CI_JOB}" ]; then


### PR DESCRIPTION
This PR deletes the daemonset used in iperf3 network metrics in order to ensure a clean environment after running the network metrics.

Fixes #5312

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>