### PR TITLE
metrics: Update sysbench pod yaml

### DIFF
--- a/metrics/density/runtimeclass_workloads/sysbench-pod.yaml
+++ b/metrics/density/runtimeclass_workloads/sysbench-pod.yaml
@@ -9,7 +9,6 @@ metadata:
   name: test-sysbench
 spec:
   terminationGracePeriodSeconds: 0
-  shareProcessNamespace: true
   runtimeClassName: kata
   containers:
   - name: test-sysbench


### PR DESCRIPTION
This PR updates the sysbench pod yaml by removing the shareProcessNamespace configuration as this bench does not need that processes in the container are visible to all containers in the same pod.

Fixes #5370

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>