### PR TITLE
tests: Explicitly set the containerd config file version

### DIFF
--- a/.ci/configure_containerd_for_kata.sh
+++ b/.ci/configure_containerd_for_kata.sh
@@ -14,6 +14,7 @@ readonly runc_path=$(command -v runc)
 sudo mkdir -p /etc/containerd/
 
 cat << EOF | sudo tee /etc/containerd/config.toml
+version = 2
 [debug]
   level = "debug"
 [plugins]

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -119,6 +119,7 @@ create_containerd_config() {
 	runtime="${runtime//./-}"
 
 cat << EOF | sudo tee "${CONTAINERD_CONFIG_FILE}"
+version = 2
 [debug]
   level = "debug"
 [plugins]

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -118,6 +118,7 @@ function config_containerd() {
 	fi
 
 	cat <<EOF | sudo tee $containerd_config
+version = 2
 [debug]
   level = "debug"
 [proxy_plugins]


### PR DESCRIPTION
containerd config version 1 has been deprecated and will be removed in containerd v2.0

Fixes: #5352

Signed-off-by: Bin Liu <bin@hyper.sh>