### PR TITLE
stability: Add more write tests for cassandra stress tool

### DIFF
--- a/stability/cassandra_stress.sh
+++ b/stability/cassandra_stress.sh
@@ -16,7 +16,6 @@ DOCKER_IMAGE="cassandra:latest"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 CMD="cassandra -R"
 
-
 function main() {
 	local cmds=("docker")
 
@@ -28,8 +27,15 @@ function main() {
 
 	sudo -E ctr run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
 	sudo -E ctr t exec --exec-id 1 "${CONTAINER_NAME}" sh -c "${CMD}"
+	info "Write one million rows"
 	local WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1000000 -rate threads=50"
 	sudo -E ctr t exec --exec-id 2 "${CONTAINER_NAME}" sh -c "${WRITE_CMD}"
+	info "Load one row with default schema"
+	local CQL_WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1 c1=one -mode native cql3 -log file-create_schema.log"
+	sudo -E ctr t exec --exec-id 3 "${CONTAINER_NAME}" sh -c "${CQL_WRITE_CMD}"
+	info "Run a write workload using CQL"
+	local REAL_WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1000000 cl=one -mode native cql3 -schema keyspace='keyspace1' -log file=load_1M_rows.log"
+	sudo -E ctr t exec --exec-id 4 "${CONTAINER_NAME}" sh -c "${REAL_WRITE_CMD}"
 
 	clean_env_ctr
 }


### PR DESCRIPTION
This PR adds more write tests using CQL for the cassandra stress tool test.

Fixes #5478