### PR TITLE
metrics: Add collection for iperf3 parallel results

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -51,6 +51,9 @@ if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 	tests+=("latency")
 	test_queries+=(".\"latency\".Results | .[] | .latency.Result")
 
+	tests+=("network-iperf3")
+	test_queries+=(".\"network-iperf3\".Results | .[] | .parallel.Result")
+
 fi
 
 # What is the base URL of the Jenkins server


### PR DESCRIPTION
This PR adds the collection for iperf3 parallel results that we got from metrics CI.

Fixes #5437

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>