### PR TITLE
SEV: Fix pulling image labels

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -128,7 +128,7 @@ case "${CI_JOB}" in
 			fi
 			if [[ "${CI_JOB}" =~ SEV ]]; then
 				export TEE_TYPE="sev"
-				export AA_KBC="offline_sev_kbc"
+				export AA_KBC="online_sev_kbc"
 				export TEST_INITRD="yes"
 			fi
 			;;

--- a/functional/sev/run.sh
+++ b/functional/sev/run.sh
@@ -71,7 +71,7 @@ calculate_measurement_and_add_to_kbs() {
   if [[ -z "${measurement}" ]]; then >&2 echo "Measurement is invalid"; return 1; fi
 
   # Get encryption key from docker image label
-  enc_key=$(esudo docker inspect quay.io/kata-containers/encrypted-image-tests:unencrypted \
+  enc_key=$(esudo docker inspect ghcr.io/fitzthum/encrypted-image-tests:unencrypted \
     | jq -r '.[0].Config.Labels.enc_key')
 
   # Add key, keyset and policy with measurement to DB
@@ -113,7 +113,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: encrypted-image-tests
-        image: quay.io/kata-containers/encrypted-image-tests:encrypted
+        image: ghcr.io/fitzthum/encrypted-image-tests:encrypted
         imagePullPolicy: Always
 EOF
 
@@ -141,7 +141,7 @@ EOF
   pod_ip=$(esudo kubectl get pod -o wide | grep encrypted-image-tests | awk '{print $6;}')
   
   # Get ssh key from docker image label and save to file
-  esudo docker inspect quay.io/kata-containers/encrypted-image-tests:unencrypted \
+  esudo docker inspect ghcr.io/fitzthum/encrypted-image-tests:unencrypted \
     | jq -r '.[0].Config.Labels.ssh_key' \
     | sed "s|\(-----BEGIN OPENSSH PRIVATE KEY-----\)|\1\n|g" \
     | sed "s|\(-----END OPENSSH PRIVATE KEY-----\)|\n\1|g" \
@@ -203,7 +203,7 @@ main() {
   pip install sev-snp-measure
 
   # Pull unencrypted docker image to get labels
-  esudo docker pull quay.io/kata-containers/encrypted-image-tests:unencrypted
+  esudo docker pull ghcr.io/fitzthum/encrypted-image-tests:unencrypted
 
   # Copy agent-config.toml to initrd image
   initrd_add_files

--- a/functional/sev/run.sh
+++ b/functional/sev/run.sh
@@ -71,7 +71,7 @@ calculate_measurement_and_add_to_kbs() {
   if [[ -z "${measurement}" ]]; then >&2 echo "Measurement is invalid"; return 1; fi
 
   # Get encryption key from docker image label
-  enc_key=$(esudo docker inspect quay.io/kata-containers/encrypted-image-tests:encrypted \
+  enc_key=$(esudo docker inspect quay.io/kata-containers/encrypted-image-tests:unencrypted \
     | jq -r '.[0].Config.Labels.enc_key')
 
   # Add key, keyset and policy with measurement to DB
@@ -141,7 +141,7 @@ EOF
   pod_ip=$(esudo kubectl get pod -o wide | grep encrypted-image-tests | awk '{print $6;}')
   
   # Get ssh key from docker image label and save to file
-  esudo docker inspect quay.io/kata-containers/encrypted-image-tests:encrypted \
+  esudo docker inspect quay.io/kata-containers/encrypted-image-tests:unencrypted \
     | jq -r '.[0].Config.Labels.ssh_key' \
     | sed "s|\(-----BEGIN OPENSSH PRIVATE KEY-----\)|\1\n|g" \
     | sed "s|\(-----END OPENSSH PRIVATE KEY-----\)|\n\1|g" \
@@ -202,8 +202,8 @@ main() {
   esudo apt install -y docker-compose
   pip install sev-snp-measure
 
-  # Pull encrypted docker image - workload
-  esudo docker pull quay.io/kata-containers/encrypted-image-tests:encrypted
+  # Pull unencrypted docker image to get labels
+  esudo docker pull quay.io/kata-containers/encrypted-image-tests:unencrypted
 
   # Copy agent-config.toml to initrd image
   initrd_add_files

--- a/integration/kubernetes/confidential/fixtures/encrypted-image-tests.yaml
+++ b/integration/kubernetes/confidential/fixtures/encrypted-image-tests.yaml
@@ -24,5 +24,5 @@ spec:
       runtimeClassName: kata-qemu-sev
       containers:
       - name: encrypted-image-tests
-        image: quay.io/kata-containers/encrypted-image-tests:encrypted
+        image: ghcr.io/fitzthum/encrypted-image-tests:encrypted
         imagePullPolicy: Always

--- a/integration/kubernetes/confidential/fixtures/unencrypted-image-tests.yaml
+++ b/integration/kubernetes/confidential/fixtures/unencrypted-image-tests.yaml
@@ -24,5 +24,5 @@ spec:
       runtimeClassName: kata-qemu-sev
       containers:
       - name: unencrypted-image-tests
-        image: quay.io/kata-containers/encrypted-image-tests:unencrypted
+        image: ghcr.io/fitzthum/encrypted-image-tests:unencrypted
         imagePullPolicy: Always

--- a/integration/kubernetes/confidential/sev.bats
+++ b/integration/kubernetes/confidential/sev.bats
@@ -360,11 +360,11 @@ EOF
   pod_info=$(esudo kubectl describe pod ${pod_name})
 
   # Check failure condition
-  if [[ ! ${pod_info} =~ "fw digest not valid" ]]; then
+  if [[ ! ${pod_info} =~ "Failed to pull image" ]]; then
     >&2 echo -e "${RED}TEST - FAIL${NC}"
     return 1
   else
-    echo "Pod message contains: fw digest not valid"
+    echo "Pod message contains: Failed to pull image"
     echo -e "${GREEN}TEST - PASS${NC}"
   fi
 }

--- a/integration/kubernetes/confidential/sev.bats
+++ b/integration/kubernetes/confidential/sev.bats
@@ -156,7 +156,7 @@ run_kbs() {
 
 pull_unencrypted_image_and_set_keys() {
   # Pull unencrypted test image to get labels
-  local unencrypted_image_url="quay.io/kata-containers/encrypted-image-tests:unencrypted"
+  local unencrypted_image_url="ghcr.io/fitzthum/encrypted-image-tests:unencrypted"
   esudo docker pull "${unencrypted_image_url}"
 
   # Get encryption key from docker image label

--- a/integration/kubernetes/confidential/sev.bats
+++ b/integration/kubernetes/confidential/sev.bats
@@ -154,17 +154,17 @@ run_kbs() {
   popd
 }
 
-pull_encrypted_image_and_set_keys() {
-  # Pull encrypted docker image - test workload
-  local encrypted_image_url="quay.io/kata-containers/encrypted-image-tests:encrypted"
-  esudo docker pull "${encrypted_image_url}"
+pull_unencrypted_image_and_set_keys() {
+  # Pull unencrypted test image to get labels
+  local unencrypted_image_url="quay.io/kata-containers/encrypted-image-tests:unencrypted"
+  esudo docker pull "${unencrypted_image_url}"
 
   # Get encryption key from docker image label
-  ENCRYPTION_KEY=$(esudo docker inspect ${encrypted_image_url} \
+  ENCRYPTION_KEY=$(esudo docker inspect ${unencrypted_image_url} \
     | jq -r '.[0].Config.Labels.enc_key')
 
   # Get ssh key from docker image label and save to file
-  esudo docker inspect ${encrypted_image_url} \
+  esudo docker inspect ${unencrypted_image_url} \
     | jq -r '.[0].Config.Labels.ssh_key' \
     | sed "s|\(-----BEGIN OPENSSH PRIVATE KEY-----\)|\1\n|g" \
     | sed "s|\(-----END OPENSSH PRIVATE KEY-----\)|\n\1|g" \
@@ -265,9 +265,9 @@ setup_file() {
   echo "Setting up simple-kbs..."
   run_kbs
 
-  # Pull image and retrieve encryption and ssh keys
-  echo "Pulling encrypted image and setting keys..."
-  pull_encrypted_image_and_set_keys
+  # Pull unencrypted image and retrieve encryption and ssh keys
+  echo "Pulling unencrypted image and setting keys..."
+  pull_unencrypted_image_and_set_keys
 
   echo "SETUP FILE - COMPLETE"
   echo "###############################################################################"


### PR DESCRIPTION
Docker fails to pull encrypted image to get labels. Use the unencrypted image (which has the same labels) instead.

Fixes: #5360

Signed-off-by: Tobin Feldman-Fitzthum <tobin@ibm.com>

cc: @ryansavino