### PR TITLE
CI: Stabilize kubernetes integration tests

### DIFF
--- a/integration/kubernetes/cleanup_bare_metal_env.sh
+++ b/integration/kubernetes/cleanup_bare_metal_env.sh
@@ -11,6 +11,8 @@ set -o pipefail
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../../lib/common.bash"
 
+info "Clean up bare metal env"
+keep_cni_bin="${1:-false}"
 iptables_cache="${KATA_TESTS_DATADIR}/iptables_cache"
 
 # The kubeadm reset process does not reset or clean up iptables rules
@@ -26,7 +28,9 @@ sudo -E rm -rf "$HOME/.kube"
 
 # Remove existing CNI configurations and binaries.
 sudo sh -c 'rm -rf /var/lib/cni'
-sudo sh -c 'rm -rf /opt/cni/bin/*'
+if [ "${keep_cni_bin}" = "false" ]; then
+	sudo sh -c 'rm -rf /opt/cni/bin/*'
+fi
 
 #cleanup stale file under /run
 sudo sh -c 'rm -rf /run/flannel'

--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -15,6 +15,7 @@ CRI_RUNTIME="${CRI_RUNTIME:-crio}"
 
 main () {
 	local cri_runtime_socket=""
+	local keep_cni_bin="${1:-false}"
 
 	case "${CRI_RUNTIME}" in
 	containerd)
@@ -48,7 +49,7 @@ main () {
 
 	# if CI run in bare-metal, we need a set of extra clean
 	if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
-		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh"
+		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh ${keep_cni_bin}"
 	fi
 
 	info "Check no kata processes are left behind after reseting kubernetes"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -158,7 +158,7 @@ configure_network() {
 		fi
 		local list_pods="kubectl get -n kube-flannel --selector app=flannel pods"
 		info "Wait for Flannel pods to show up"
-		waitForProcess "30" "10" \
+		waitForProcess "60" "10" \
 			"[ \$($list_pods 2>/dev/null | wc -l) -gt 0 ]"
 		local flannel_p
 		for flannel_p in $($list_pods \

--- a/integration/kubernetes/run_kubernetes_tests.sh
+++ b/integration/kubernetes/run_kubernetes_tests.sh
@@ -124,7 +124,7 @@ info "Initialize the test environment"
 wait_init_retry="30"
 if ! bash ./init.sh; then
 	info "Environment initialization failed. Clean up and try again."
-	if ! bash ./cleanup_env.sh; then
+	if ! bash ./cleanup_env.sh "true"; then
 		die "Failed on cleanup, it won't retry. Bailing out..."
 	else
 		# trap on exit should be added only if cleanup_env.sh returned


### PR DESCRIPTION
This is to relax timeout threshold for flannel and prevent removing cni plugins for retry on baremetal.

The timeout threshold for flannel for s390x is a little bit tight.
This is to relax it to 60 secs.

Fixes: #5288 and #5295 for stable-3.0

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
(cherry picked from commit 405637f)
(cherry picked from commit dff44db)