### PR TITLE
Add SEV-ES Test

### DIFF
--- a/integration/kubernetes/confidential/fixtures/service.yaml.in
+++ b/integration/kubernetes/confidential/fixtures/service.yaml.in
@@ -26,6 +26,7 @@ spec:
         app: $NAME
       annotations:
         io.katacontainers.config.pre_attestation.uri: "$KBS_URI"
+        io.katacontainers.config.sev.policy: "$POLICY"
     spec:
       runtimeClassName: $RUNTIMECLASS
       containers:

--- a/integration/kubernetes/confidential/sev.bats
+++ b/integration/kubernetes/confidential/sev.bats
@@ -275,13 +275,11 @@ add_key_to_kbs_db() {
   if [ -n "${measurement}" ]; then
     mysql -u${KBS_DB_USER} -p${KBS_DB_PW} -h ${KBS_DB_HOST} -D ${KBS_DB} <<EOF
       INSERT INTO secrets VALUES (10, 'key_id1', '${ENCRYPTION_KEY}', 10);
-      INSERT INTO keysets VALUES (10, 'KEYSET-1', '["key_id1"]', 10);
       INSERT INTO policy VALUES (10, '["${measurement}"]', '[]', 0, 0, '[]', now(), NULL, 1);
 EOF
   else
     mysql -u${KBS_DB_USER} -p${KBS_DB_PW} -h ${KBS_DB_HOST} -D ${KBS_DB} <<EOF
       INSERT INTO secrets VALUES (10, 'key_id1', '${ENCRYPTION_KEY}', NULL);
-      INSERT INTO keysets VALUES (10, 'KEYSET-1', '["key_id1"]', 10);
 EOF
   fi
 }


### PR DESCRIPTION
Adds a test for SEV-ES and some minor cleanup of `sev.bats`. 

In theory we could double the number of tests by running each with SEV and SEV-ES. I think that would be unnecessary use of resources. Instead, we just run the most strict test (encrypted container with check of launch measurement) with both SEV and SEV-ES. SEV-ES only differs slightly from SEV (mainly attestation) so I think this is appropriate. 

@ryansavino @dubek

I think the SEV CI might currently fail without https://github.com/confidential-containers/operator/pull/180. I have tested locally with that PR and it seems to work.

