### PR TITLE
metrics: Delete nginx service

### DIFF
--- a/metrics/network/nginx_kubernetes/nginx-network.sh
+++ b/metrics/network/nginx_kubernetes/nginx-network.sh
@@ -71,6 +71,7 @@ EOF
 
 function nginx_cleanup() {
 	kubectl delete deployment "${deployment}"
+	kubectl delete service "${deployment}"
 	if [ -z "${CI_JOB}" ]; then
 		end_kubernetes
 		check_processes


### PR DESCRIPTION
This PR deletes the nginx service in order to have a clean environment while running the nginx benchmark.

Fixes #5569