### PR TITLE
tests: defer configuring runtime config settings for kata-container CI

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -204,6 +204,10 @@ if [ "${METRICS_CI}" = "false" ]; then
 		# If not a PR, we are testing on stable or master branch.
 		[ -z "$pr_number" ] && specific_branch="true"
 		"${ci_dir_name}/static-checks.sh" --only-arch "$kata_repo" "$specific_branch"
+		# It is too early to configure defaultRuntimeConfiguration
+		# The file generation should be deferred at runtime installation with
+		# /opt/confidential-containers/share/defaults/kata-containers/configuration.toml
+		rm -f src/runtime/pkg/katautils/config-settings.go
 	fi
 fi
 


### PR DESCRIPTION
This is to remove config-settings.go and defer generating it at runtime installation for kata-container CI jobs on non-x86_64 architectures.

Fixes: #5314

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
(cherry picked from commit 66842c4a1edae5afe78dfef9200489e990c4b8db)