### PR TITLE
metrics: Add collection for iperf3 jitter results

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -54,6 +54,8 @@ if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 	tests+=("network-iperf3")
 	test_queries+=(".\"network-iperf3\".Results | .[] | .parallel.Result")
 
+	tests+=("network-iperf3")
+	test_queries+=(".\"network-iperf3\".Results | .[] | .jitter.Result")
 fi
 
 # What is the base URL of the Jenkins server


### PR DESCRIPTION
This PR adds the collection for iperf3 jitter results that we got from metrics CI.

Fixes #5443

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>