### PR TITLE
test: update ci system to let dragonball use upcall 

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -47,7 +47,7 @@ build_and_install_kernel() {
 		sev)
 			extra_opts="-x sev"
 			;;
-		dragonabll)
+		dragonball)
 			extra_opts="-e -t dragonball"
 	esac
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -121,6 +121,7 @@ case "${KATA_HYPERVISOR}" in
 		fi
 		;;
 	"dragonball")
+		sudo sed -i -e 's/vmlinux.container/vmlinux-dragonball-experimental.container/' "${PKGDEFAULTSDIR}/configuration-dragonball.toml"
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-dragonball.toml"
 		;;
 	*)


### PR DESCRIPTION
1. dragonball is mispelled as dragonabll for upcall kernel.
    
2. we need to update the config file for Dragonball in order to let
    upcall kernel be used.

fixes: #5354

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>