### PR TITLE
ci: remove deprecated linters

### DIFF
--- a/.ci/.golangci.yml
+++ b/.ci/.golangci.yml
@@ -14,7 +14,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - gocyclo
     - gofmt
     - gosimple
@@ -22,10 +21,8 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   gocyclo:


### PR DESCRIPTION
The linters `deadcode`, `structcheck` and `varcheck` are deprecated since `v1.49.0`. `unused` can be used instead.

Fixes: #5471