### PR TITLE
CC: Enable e2e tests for IBM Z secure execution (SE)

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -158,7 +158,9 @@ case "${CI_JOB}" in
 		export KATA_BUILD_QEMU_TYPE="tdx"
 		export AA_KBC="eaa_kbc"
 	elif [[ "${CI_JOB}" =~ _SE_ ]]; then
-		export TEE_TYPE="se"
+		if grep -q 'prot_virt=1' /proc/cmdline && grep -Eq '^facilities.* 158 .*' /proc/cpuinfo; then
+			export TEE_TYPE="se"
+		fi
 	fi
 
 	if [[ "${CI_JOB}" =~ CLOUD_HYPERVISOR ]]; then

--- a/.ci/install_kata.sh
+++ b/.ci/install_kata.sh
@@ -44,6 +44,18 @@ echo "rust image is default for Kata 2.0"
 echo "Install Kata Containers Kernel"
 "${cidir}/install_kata_kernel.sh" -t "${KATA_BUILD_KERNEL_TYPE}"
 
+if [ "${TEE_TYPE:-}" == "se" ]; then
+	# Set an environment variable HKD_PATH
+	[ -f "${CI_HKD_PATH}" ] || die "Host key document for SE image build not found"
+
+	export HKD_PATH="host-key-document"
+	local_hkd_path="${katacontainers_repo_dir}/${HKD_PATH}"
+	mkdir -p "${local_hkd_path}"
+	cp "${CI_HKD_PATH}" "${local_hkd_path}"
+
+	build_static_artifact_and_install "se-image"
+fi
+
 install_qemu(){
 	echo "Installing qemu"
 	if [ "$experimental_qemu" == "true" ]; then

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -85,6 +85,8 @@ build_image_for_cc () {
 			# use the generic image.  QEMU, on the other hand, is using
 			# `eaa_kbc` and it requires the `tdx-rootfs-image`.
 			build_static_artifact_and_install "tdx-rootfs-image"
+		elif [ "${TEE_TYPE}" == "se" ]; then
+			build_static_artifact_and_install "rootfs-initrd"
 		else
 			build_static_artifact_and_install "rootfs-image"
 		fi

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -137,6 +137,8 @@ case "${KATA_HYPERVISOR}" in
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-tdx.toml"
 		elif [ "$TEE_TYPE" == "sev" ]; then
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-sev.toml"
+		elif [ "$TEE_TYPE" == "se" ]; then
+			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu-se.toml"
 		else
 			enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-qemu.toml"
 		fi


### PR DESCRIPTION
This is to run e2e tests differently based on TEE support for s390x. If the environment is detected, a secure image is built. Otherwise, kernel+rootfs is used for the test.

Fixes: #5429

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>