### PR TITLE
metrics: Add bandwidth iperf3 results to history.sh

### DIFF
--- a/cmd/checkmetrics/history/history.sh
+++ b/cmd/checkmetrics/history/history.sh
@@ -56,6 +56,9 @@ if [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]; then
 
 	tests+=("network-iperf3")
 	test_queries+=(".\"network-iperf3\".Results | .[] | .jitter.Result")
+
+	tests+=("network-iperf3")
+	test_queries+=(".\"network-iperf3\".Results | .[] | .bandwidth.Result")
 fi
 
 # What is the base URL of the Jenkins server


### PR DESCRIPTION
This PR enables the possibility gathered the bandwidth iperf3 results at the history.sh script.

Fixes #5500