### PR TITLE
metrics: Add nginx yaml for k8s test

### DIFF
--- a/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
+++ b/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 0
+      runtimeClassName: kata
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This PR adds the deployment.yaml for nginx network metrics k8s test.

Fixes #5506