### PR TITLE
metrics: Update boot time for qemu

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-sv-c1-small-x86-01.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.69
+midval = 0.86
 minpercent = 20.0
 maxpercent = 20.0
 


### PR DESCRIPTION
It seems that boot time takes a bit longer with the PR below.

Depends-on: github.com/kata-containers/kata-containers#5736
Fixes #5328 
Signed-off-by: Greg Kurz <groug@kaod.org>