### PR TITLE
metrics: Add nginx test to README

### DIFF
--- a/metrics/network/README.md
+++ b/metrics/network/README.md
@@ -13,6 +13,9 @@ parallel bandwidth.
 
 - `k8s-network-metrics-iperf3.sh` measures bandwidth which is the speed of the data transfer.
 - `latency-network.sh` measures network latency.
+- `nginx-network.sh` is a benchmark of the lightweight Nginx HTTPS web-server and measures
+the HTTP requests over a fixed period of time with a configurable number of concurrent
+clients/connections.
 
 ## Running the tests
 


### PR DESCRIPTION
This PR adds the nginx network test to the README documentation.

Fixes #5511