### PR TITLE
ci: Update cri endpoint for kubernetes tests

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -19,10 +19,10 @@ main () {
 
 	case "${CRI_RUNTIME}" in
 	containerd)
-		cri_runtime_socket="/run/containerd/containerd.sock"
+		cri_runtime_socket="unix:///run/containerd/containerd.sock"
 		;;
 	crio)
-		cri_runtime_socket="/var/run/crio/crio.sock"
+		cri_runtime_socket="unix:///var/run/crio/crio.sock"
 		;;
 	*)
 		die "Runtime ${CRI_RUNTIME} not supported"

--- a/integration/kubernetes/init.sh
+++ b/integration/kubernetes/init.sh
@@ -292,11 +292,11 @@ main() {
 
 	case "${CRI_RUNTIME}" in
 	containerd)
-		cri_runtime_socket="/run/containerd/containerd.sock"
+		cri_runtime_socket="unix:///run/containerd/containerd.sock"
 		cgroup_driver="cgroupfs"
 		;;
 	crio)
-		cri_runtime_socket="/var/run/crio/crio.sock"
+		cri_runtime_socket="unix:///var/run/crio/crio.sock"
 		cgroup_driver="systemd"
 		;;
 	*)


### PR DESCRIPTION
Using the unix:// prefix, as the current form is deprecated.

Fixes: #5557