### PR TITLE
ci: remove the PodOverhead feature gate for kubernetes 1.26

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -19,10 +19,10 @@ main () {
 
 	case "${CRI_RUNTIME}" in
 	containerd)
-		cri_runtime_socket="/run/containerd/containerd.sock"
+		cri_runtime_socket="unix:///run/containerd/containerd.sock"
 		;;
 	crio)
-		cri_runtime_socket="/var/run/crio/crio.sock"
+		cri_runtime_socket="unix:///var/run/crio/crio.sock"
 		;;
 	*)
 		die "Runtime ${CRI_RUNTIME} not supported"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -164,7 +164,7 @@ configure_network() {
 			info "Restart the CRI-O service due to $issue"
 			sudo systemctl restart crio
 		fi
-		local list_pods="kubectl get -n kube-system --selector app=flannel pods"
+		local list_pods="kubectl get -n kube-flannel --selector app=flannel pods"
 		info "Wait for Flannel pods to show up"
 		waitForProcess "60" "10" \
 			"[ \$($list_pods 2>/dev/null | wc -l) -gt 0 ]"
@@ -172,11 +172,11 @@ configure_network() {
 		for flannel_p in $($list_pods \
 			-o jsonpath='{.items[*].metadata.name}'); do
 			info "Wait for pod $flannel_p be ready"
-			if ! kubectl wait -n kube-system --for=condition=Ready \
+			if ! kubectl wait -n kube-flannel --for=condition=Ready \
 				"pod/$flannel_p"; then
 				info "Flannel pod $flannel_p failed to start"
 				echo "[DEBUG] Pod ${flannel_p}:" 1>&2
-				kubectl describe -n kube-system "pod/$flannel_p"
+				kubectl describe -n kube-flannel "pod/$flannel_p"
 			fi
 		done
 	fi

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -292,11 +292,11 @@ main() {
 
 	case "${CRI_RUNTIME}" in
 	containerd)
-		cri_runtime_socket="/run/containerd/containerd.sock"
+		cri_runtime_socket="unix:///run/containerd/containerd.sock"
 		cgroup_driver="cgroupfs"
 		;;
 	crio)
-		cri_runtime_socket="/var/run/crio/crio.sock"
+		cri_runtime_socket="unix:///var/run/crio/crio.sock"
 		cgroup_driver="systemd"
 		;;
 	*)

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -30,11 +30,6 @@ untaint_node() {
 	# Enable the master node to be able to schedule pods.
 	local node_name="$(hostname | awk '{print tolower($0)}')"
 	local get_taints="kubectl get 'node/${node_name}' -o jsonpath='{.spec.taints}'"
-	if eval $get_taints | grep -q 'NoSchedule'; then
-		info "Taint 'NoSchedule' is found. Untaint the node so pods can be scheduled."
-		kubectl taint nodes "${node_name}" \
-			node-role.kubernetes.io/master:NoSchedule-
-	fi
 	if eval $get_taints | grep -q 'control-plane'; then
 		info "Taint 'control-plane' is found. Untaint the node so pods can be scheduled."
 		kubectl taint nodes "${node_name}" \

--- a/integration/kubernetes/kubeadm/config.yaml
+++ b/integration/kubernetes/kubeadm/config.yaml
@@ -13,18 +13,10 @@ networking:
   dnsDomain: cluster.local
   podSubnet: 10.244.0.0/16
   serviceSubnet: 10.96.0.0/12
-apiServer:
-  extraArgs:
-    feature-gates: PodOverhead=true
-scheduler:
-  extraArgs:
-    feature-gates: PodOverhead=true
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: CGROUP_DRIVER
-featureGates:
-  PodOverhead: true
 systemReserved:
   cpu: 500m
   memory: 256Mi

--- a/versions.yaml
+++ b/versions.yaml
@@ -43,10 +43,10 @@ externals:
   description: "Third-party projects used specifically for testing"
 
   flannel:
-    url: "https://github.com/coreos/flannel"
-    version: "v0.14.0"
+    url: "https://github.com/flannel-io/flannel"
+    version: "v0.20.1"
     # yamllint disable-line rule:line-length
-    kube-flannel_url: "https://raw.githubusercontent.com/coreos/flannel/v0.14.0/Documentation/kube-flannel.yml"
+    kube-flannel_url: "https://raw.githubusercontent.com/flannel-io/flannel/v0.20.1/Documentation/kube-flannel.yml"
 
   xurls:
     description: |


### PR DESCRIPTION
Depends-on: github.com/kata-containers/kata-containers#5989 Fixes: #5365

Signed-off-by: Julien Ropé <jrope@redhat.com>