### PR TITLE
lib: Add missing sudo for ctr list

### DIFF
--- a/lib/common.bash
+++ b/lib/common.bash
@@ -223,7 +223,7 @@ clean_env()
 
 clean_env_ctr()
 {
-	local count_running="$(ctr c list -q | wc -l)"
+	local count_running="$(sudo ctr c list -q | wc -l)"
 	local remaining_attempts=10
 	declare -a running_tasks=()
 	local count_tasks=0


### PR DESCRIPTION
This PR adds sudo to get the ctr list in order to have a consistency as all the functions are using sudo with ctr.

Fixes #5316

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>