### PR TITLE
metrics: Fix memory inside container test

### DIFF
--- a/metrics/density/memory_usage_inside_container.sh
+++ b/metrics/density/memory_usage_inside_container.sh
@@ -122,7 +122,7 @@ function main() {
 	metrics_json_init
 
 	for (( i=0; i<$iterations; i++ )) do
-		local output=$(ctr run --memory-limit $((MEMSIZE*1024)) --rm --runtime=$CTR_RUNTIME $IMAGE busybox sh -c "$CMD" 2>&1)
+		local output=$(sudo -E "${CTR_EXE}" run --memory-limit $((MEMSIZE*1024)) --rm --runtime=$CTR_RUNTIME $IMAGE busybox sh -c "$CMD" 2>&1)
 
 		if [ ${output_format} = "json" ]; then
 			parse_results "${output}" "${memtotalAvg}" "${memfreeAvg}" "${memavailableAvg}"


### PR DESCRIPTION
This PR replaces ctr with CTR_EXE which is defined in the metrics lib common.bash as well as it uses sudo to have uniformity across the metrics scripts.

Fixes #5524