### PR TITLE
metrics: Update latency value

### DIFF
--- a/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric7.toml
+++ b/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric7.toml
@@ -55,7 +55,7 @@ description = "measure network latency"
 # within (inclusive)
 checkvar = ".\"latency\".Results | .[] | .latency.Result"
 checktype = "mean"
-midval = 0.73
+midval = 0.81
 minpercent = 20.0
 maxpercent = 10.0
 


### PR DESCRIPTION
This PR updates latency value due the change that was introduced to stop building kata components and use kata deploy as part of the CI.

Fixes #5549