### PR TITLE
metrics: Adjust write 95 percentile for FIO

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-sv-c1-small-x86-01.toml
@@ -94,7 +94,7 @@ description = "measure write 95 percentile using fio"
 # within (inclusive)
 checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
 checktype = "mean"
-midval = 72362.0
+midval = 87296.0
 minpercent = 70.0
 maxpercent = 70.0
 


### PR DESCRIPTION
This PR adjust the average for the write 95 percentile for the FIO metrics.

Fixes #5330

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>