### PR TITLE
spellcheck: Add Cassandra to dictionary

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -8,6 +8,7 @@ Ansible/B
 AppArmor/B
 blogbench/B
 BusyBox/B
+Cassandra/B
 ccloudvm/B
 codecov/B
 containerd/B


### PR DESCRIPTION
This PR adds Cassandra as part of our spell check dictionary as this is part of the metrics benchmarks.

Fixes #5393

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>