### PR TITLE
ci: use flannel from master for ppc64le

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -44,9 +44,9 @@ externals:
 
   flannel:
     url: "https://github.com/flannel-io/flannel"
-    version: "v0.20.2"
+    version: "v0.21.0"
     # yamllint disable-line rule:line-length
-    kube-flannel_url: "https://raw.githubusercontent.com/flannel-io/flannel/v0.20.2/Documentation/kube-flannel.yml"
+    kube-flannel_url: "https://raw.githubusercontent.com/flannel-io/flannel/v0.21.0/Documentation/kube-flannel.yml"
 
   xurls:
     description: |


### PR DESCRIPTION
The images used in the flannel version for CI - `v0.20.2` doesn't support `ppc64le`. Use the latest yaml until the next release to fix the Power CI.

Fixes: #5403

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>