### PR TITLE
versions: Update hadolint version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -67,7 +67,7 @@ externals:
   hadolint:
     description: "the dockerfile linter used by static-checks"
     url: "https://github.com/hadolint/hadolint"
-    version: "2.7.0"
+    version: "2.12.0"
 
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"


### PR DESCRIPTION
This PR updates the hadolint version to v2.12.0 which has a changes:
- Try a newer GHC version for valid MacOS Ventura builds
- build(deps): bump actions/cache from 3.0.4 to 3.0.11
- build(deps): bump cachix/install-nix-action from 17 to 18
- build(deps): bump cachix/cachix-action from 10 to 12

Fixes #5545