### PR TITLE
metrics: Support to gathered latency results

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -47,6 +47,10 @@ test_queries+=(".\"memory-footprint-inside-container\".Results | .[] | .memtotal
 if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 	tests+=("network-iperf3")
 	test_queries+=(".\"network-iperf3\".Results | .[] | .cpu.Result")
+
+	tests+=("latency")
+	test_queries+=(".\"latency\".Results | .[] | .latency.Result")
+
 fi
 
 # What is the base URL of the Jenkins server


### PR DESCRIPTION
This PR adds support to gathered the latency metrics that we get from the artifacts when running the metrics CI.

Fixes #5387

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>