### PR TITLE
docs: Add sysbench metrics information

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -83,6 +83,7 @@ snapcraft/B
 snapd/B
 SQLite/B
 SUSE/B
+Sysbench/B
 systemd/B
 TravisCI/B
 Tokio/B

--- a/metrics/density/README.md
+++ b/metrics/density/README.md
@@ -51,3 +51,9 @@ For more details see the [footprint test documentation](footprint_data.md).
 Measures the memory statistics *inside* the container. This allows evaluation of
 the overhead the VM kernel and rootfs are having on the memory that was requested
 by the container co-ordination system, and thus supplied to the VM.
+
+## `k8s-sysbench`
+
+Sysbench is an open-source and multi-purpose benchmark utility that evaluates parameters features
+tests for CPU, memory and I/O. Currently the `k8s-sysbench` test is measuring
+the CPU performance.


### PR DESCRIPTION
This PR adds the sysbench metrics information for the current sysbench that we have.

Fixes #5396

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>