### PR TITLE
runtime-rs: add cpu-ns k8s test case

### DIFF
--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -67,6 +67,7 @@ else
                 "k8s-caps.bats" \
                 "k8s-configmap.bats" \
                 "k8s-copy-file.bats" \
+                "k8s-cpu-ns.bats" \
                 "k8s-credentials-secrets.bats" \
                 "k8s-custom-dns.bats" \
                 "k8s-empty-dirs.bats" \


### PR DESCRIPTION
Since runtime-rs enable cpu resize ability, we could try to enable k8s cpu ns test cases.

fixes: #5391
Depends-on:github.com/kata-containers/kata-containers#6009

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>