### PR TITLE
ci: do not stop containerd when testing with crio

### DIFF
--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -265,10 +265,10 @@ start_cri_runtime_service() {
 	# Sleep time between checks.
 	local wait_time_cri_socket_check=5
 
-	# stop containerd first and then restart it
-	if systemctl is-active --quiet containerd; then
-		info "Stop containerd service"
-		sudo systemctl stop containerd
+	# stop the service first and then restart it
+	if systemctl is-active --quiet ${cri}; then
+		info "Stop ${cri} service"
+		sudo systemctl stop ${cri}
 	fi
 
 	sudo systemctl enable --now ${cri}


### PR DESCRIPTION
When starting the cri service, we need to stop/restart it.

We used to stop containerd, assuming it was the one being started anyway, but it is an error: when we test with cri-o, stopping containerd also stops docker, which is needed by cri-o to access its image repository.

Fixes: #5544