### PR TITLE
stability: Add a new stressor CPU test

### DIFF
--- a/stability/stressng.sh
+++ b/stability/stressng.sh
@@ -48,6 +48,11 @@ function main() {
 	FLOAT_CMD="stress-ng --matrix 1 -t 1m"
 	sudo -E ctr t exec --exec-id 5 "${CONTAINER_NAME}" sh -c "${FLOAT_CMD}"
 
+	# Runs two instances of the CPU stressors, one instance of the matrix
+	info "Running instances of the CPU stressors"
+	INSTANCE_CMD='stress-ng --cpu 2 --matrix 1 --mq 3 -t 5m'
+	sudo -E ctr t exec --exec-id 6 "${CONTAINER_NAME}" sh -c "${INSTANCE_CMD}"
+
 	clean_env_ctr
 }
 


### PR DESCRIPTION
This PR adds a new stressor CPU test for stress-ng as well as puts the file of stressng.sh in the proper file path.

Fixes #5453

Signed-off-by: Gabriela Cervantes [gabriela.cervantes.tellez@intel.com](mailto:gabriela.cervantes.tellez@intel.com)