### PR TITLE
CC: fix bug "Unable to correctly running the integration tests with offline_fs_kbc with kubernetes"

### DIFF
--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -216,7 +216,11 @@ assert_logs_contain() {
 	echo "Pod config: ${pod_config}"
 
 	assert_pod_fail "${pod_config}"
-	assert_logs_contain 'failed to pull manifest Not authorized'
+	if [ "${AA_KBC}" = "eaa_kbc" ]; then 
+		assert_logs_contain 'failed to pull manifest Not authorized'
+	else
+		assert_logs_contain 'failed to pull manifest Authentication failure'
+	fi
 }
 
 teardown() {


### PR DESCRIPTION
This PR fixes that the integration tests are unable to correctly running with offline_fs_kbc with kubernetes.

Fixed: #5484 

Signed-off-by: ChengyuZhu6 [chengyu.zhu@intel.com](mailto:chengyu.zhu@intel.com)