### PR TITLE
cri-o: explicitly setup docker local registry

### DIFF
--- a/.ci/install_crio.sh
+++ b/.ci/install_crio.sh
@@ -91,6 +91,13 @@ unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.
   "debian" = "docker.io/library/debian"
   # Oracle Linux
   "oraclelinux" = "container-registry.oracle.com/os/oraclelinux"
+
+# As done for containerd, we need to ensure we add support for the local
+# registry for CRI-O as well.
+# We mark it as "insecure" as we're not setting it up using TLS.
+[[registry]]
+location="localhost:5000"
+insecure=true
 EOF
 
 echo "Get CRI-O sources"


### PR DESCRIPTION
Recently we've changed the way we build our components in the CI, and with that change we've been forcing the usage of docker (instead of podman) with CRI-O.

This, however, introduced a regression and podman local registries are transparently understood by CRI-O, but the docker one must be explicitly configured.

Fixes: #6510