### PR TITLE
kernel: Adapt to the new names in versions.yaml

### DIFF
--- a/.ci/install_kata_kernel.sh
+++ b/.ci/install_kata_kernel.sh
@@ -186,7 +186,7 @@ main() {
 			install_kernel "${kernel_type}" $(get_version "assets.kernel.sev.tag")
 			;;
 		dragonball)
-			install_kernel "${kernel_type}" $(get_version "assets.dragonball-kernel-experimental.version")
+			install_kernel "${kernel_type}" $(get_version "assets.kernel-dragonball-experimental.version")
 			;;
 		*)
 			info "kernel type '${kernel_type}' not supported"


### PR DESCRIPTION
We changed the name of the dragonball kernel in versions.yaml so it'd be aligned with what's part of the kata-deploy local builds, and that change must be reflected here

Fixes: #6481