### PR TITLE
tests: Link to instead of copying the default config

### DIFF
--- a/.ci/aarch64/install_rom_aarch64.sh
+++ b/.ci/aarch64/install_rom_aarch64.sh
@@ -130,9 +130,9 @@ enable_pflash_in_config()
 	do
 		config_path="${con_pre}/kata-containers/configuration.toml"
 		[ -f "${config_path}" ] || continue	
-		sudo sed -i 's|pflashes = \[\]|pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]|' "${config_path}"
+		sudo sed --follow-symlinks -i 's|pflashes = \[\]|pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]|' "${config_path}"
 		#enable pflash
-		sudo sed -i 's|#pflashes|pflashes|' "${config_path}"
+		sudo sed --follow-symlinks -i 's|#pflashes|pflashes|' "${config_path}"
 	done
 }
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -97,7 +97,7 @@ fi
 enable_hypervisor_config(){
 	local path=$1
 	sudo rm -f "${PKGDEFAULTSDIR}/configuration.toml"
-	sudo cp -a "$path" "${PKGDEFAULTSDIR}/configuration.toml"
+	sudo ln -sf "$path" "${PKGDEFAULTSDIR}/configuration.toml"
 
 }
 

--- a/.ci/install_runtime.sh
+++ b/.ci/install_runtime.sh
@@ -117,11 +117,11 @@ case "${KATA_HYPERVISOR}" in
 			# Due to a KVM bug, vmx-rdseed-exit must be disabled in QEMU >= 4.2
 			# All CI now uses qemu 5.0+, disabled in the time..
 			# see https://github.com/kata-containers/runtime/pull/2355#issuecomment-625469252
-			sudo sed -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
+			sudo sed --follow-symlinks -i 's|^cpu_features="|cpu_features="-vmx-rdseed-exit,|g' "${runtime_config_path}"
 		fi
 		;;
 	"dragonball")
-		sudo sed -i -e 's/vmlinux.container/vmlinux-dragonball-experimental.container/' "${PKGDEFAULTSDIR}/configuration-dragonball.toml"
+		sudo sed --follow-symlinks -i -e 's/vmlinux.container/vmlinux-dragonball-experimental.container/' "${PKGDEFAULTSDIR}/configuration-dragonball.toml"
 		enable_hypervisor_config "${PKGDEFAULTSDIR}/configuration-dragonball.toml"
 		;;
 	*)
@@ -133,20 +133,20 @@ if [ x"${TEST_INITRD}" == x"yes" ]; then
 	echo "Set to test initrd image"
 	image_path="${image_path:-$SHAREDIR/kata-containers}"
 	initrd_name=${initrd_name:-kata-containers-initrd.img}
-	sudo sed -i -e "s|^image =.*|initrd = \"$image_path/$initrd_name\"|" "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e "s|^image =.*|initrd = \"$image_path/$initrd_name\"|" "${runtime_config_path}"
 fi
 
 if [ -z "${METRICS_CI}" ]; then
 	echo "Enabling all debug options in file ${runtime_config_path}"
-	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
-	sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${runtime_config_path}"
 else
 	echo "Metrics run - do not enable all debug options in file ${runtime_config_path}"
 fi
 
 if [ "$USE_VSOCK" == "yes" ]; then
 	echo "Configure use of VSOCK in ${runtime_config_path}"
-	sudo sed -i -e 's/^#use_vsock.*/use_vsock = true/' "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e 's/^#use_vsock.*/use_vsock = true/' "${runtime_config_path}"
 
 	# On OpenShift CI the vhost module should not be loaded on build time.
 	if [ "$OPENSHIFT_CI" == "false" ]; then
@@ -163,37 +163,37 @@ fi
 
 if [ "$MACHINETYPE" == "q35" ]; then
 	echo "Use machine_type q35"
-	sudo sed -i -e 's|machine_type = "pc"|machine_type = "q35"|' "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e 's|machine_type = "pc"|machine_type = "q35"|' "${runtime_config_path}"
 fi
 
 # Enable experimental features if KATA_EXPERIMENTAL_FEATURES is set to true
 if [ "$KATA_EXPERIMENTAL_FEATURES" = true ]; then
 	echo "Enable runtime experimental features"
 	feature="newstore"
-	sudo sed -i -e "s|^experimental.*$|experimental=[ \"$feature\" ]|" "${runtime_config_path}"
+	sudo sed --follow-symlinks -i -e "s|^experimental.*$|experimental=[ \"$feature\" ]|" "${runtime_config_path}"
 fi
 
 # Enable virtio-blk device driver only for ubuntu with initrd for this moment
 # see https://github.com/kata-containers/tests/issues/1603
 if [ "$ID" == ubuntu ] && [ x"${TEST_INITRD}" == x"yes" ] && [ "$VERSION_ID" != "16.04" ] && [ "$arch" != "ppc64le" ]; then
 	echo "Set virtio-blk as the block device driver on $ID"
-	sudo sed -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
+	sudo sed --follow-symlinks -i 's/block_device_driver = "virtio-scsi"/block_device_driver = "virtio-blk"/' "${runtime_config_path}"
 fi
 
 if [ "$TEE_TYPE" == "tdx" ]; then
         echo "Use tdx enabled guest config in ${runtime_config_path}"
-        sudo sed -i -e 's/vmlinux.container/vmlinuz-tdx.container/' "${runtime_config_path}"
-        sudo sed -i -e 's/^# confidential_guest/confidential_guest/' "${runtime_config_path}"
-        sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 force_tdx_guest tdx_disable_filter "/g' "${runtime_config_path}"
+        sudo sed --follow-symlinks -i -e 's/vmlinux.container/vmlinuz-tdx.container/' "${runtime_config_path}"
+        sudo sed --follow-symlinks -i -e 's/^# confidential_guest/confidential_guest/' "${runtime_config_path}"
+        sudo sed --follow-symlinks -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 force_tdx_guest tdx_disable_filter "/g' "${runtime_config_path}"
 
         case "${KATA_HYPERVISOR}" in
 		"cloud-hypervisor")
-			sudo sed -i -e 's/^firmware = ".*"/firmware = "\/usr\/share\/td-shim\/final-pe.bin"/' "${runtime_config_path}"
+			sudo sed --follow-symlinks -i -e 's/^firmware = ".*"/firmware = "\/usr\/share\/td-shim\/final-pe.bin"/' "${runtime_config_path}"
 			;;
 
 		"qemu")
-			sudo sed -i -e 's/^firmware = ".*"/firmware = "\/usr\/share\/qemu\/OVMF.fd"/' "${runtime_config_path}"
-			sudo sed -i -e 's/^firmware_volume = ".*"/firmware_volume = "\/usr\/share\/qemu\/OVMF_VARS.fd"/' "${runtime_config_path}"
+			sudo sed --follow-symlinks -i -e 's/^firmware = ".*"/firmware = "\/usr\/share\/qemu\/OVMF.fd"/' "${runtime_config_path}"
+			sudo sed --follow-symlinks -i -e 's/^firmware_volume = ".*"/firmware_volume = "\/usr\/share\/qemu\/OVMF_VARS.fd"/' "${runtime_config_path}"
 			;;
         esac
 fi

--- a/.ci/openshift-ci/images/entrypoint.sh
+++ b/.ci/openshift-ci/images/entrypoint.sh
@@ -44,10 +44,10 @@ update_qemu_path()
 	local toml="${SRC}/opt/kata/share/defaults/kata-containers/configuration.toml"
 	# Make a copy of the original file, it can help with debugging.
 	cp -f "$toml" "${toml}.orig"
-	sed -i 's#/opt/kata/bin/qemu-system-x86_64#'${QEMU_PATH}'#g' "$toml"
+	sed --follow-symlinks -i 's#/opt/kata/bin/qemu-system-x86_64#'${QEMU_PATH}'#g' "$toml"
 	# Assume virtiofsd is located at same directory of QEMU.
 	local virtiofsd_path="$(dirname $QEMU_PATH)/virtiofsd"
-	sed -i 's#/opt/kata/libexec/kata-qemu/virtiofsd#'$virtiofsd_path'#g' \
+	sed --follow-symlinks -i 's#/opt/kata/libexec/kata-qemu/virtiofsd#'$virtiofsd_path'#g' \
 		"$toml"
 }
 
@@ -57,7 +57,7 @@ update_kernel_path()
 {
 	local toml="${SRC}/opt/kata/share/defaults/kata-containers/configuration.toml"
 	local kernel_path="/lib/modules/$(uname -r)/vmlinuz"
-	sed -i 's#^kernel = ".*"#kernel = "'${kernel_path}'"#g' "$toml"
+	sed --follow-symlinks -i 's#^kernel = ".*"#kernel = "'${kernel_path}'"#g' "$toml"
 }
 
 # In case the initrd was not created in a build root which kernel version

--- a/.ci/set_kata_config.sh
+++ b/.ci/set_kata_config.sh
@@ -94,7 +94,7 @@ if [ "${KATA_ETC_CONFIG_PATH}" != "${kata_config_path}" ]; then
 		sudo mkdir -p "${kata_etc_dir}"
 	fi
 	info "Creating etc config based on ${kata_config_path}"
-	sudo cp "${kata_config_path}" "${KATA_ETC_CONFIG_PATH}"
+	sudo ln -sf "${kata_config_path}" "${KATA_ETC_CONFIG_PATH}"
 fi
 
 info "modifying config file : ${KATA_ETC_CONFIG_PATH}"

--- a/cmd/kata-manager/kata-manager.sh
+++ b/cmd/kata-manager/kata-manager.sh
@@ -141,14 +141,14 @@ disable_image()
 {
 	config_checks
 
-	sudo sed -i 's/^\(image *=.*\)/# \1/g' "$config_file"
+	sudo sed --follow-symlinks -i 's/^\(image *=.*\)/# \1/g' "$config_file"
 }
 
 disable_initrd()
 {
 	config_checks
 
-	sudo sed -i 's/^\(initrd *=.*\)/# \1/g' "$config_file"
+	sudo sed --follow-symlinks -i 's/^\(initrd *=.*\)/# \1/g' "$config_file"
 }
 
 add_hypervisor_config()
@@ -158,7 +158,7 @@ add_hypervisor_config()
 
 	local -r hypervisor="qemu"
 
-	sudo sed -i "/\[hypervisor\.${hypervisor}\]/a ${name} = $value" "$config_file"
+	sudo sed --follow-symlinks -i "/\[hypervisor\.${hypervisor}\]/a ${name} = $value" "$config_file"
 }
 
 enable_image()
@@ -169,7 +169,7 @@ enable_image()
 
 	config_checks
 
-	sudo sed -i "s!^#*.*image *=.*\$!image = \"$file\"!g" "$config_file"
+	sudo sed --follow-symlinks -i "s!^#*.*image *=.*\$!image = \"$file\"!g" "$config_file"
 
 	egrep -q "\<image\> *=" "$config_file" && return
 
@@ -185,7 +185,7 @@ enable_initrd()
 
 	config_checks
 
-	sudo sed -i "s!^#*.*initrd *=.*\$!initrd = \"$file\"!g" "$config_file"
+	sudo sed --follow-symlinks -i "s!^#*.*initrd *=.*\$!initrd = \"$file\"!g" "$config_file"
 
 	egrep -q "\<initrd\> *=" "$config_file" && return
 
@@ -199,8 +199,8 @@ cmd_enable_full_debug()
 
 	config_checks
 
-	sudo sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' "$config_file"
-	sudo sed -i -e "s/^kernel_params = \"\(.*\)\"/kernel_params = \"\1 ${agent_debug}\"/g" "$config_file"
+	sudo sed --follow-symlinks -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' "$config_file"
+	sudo sed --follow-symlinks -i -e "s/^kernel_params = \"\(.*\)\"/kernel_params = \"\1 ${agent_debug}\"/g" "$config_file"
 }
 
 cmd_disable_all_debug()
@@ -209,22 +209,22 @@ cmd_disable_all_debug()
 
 	config_checks
 
-	sudo sed -i -e 's/^\(enable_debug.*=.*$\)/# \1/g' "$config_file"
-	sudo sed -i -e "s/^\(kernel_params = \".*\)${agent_debug}\(.*\"\)/\1 \2/g" "$config_file"
+	sudo sed --follow-symlinks -i -e 's/^\(enable_debug.*=.*$\)/# \1/g' "$config_file"
+	sudo sed --follow-symlinks -i -e "s/^\(kernel_params = \".*\)${agent_debug}\(.*\"\)/\1 \2/g" "$config_file"
 }
 
 cmd_disable_vsock()
 {
 	info "disabling vsock"
 	config_checks
-	sudo sed -i -e 's/^\(use_vsock.*=.*true\)/# \1/g' "${config_file}"
+	sudo sed --follow-symlinks -i -e 's/^\(use_vsock.*=.*true\)/# \1/g' "${config_file}"
 }
 
 cmd_enable_vsock()
 {
 	info "enabling vsock"
 	config_checks
-	sudo sed -i -e 's/^# *\(use_vsock\).*/\1 = true/' "${config_file}"
+	sudo sed --follow-symlinks -i -e 's/^# *\(use_vsock\).*/\1 = true/' "${config_file}"
 
 	local -r vsock_module="vhost_vsock"
 	echo "Check if ${vsock_module} is loaded"

--- a/functional/rootless/rootless_test.sh
+++ b/functional/rootless/rootless_test.sh
@@ -22,12 +22,12 @@ setup() {
 	sudo chown root:kvm /dev/kvm
 	sudo chmod g+rw /dev/kvm
 	sudo systemctl start crio
-	sudo sed -i -e 's/^# *\(rootless\).*=.*$/\1 = true/g' /usr/share/defaults/kata-containers/configuration.toml
+	sudo sed --follow-symlinks -i -e 's/^# *\(rootless\).*=.*$/\1 = true/g' /usr/share/defaults/kata-containers/configuration.toml
 	sudo rm -rf /run/kata-containers/ /run/vc/
 }
 
 cleanup() {
-	sudo sed -i -e 's/^.*\(rootless\)/# \1/g' /usr/share/defaults/kata-containers/configuration.toml
+	sudo sed --follow-symlinks -i -e 's/^.*\(rootless\)/# \1/g' /usr/share/defaults/kata-containers/configuration.toml
 	sudo crictl stopp "$pod_id" &>/dev/null || true
 	sudo crictl rmp "$pod_id" &>/dev/null || true
 }

--- a/functional/sgx/run.sh
+++ b/functional/sgx/run.sh
@@ -100,7 +100,7 @@ setup_configuration_file() {
 	done
 
 	# enable debug
-	sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+	sed --follow-symlinks -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
 	       -e 's/^#\(debug_console_enabled\).*=.*$/\1 = true/g' \
 	       -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
 	       "${kata_config_file}"

--- a/functional/tdx/lib/common-tdx.bash
+++ b/functional/tdx/lib/common-tdx.bash
@@ -70,7 +70,7 @@ enable_confidential_computing() {
 	sudo crudini --set "${conf_file}" 'hypervisor.qemu' 'firmware' '"'${FIRMWARE}'"'
 	sudo crudini --set "${conf_file}" 'hypervisor.qemu' 'firmware_volume' '"'${FIRMWARE_VOLUME}'"'
 	sudo crudini --set "${conf_file}" 'hypervisor.qemu' 'cpu_features' '"pmu=off,-kvm-steal-time"'
-	sudo sed -i 's|^# confidential_guest.*|confidential_guest = true|' "${conf_file}"
+	sudo sed --follow-symlinks -i 's|^# confidential_guest.*|confidential_guest = true|' "${conf_file}"
 }
 
 remove_tdx_tmp_dir() {

--- a/functional/vcpus/default_vcpus_test.sh
+++ b/functional/vcpus/default_vcpus_test.sh
@@ -34,7 +34,7 @@ function setup() {
 	restart_containerd_service
 	check_processes
 	extract_kata_env
-	sudo sed -i "s/${name} = 1/${name} = 4/g" "${RUNTIME_CONFIG_PATH}"
+	sudo sed --follow-symlinks -i "s/${name} = 1/${name} = 4/g" "${RUNTIME_CONFIG_PATH}"
 }
 
 function test_ctr_with_vcpus() {
@@ -46,7 +46,7 @@ function test_ctr_with_vcpus() {
 
 function teardown() {
 	echo "Running teardown"
-	sudo sed -i "s/${name} = 4/${name} = 1/g" "${RUNTIME_CONFIG_PATH}"
+	sudo sed --follow-symlinks -i "s/${name} = 4/${name} = 1/g" "${RUNTIME_CONFIG_PATH}"
 	clean_env_ctr
 	check_processes
 }

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -187,14 +187,14 @@ setup_configuration_file() {
 	# machine type applies to configuration.toml and configuration-qemu.toml
 	if [ -n "$MACHINE_TYPE" ]; then
 		if [ "$HYPERVISOR" = "qemu" ]; then
-			sed -i 's|^machine_type.*|machine_type = "'${MACHINE_TYPE}'"|g' "${kata_config_file}"
+			sed --follow-symlinks -i 's|^machine_type.*|machine_type = "'${MACHINE_TYPE}'"|g' "${kata_config_file}"
 		else
 			warn "Variable machine_type only applies to qemu. It will be ignored"
 		fi
 	fi
 
 	if [ -n "${SANDBOX_CGROUP_ONLY}" ]; then
-	   sed -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${SANDBOX_CGROUP_ONLY}'|g' "${kata_config_file}"
+	   sed --follow-symlinks -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${SANDBOX_CGROUP_ONLY}'|g' "${kata_config_file}"
 	fi
 
 	# Change to initrd or image depending on user input.
@@ -202,29 +202,29 @@ setup_configuration_file() {
 	if [ "$IMAGE_TYPE" = "initrd" ]; then
 		if $(grep -q "^image.*" ${kata_config_file}); then
 			if $(grep -q "^initrd.*" ${kata_config_file}); then
-				sed -i '/^image.*/d' "${kata_config_file}"
+				sed --follow-symlinks -i '/^image.*/d' "${kata_config_file}"
 			else
-				sed -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${kata_config_file}"
+				sed --follow-symlinks -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${kata_config_file}"
 			fi
 		fi
 	else
 		if $(grep -q "^initrd.*" ${kata_config_file}); then
 			if $(grep -q "^image.*" ${kata_config_file}); then
-				sed -i '/^initrd.*/d' "${kata_config_file}"
+				sed --follow-symlinks -i '/^initrd.*/d' "${kata_config_file}"
 			else
-				sed -i 's|^initrd.*|image = "'${image_file}'"|g' "${kata_config_file}"
+				sed --follow-symlinks -i 's|^initrd.*|image = "'${image_file}'"|g' "${kata_config_file}"
 			fi
 		fi
 	fi
 
 	# enable debug
-	sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+	sed --follow-symlinks -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
 	       -e 's/^#\(debug_console_enabled\).*=.*$/\1 = true/g' \
 	       -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
 	       "${kata_config_file}"
 
 	# enable VFIO relevant hypervisor annotations
-	sed -i -e 's/^\(enable_annotations\).*=.*$/\1 = ["enable_iommu"]/' \
+	sed --follow-symlinks -i -e 's/^\(enable_annotations\).*=.*$/\1 = ["enable_iommu"]/' \
 		"${kata_config_file}"
 }
 

--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -72,14 +72,14 @@ ci_config() {
 	if [ "$ID" == ubuntu ] &&  [ -n "${CI}" ] ;then
 		# https://github.com/kata-containers/tests/issues/352
 		if [ -n "${FACTORY_TEST}" ]; then
-			sudo sed -i -e 's/^#enable_template.*$/enable_template = true/g' "${kata_config}"
+			sudo sed --follow-symlinks -i -e 's/^#enable_template.*$/enable_template = true/g' "${kata_config}"
 			echo "init vm template"
 			sudo -E PATH=$PATH "$RUNTIME" factory init
 		fi
 	fi
 
 	echo "enable debug for kata-runtime"
-	sudo sed -i 's/^#enable_debug =/enable_debug =/g' ${kata_config}
+	sudo sed --follow-symlinks -i 's/^#enable_debug =/enable_debug =/g' ${kata_config}
 }
 
 ci_cleanup() {
@@ -265,11 +265,11 @@ TestContainerMemoryUpdate() {
 		fi
 		info "Test container memory update with virtio-mem"
 
-		sudo sed -i -e 's/^#enable_virtio_mem.*$/enable_virtio_mem = true/g' "${kata_config}"
+		sudo sed --follow-symlinks -i -e 's/^#enable_virtio_mem.*$/enable_virtio_mem = true/g' "${kata_config}"
 	else
 		info "Test container memory update without virtio-mem"
 
-		sudo sed -i -e 's/^enable_virtio_mem.*$/#enable_virtio_mem = true/g' "${kata_config}"
+		sudo sed --follow-symlinks -i -e 's/^enable_virtio_mem.*$/#enable_virtio_mem = true/g' "${kata_config}"
 	fi
 
 	testContainerStart
@@ -321,7 +321,7 @@ TestContainerSwap() {
 	info "Test container with guest swap"
 
 	create_containerd_config "${containerd_runtime_test}" 1
-	sudo sed -i -e 's/^#enable_guest_swap.*$/enable_guest_swap = true/g' "${kata_config}"
+	sudo sed --follow-symlinks -i -e 's/^#enable_guest_swap.*$/enable_guest_swap = true/g' "${kata_config}"
 
 	# Test without swap device
 	testContainerStart

--- a/integration/kubernetes/k8s-hugepages.bats
+++ b/integration/kubernetes/k8s-hugepages.bats
@@ -35,7 +35,7 @@ setup() {
 	sed "s/\${hugepages_size}/$hugepages_size_k8s/" "$pod_config_dir/pod-hugepage.yaml" > "$pod_config_dir/test_hugepage.yaml"
 
 	# Enable hugepages
-	sed -i 's/#enable_hugepages = true/enable_hugepages = true/g' ${RUNTIME_CONFIG_PATH}
+	sed --follow-symlinks -i 's/#enable_hugepages = true/enable_hugepages = true/g' ${RUNTIME_CONFIG_PATH}
 
 	old_pages=$(cat "/sys/kernel/mm/hugepages/$hugepages_sysfs_dir/nr_hugepages")
 
@@ -65,8 +65,8 @@ setup() {
 
 	# Enable sandbox_cgroup_only
 	# And set default memory to a low value that is not smaller then container's request
-	sed -i 's/sandbox_cgroup_only=false/sandbox_cgroup_only=true/g' ${RUNTIME_CONFIG_PATH}
-	sed -i 's|^default_memory.*|default_memory = 512|g' $RUNTIME_CONFIG_PATH
+	sed --follow-symlinks -i 's/sandbox_cgroup_only=false/sandbox_cgroup_only=true/g' ${RUNTIME_CONFIG_PATH}
+	sed --follow-symlinks -i 's|^default_memory.*|default_memory = 512|g' $RUNTIME_CONFIG_PATH
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/test_hugepage.yaml"
@@ -77,7 +77,7 @@ setup() {
 	kubectl exec $pod_name mount | grep "nodev on /hugepages type hugetlbfs (rw,relatime,pagesize=$hugepages_size_mount.*)"
 
 	# Disable sandbox_cgroup_only
-	sed -i 's/sandbox_cgroup_only=true/sandbox_cgroup_only=false/g' ${RUNTIME_CONFIG_PATH}
+	sed --follow-symlinks -i 's/sandbox_cgroup_only=true/sandbox_cgroup_only=false/g' ${RUNTIME_CONFIG_PATH}
 }
 
 teardown() {
@@ -87,9 +87,9 @@ teardown() {
 	kubectl delete pod "$pod_name"
 
 	# Disable sandbox_cgroup_only, in case previous test failed.
-	sed -i 's/sandbox_cgroup_only=true/sandbox_cgroup_only=false/g' ${RUNTIME_CONFIG_PATH}
+	sed --follow-symlinks -i 's/sandbox_cgroup_only=true/sandbox_cgroup_only=false/g' ${RUNTIME_CONFIG_PATH}
 
 	# Disable hugepages and set default memory back to 2048Mi
-	sed -i 's/enable_hugepages = true/#enable_hugepages = true/g' ${RUNTIME_CONFIG_PATH}
-	sed -i 's|^default_memory.*|default_memory = 2048|g' $RUNTIME_CONFIG_PATH
+	sed --follow-symlinks -i 's/enable_hugepages = true/#enable_hugepages = true/g' ${RUNTIME_CONFIG_PATH}
+	sed --follow-symlinks -i 's|^default_memory.*|default_memory = 2048|g' $RUNTIME_CONFIG_PATH
 }

--- a/integration/kubernetes/k8s-seccomp.bats
+++ b/integration/kubernetes/k8s-seccomp.bats
@@ -11,7 +11,7 @@ setup() {
 	extract_kata_env
 
 	# Ensure setting seccomp mode is allowed on guest
-	sudo sed -i 's/disable_guest_seccomp=true/disable_guest_seccomp=false/' ${RUNTIME_CONFIG_PATH}
+	sudo sed --follow-symlinks -i 's/disable_guest_seccomp=true/disable_guest_seccomp=false/' ${RUNTIME_CONFIG_PATH}
 
 	pod_name="seccomp-container"
 	get_pod_config_dir
@@ -37,6 +37,6 @@ teardown() {
 	kubectl describe "pod/${pod_name}"
 
 	kubectl delete -f "${pod_config_dir}/pod-seccomp.yaml" || true
-	sudo sed -i 's/disable_guest_seccomp=false/disable_guest_seccomp=true/'\
+	sudo sed --follow-symlinks -i 's/disable_guest_seccomp=false/disable_guest_seccomp=true/'\
 		${RUNTIME_CONFIG_PATH}
 }

--- a/integration/kubernetes/vfio.sh
+++ b/integration/kubernetes/vfio.sh
@@ -59,14 +59,14 @@ setup_configuration_file() {
 	# machine type applies to configuration.toml and configuration-qemu.toml
 	if [ -n "${machine_type}" ]; then
 		if [ "${hypervisor}" = "qemu" ]; then
-			sudo sed -i 's|^machine_type.*|machine_type = "'${machine_type}'"|g' "${SYSCONFIG_FILE}"
+			sudo sed --follow-symlinks -i 's|^machine_type.*|machine_type = "'${machine_type}'"|g' "${SYSCONFIG_FILE}"
 		else
 			info "Variable machine_type only applies to qemu. It will be ignored"
 		fi
 	fi
 
 	if [ -n "${sandbox_cgroup_only}" ]; then
-		sudo sed -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${sandbox_cgroup_only}'|g' "${SYSCONFIG_FILE}"
+		sudo sed --follow-symlinks -i 's|^sandbox_cgroup_only.*|sandbox_cgroup_only='${sandbox_cgroup_only}'|g' "${SYSCONFIG_FILE}"
 	fi
 
 	# Change to initrd or image depending on user input.
@@ -74,30 +74,30 @@ setup_configuration_file() {
 	if [ "${image_type}" = "initrd" ]; then
 		if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
 			if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
-				sudo sed -i '/^image.*/d' "${SYSCONFIG_FILE}"
+				sudo sed --follow-symlinks -i '/^image.*/d' "${SYSCONFIG_FILE}"
 			else
-				sudo sed -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${SYSCONFIG_FILE}"
+				sudo sed --follow-symlinks -i 's|^image.*|initrd = "'${initrd_file}'"|g' "${SYSCONFIG_FILE}"
 			fi
 		fi
 	else
 		if $(grep -q "^initrd.*" "${SYSCONFIG_FILE}"); then
 			if $(grep -q "^image.*" "${SYSCONFIG_FILE}"); then
-				sudo sed -i '/^initrd.*/d' "${SYSCONFIG_FILE}"
+				sudo sed --follow-symlinks -i '/^initrd.*/d' "${SYSCONFIG_FILE}"
 			else
-				sudo sed -i 's|^initrd.*|image = "'${image_file}'"|g' "${SYSCONFIG_FILE}"
+				sudo sed --follow-symlinks -i 's|^initrd.*|image = "'${image_file}'"|g' "${SYSCONFIG_FILE}"
 			fi
 		fi
 	fi
 
 	# enable debug
-	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
+	sudo sed --follow-symlinks -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' \
 		-e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' \
 		"${SYSCONFIG_FILE}"
 
 	# Cloud-hypervisor workaround
 	# Issue: https://github.com/kata-containers/tests/issues/2963
 	if [ "${hypervisor}" = "cloud-hypervisor" ]; then
-		sudo sed -i -e 's|^default_memory.*|default_memory = 1024|g' \
+		sudo sed --follow-symlinks -i -e 's|^default_memory.*|default_memory = 1024|g' \
 		            -e 's|^virtio_fs_cache =.*|virtio_fs_cache = "none"|g' \
 		            "${SYSCONFIG_FILE}"
 	fi

--- a/integration/nydus/nydus_tests.sh
+++ b/integration/nydus/nydus_tests.sh
@@ -98,15 +98,15 @@ function config_kata() {
 	fi
 
 	echo "Enabling all debug options in file ${SYSCONFIG_FILE}"
-	sudo sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${SYSCONFIG_FILE}"
-	sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${SYSCONFIG_FILE}"
+	sudo sed --follow-symlinks -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${SYSCONFIG_FILE}"
+	sudo sed --follow-symlinks -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug"/g' "${SYSCONFIG_FILE}"
 
 	if [ "$KATA_HYPERVISOR" != "dragonball" ]; then
-		sudo sed -i 's|^shared_fs.*|shared_fs = "virtio-fs-nydus"|g' "${SYSCONFIG_FILE}"
-		sudo sed -i 's|^virtio_fs_daemon.*|virtio_fs_daemon = "/usr/local/bin/nydusd"|g' "${SYSCONFIG_FILE}"
+		sudo sed --follow-symlinks -i 's|^shared_fs.*|shared_fs = "virtio-fs-nydus"|g' "${SYSCONFIG_FILE}"
+		sudo sed --follow-symlinks -i 's|^virtio_fs_daemon.*|virtio_fs_daemon = "/usr/local/bin/nydusd"|g' "${SYSCONFIG_FILE}"
 	fi
 
-	sudo sed -i 's|^virtio_fs_extra_args.*|virtio_fs_extra_args = []|g' "${SYSCONFIG_FILE}"
+	sudo sed --follow-symlinks -i 's|^virtio_fs_extra_args.*|virtio_fs_extra_args = []|g' "${SYSCONFIG_FILE}"
 }
 
 function config_containerd() {
@@ -189,6 +189,7 @@ function teardown() {
 	# restore kata configuratiom.toml if needed
 	if [ "${need_restore_kata_config}" == "true" ]; then
 		sudo mv "$kata_config_backup" "$default_config"
+		sudo ln -sf "$default_config" "${SYSCONFIG_FILE}"
 	else
 		sudo rm "$SYSCONFIG_FILE"
 	fi

--- a/integration/qat/qat_test.sh
+++ b/integration/qat/qat_test.sh
@@ -66,7 +66,7 @@ build_install_qat_image_and_kernel() {
 	sudo cp -a output/vmlinux-* ${kata_vmlinux_path}
 	sudo cp -a output/kata-containers.img ${kata_image_path}
 
-	sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 modules-load=usdm_drv,qat_c62xvf"/g' ${config_file}
+	sudo sed --follow-symlinks -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 modules-load=usdm_drv,qat_c62xvf"/g' ${config_file}
 	popd
 }
 
@@ -117,7 +117,7 @@ run_test() {
 	local qat_conf_dir="${GOPATH}/src/github.com/kata-containers/kata-containers/tools/osbuilder/dockerfiles/QAT/output/configs"
 	local config_file="/usr/share/defaults/kata-containers/configuration.toml"
 
-	sudo sed -i -e 's/^kernel_params =.*/kernel_params = "modules-load=usdm_drv,qat_c62xvf"/g' ${config_file}
+	sudo sed --follow-symlinks -i -e 's/^kernel_params =.*/kernel_params = "modules-load=usdm_drv,qat_c62xvf"/g' ${config_file}
 
 	sudo ctr run --runtime ${CTR_RUNTIME} --privileged -d --rm --device=/dev/vfio/${vfio_dev} \
 		 --mount type=bind,src=/dev,dst=/dev,options=rbind:rw \
@@ -130,7 +130,7 @@ run_test() {
 	local ssl_output=$(sudo ctr t exec --exec-id 2 qat openssl engine -c -t qat-hw)
 	echo "${ssl_output}" | grep "qat-hw"
 	echo "${ssl_output}" | grep "\[ available \]"
-	sudo sed -i -e 's/^kernel_params =.*/kernel_params = ""/g' ${config_file}
+	sudo sed --follow-symlinks -i -e 's/^kernel_params =.*/kernel_params = ""/g' ${config_file}
 }
 
 main() {

--- a/lib/common.bash
+++ b/lib/common.bash
@@ -141,6 +141,7 @@ extract_kata_env() {
 	SHIM_VERSION=${RUNTIME_VERSION}
 
 	HYPERVISOR_PATH=$(kata-runtime kata-env --json | jq -r .Hypervisor.Path)
+	HYPERVISOR_SHARED_FS=$(kata-runtime kata-env --json | jq -r .Hypervisor.SharedFS)
 	# TODO: there is no kata-runtime of rust version currently
 	if [ "${KATA_HYPERVISOR}" != "dragonball" ]; then
 		HYPERVISOR_VERSION=$(${HYPERVISOR_PATH} --version | head -n1)


### PR DESCRIPTION
By doing this we can ensure that even if the containerd or runtime configuration points to a specific path, changes in the default config will be reflected in the specific path.