### PR TITLE
gitignore: Added cmd/check-markdown/kata-check-markdown to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ginkgo
 !/**/ginkgo
 /.vagrant/
+cmd/check-markdown/kata-check-markdown


### PR DESCRIPTION
.gitignore has been updated to contain the line "cmd/check-markdown/kata-check-markdown".

Fixes #4790

Signed-off-by: Maxwell Wendlandt <maxjman101@gmail.com>