### PR TITLE
spellcheck: Add Tokio to dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -85,6 +85,7 @@ SQLite/B
 SUSE/B
 systemd/B
 TravisCI/B
+Tokio/B
 Vexxhost/B
 virtcontainers/B
 VMWare/B


### PR DESCRIPTION
This PR adds Tokio as part of our spell check dictionary as this is part of Rust.

Fixes #5378

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>