### PR TITLE
Sev cargo sourcing

### DIFF
--- a/functional/sev/run.sh
+++ b/functional/sev/run.sh
@@ -193,7 +193,9 @@ cleanup() {
 }
 
 main() {
-  source "$HOME/.cargo/env"
+  # Rust required to build sevctl
+  "${tests_repo_dir}/.ci/install_rust.sh" && source "$HOME/.cargo/env"
+  
   mkdir -p test
 
   # Install package dependencies


### PR DESCRIPTION
sev: added rust installation on host

Needed to build sevctl

Fixes: [#5320](https://github.com/kata-containers/tests/issues/5320)

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>