### PR TITLE
SEV: Add annotation support

### DIFF
--- a/integration/kubernetes/confidential/fixtures/service.yaml.in
+++ b/integration/kubernetes/confidential/fixtures/service.yaml.in
@@ -24,6 +24,8 @@ spec:
     metadata:
       labels:
         app: $NAME
+      annotations:
+        io.katacontainers.config.pre_attestation.uri: "$KBS_URI"
     spec:
       runtimeClassName: $RUNTIMECLASS
       containers:


### PR DESCRIPTION
Set KBS_URI via annotation and don't modify the kernel params if we're using a new config file.

Note that this is written to keep the tests from breaking before and after we merge https://github.com/kata-containers/kata-containers/pull/5665. This requires one extra conditional. Once we have 5665 merged I will remove it.

@jimcadden
