### PR TITLE
stable-3.1: Change references from main to stable-3.1

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -13,7 +13,7 @@ export KATA_ETC_CONFIG_PATH="/etc/kata-containers/configuration.toml"
 export katacontainers_repo=${katacontainers_repo:="github.com/kata-containers/kata-containers"}
 export katacontainers_repo_git="https://${katacontainers_repo}.git"
 export katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
-export kata_default_branch="${kata_default_branch:-main}"
+export kata_default_branch="${kata_default_branch:-stable-3.1}"
 export CI_JOB="${CI_JOB:-}"
 
 # Name of systemd service for the throttler

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -40,7 +40,7 @@ typeset -r arch_func_regex="_arch_specific$"
 repo=""
 specific_branch="false"
 force="false"
-branch=${branch:-main}
+branch=${branch:-stable-3.1}
 
 # Which static check functions to consider.
 handle_funcs="all"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ We provide several tests to ensure Kata-Containers run on different scenarios
 and with different container managers.
 
 1. Integration tests to ensure compatibility with:
-   - [Kubernetes](https://github.com/kata-containers/tests/tree/main/integration/kubernetes)
-   - [Containerd](https://github.com/kata-containers/tests/tree/main/integration/containerd)
+   - [Kubernetes](https://github.com/kata-containers/tests/tree/stable-3.1/integration/kubernetes)
+   - [Containerd](https://github.com/kata-containers/tests/tree/stable-3.1/integration/containerd)
 2. [Stability tests](./stability)
-3. [Metrics](https://github.com/kata-containers/tests/tree/main/metrics)
-4. [VFIO](https://github.com/kata-containers/tests/tree/main/functional/vfio)
+3. [Metrics](https://github.com/kata-containers/tests/tree/stable-3.1/metrics)
+4. [VFIO](https://github.com/kata-containers/tests/tree/stable-3.1/functional/vfio)
 
 ## CI Content
 
@@ -164,7 +164,7 @@ possible tests.
 
 ## Write a new Unit Test
 
-See the [unit test advice documentation](https://github.com/kata-containers/kata-containers/blob/main/docs/Unit-Test-Advice.md).
+See the [unit test advice documentation](https://github.com/kata-containers/kata-containers/blob/stable-3.1/docs/Unit-Test-Advice.md).
 
 ## Run the Kata Containers tests
 
@@ -175,7 +175,7 @@ You need to install the following to run Kata Containers tests:
 - [golang](https://golang.org/dl)
 
   To view the versions of go known to work, see the `golang` entry in the
-  [versions database](https://github.com/kata-containers/kata-containers/blob/main/versions.yaml).
+  [versions database](https://github.com/kata-containers/kata-containers/blob/stable-3.1/versions.yaml).
 
 - `make`.
 
@@ -183,7 +183,7 @@ You need to install the following to run Kata Containers tests:
 
 The recommended method to set up Kata Containers is to use the official and latest
 stable release. You can find the official documentation to do this in the
-[Kata Containers installation user guides](https://github.com/kata-containers/kata-containers/blob/main/docs/install/README.md).
+[Kata Containers installation user guides](https://github.com/kata-containers/kata-containers/blob/stable-3.1/docs/install/README.md).
 
 To try the latest commits of Kata use the CI scripts, which build and install from the
 `kata-containers` repositories, with the following steps:
@@ -213,7 +213,7 @@ $ export CI_JOB=CRI_CONTAINERD_K8S
 $ .ci/setup.sh
 ```
 In this case we are exporting the environment variables for the CRI_CONTAINERD_K8S Jenkins Job for more information
-of which CI_JOB needs to be used see the following https://github.com/kata-containers/tests/blob/main/.ci/ci_job_flags.sh.
+of which CI_JOB needs to be used see the following https://github.com/kata-containers/tests/blob/stable-3.1/.ci/ci_job_flags.sh.
 
 > **Limitation:** If the script fails for a reason and it is re-executed, it will execute
 all steps from the beginning and not from the failed step.

--- a/cmd/github-labels/labels.yaml.in
+++ b/cmd/github-labels/labels.yaml.in
@@ -110,7 +110,7 @@ categories:
   - name: related
     description: |
       Related project. Base set can be generated from
-      https://github.com/kata-containers/kata-containers/blob/main/versions.yaml.
+      https://github.com/kata-containers/kata-containers/blob/stable-3.1/versions.yaml.
 
   - name: release
     description: Related to production of new versions.

--- a/cmd/pmemctl/pmemctl.sh
+++ b/cmd/pmemctl/pmemctl.sh
@@ -40,7 +40,7 @@ create_file() {
 	local block_size=4096
 	local data_offset=$((1024*1024*2))
 	local dax_alignment=$((1024*1024*2))
-	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/osbuilder/image-builder/nsdax.gpl.c"
+	local nsdax_src_url="https://raw.githubusercontent.com/kata-containers/kata-containers/stable-3.1/tools/osbuilder/image-builder/nsdax.gpl.c"
 
 	truncate -s "${SIZE}" "${FILE}"
 	if [ $((($(stat -c '%s' "${FILE}")/1024/1024)%128)) -ne 0 ]; then

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,7 +10,7 @@ description: |
   This file contains test specific version details.
   For other version details, see the main database:
 
-  https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
+  https://github.com/kata-containers/kata-containers/blob/stable-3.1/versions.yaml
 
 docker_images:
   description: "Docker hub images used for testing"


### PR DESCRIPTION
This will allow tests to be run with the correct branch reference on the newly created stable-3.1 branch.

Fixes: #5455