### PR TITLE
makefile: Add stability baremetal tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ stability:
 	ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
 	cd stability && ./hypervisor_stability_kill_test.sh
 
+stability-baremetal:
+	cd stability && \
+	bash -f stressng.sh
+
 # If hypervisor is dragonball, the default path to keep pod info is /run/kata. Meanwhile, there is 
 # no independent hypervisor process for dragonball, so disale hypervisor_stability_kill_test.sh
 dragonball-stability:


### PR DESCRIPTION
This PR adds the stability baremetal rule at the makefile for the stressng that will run on the baremetal.

Fixes #5433

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>