### PR TITLE
uefi/arm64: enable pflash after install it.

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -123,6 +123,19 @@ clean_up()
 	sudo rm -rf "${EDK2_WORKSPACE}"
 }
 
+enable_pflash_in_config()
+{
+	runtime_config_prefix=("/etc" "/usr/share/defaults" "/opt/kata/defaults")
+	for con_pre in "${runtime_config_prefix[@]}"
+	do
+		config_path="${con_pre}/kata-containers/configuration.toml"
+		[ -f "${config_path}" ] || continue	
+		sudo sed -i 's|pflashes = \[\]|pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]|' "${config_path}"
+		#enable pflash
+		sudo sed -i 's|#pflashes|pflashes|' "${config_path}"
+	done
+}
+
 main()
 {
 	if [ "${arch}" != "aarch64" ]; then
@@ -145,6 +158,8 @@ main()
 
 	echo "Info: install uefi rom image successfully"
 	clean_up
+
+	enable_pflash_in_config
 }
 
 main

--- a/.ci/aarch64/lib_install_qemu_aarch64.sh
+++ b/.ci/aarch64/lib_install_qemu_aarch64.sh
@@ -44,4 +44,8 @@ build_and_install_qemu() {
 	sudo mkdir -p /usr/libexec/kata-qemu/
 	sudo ln -sf $(dirname ${qemu_bin})/../libexec/qemu/virtiofsd /usr/libexec/kata-qemu/virtiofsd
         popd
+
+	# Install UEFI ROM for qemu
+	ENABLE_ARM64_UEFI="${ENABLE_ARM64_UEFI:-true}"
+	[ "${ENABLE_ARM64_UEFI}" == "true" ] && ${cidir}/aarch64/install_rom_aarch64.sh
 }

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -180,15 +180,6 @@ if [ "$ID" == ubuntu ] && [ x"${TEST_INITRD}" == x"yes" ] && [ "$VERSION_ID" != 
 	sudo sed -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
 fi
 
-# Install UEFI ROM for arm64/qemu
-ENABLE_ARM64_UEFI="${ENABLE_ARM64_UEFI:-false}"
-if [ "$arch" == "aarch64" -a "${KATA_HYPERVISOR}" == "qemu" -a "${ENABLE_ARM64_UEFI}" == "true" ]; then
-	${cidir}/aarch64/install_rom_aarch64.sh
-	sudo sed -i 's|pflashes = \[\]|pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]|' "${runtime_config_path}"
-	#enable pflash
-	sudo sed -i 's|#pflashes|pflashes|' "${runtime_config_path}"
-fi
-
 if [ "$TEE_TYPE" == "tdx" ]; then
         echo "Use tdx enabled guest config in ${runtime_config_path}"
         sudo sed -i -e 's/vmlinux.container/vmlinuz-tdx.container/' "${runtime_config_path}"


### PR DESCRIPTION
Enable pflash in configuration after installation. Also, as nvdimm support for qemu on arm need ACPI support, uefi installation should be set to default when install runtime.

Fixes: #5467