### PR TITLE
CC | install_runtime: Don't install agent-ctl for CC

### DIFF
--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -98,7 +98,9 @@ build_install_agent_ctl(){
 	popd
 }
 
-build_install_agent_ctl
+if [ "${KATA_BUILD_CC}" == "no" ]; then
+	build_install_agent_ctl
+fi
 
 experimental_qemu="${experimental_qemu:-false}"
 


### PR DESCRIPTION
CC doesn't use agent-ctl for anything and its build time is quite expensive for us.

Fixes: #5318

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>