### PR TITLE
docs: Readme for boot time metrics

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -75,6 +75,8 @@ boot into a workload or kill a container.
 This directory does *not* contain "speed" tests that measure network or storage
 for instance.
 
+For further details see the [time tests documentation](time).
+
 ### Density
 
 Tests that measure the size and overheads of the runtime. Generally this is looking at

--- a/metrics/time/README.md
+++ b/metrics/time/README.md
@@ -1,0 +1,19 @@
+# Kata Containers boot time metrics
+
+The boot time metrics test takes a number of time measurements through the complete
+launch/shutdown cycle of a single container.
+From those measurements it derives a number of time measures, such as:
+- time to payload execution
+- time to get to VM kernel
+- time in VM kernel boot
+- time to quit
+- total time (from launch to finished)
+
+## Running the test
+
+Boot time test can be run by hand, for example:
+
+```
+$ cd metrics
+$ bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 1
+```


### PR DESCRIPTION
This PR adds a README for boot time metrics which are part of the kata metrics CI.

Fixes #5560