### PR TITLE
k8s: Fix parenthesis on init.sh

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -108,7 +108,7 @@ build_custom_stress_image()
 			waitForProcess 15 3 "curl http://localhost:${registry_port}"
 			sudo -E "${container_engine}" push "${stress_image}"
 		fi
-		if [ "$(uname -m)" != "s390x" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "aarch64" ] && [ "$ID" != "fedora" }; then
+		if [ "$(uname -m)" != "s390x" ] && [ "$(uname -m)" != "ppc64le" ] && [ "$(uname -m)" != "aarch64" ] && [ "$ID" != "fedora" ]; then
 			pushd "${GOPATH}/src/github.com/kata-containers/tests/metrics/density/sysbench-dockerfile"
 			registry_port="5000"
 			sysbench_image="localhost:${registry_port}/sysbench-kata:latest"


### PR DESCRIPTION
This PR fixes the parenthesis on the init.sh that is being used in k8s.

Fixes #5322

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>