### PR TITLE
crio: use go 1.20 for the kata/crio CI job

### DIFF
--- a/.ci/ci_crio_entry_point.sh
+++ b/.ci/ci_crio_entry_point.sh
@@ -122,7 +122,7 @@ cd "${katacontainers_repo_dir}"
 ${GOPATH}/src/${tests_repo}/.ci/install_yq.sh
 
 # CRI-O switched to using go 1.18+
-golang_version="1.18.1"
+golang_version="1.20.2"
 yq w -i versions.yaml languages.golang.meta.newest-version "${golang_version}"
 
 critools_version="${branch_release_number}.0"


### PR DESCRIPTION
cri-o has started to use go 1.20 some times ago.
For this job, running from the cri-o repository, we need to use the same version.

NOTE: there is no failure on the main branch *yet*, but I've seen some PR fail on this job because of this, when they use modules requiring this version of go. Whenever those PR get merged on cri-o/main, we will have an issue.

Fixes: #5559 