### PR TITLE
k8s/arm64: skip footloose test for DB

### DIFF
--- a/.ci/aarch64/configuration_aarch64.yaml
+++ b/.ci/aarch64/configuration_aarch64.yaml
@@ -20,3 +20,4 @@ kubernetes:
   - k8s-block-volume
   - k8s-inotify
   - k8s-qos-pods
+  - k8s-footloose


### PR DESCRIPTION
footloose test based on dragonball can't pass on Arm. Skip for now until we fix it.

Fixes: #5486