### PR TITLE
ci: some tools missing when remove k8s

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -379,6 +379,7 @@ gen_clean_arch() {
 		sudo rm -rf /etc/systemd/system/kubelet.service.d
 		sudo systemctl daemon-reload
 		sudo apt-get autoremove -y kubeadm kubelet kubectl
+		sudo apt install -y curl make git
 	fi
 
 	# Remove existing k8s related configurations and binaries.


### PR DESCRIPTION
When auto remove k8s, some important tools like curl git or make may be removed accordingly. Thus install them back.

Fixes: #5469