### PR TITLE
ci: Set cc_kbc as the AA_KBC type for TDX

### DIFF
--- a/.ci/ci_job_flags.sh
+++ b/.ci/ci_job_flags.sh
@@ -134,7 +134,7 @@ case "${CI_JOB}" in
 	export CRI_RUNTIME="containerd"
 	export KATA_HYPERVISOR="qemu"
 	export KATA_BUILD_CC="yes"
-	export AA_KBC="eaa_kbc"
+	export AA_KBC="cc_kbc"
 	export TEE_TYPE="tdx"
 	export KATA_BUILD_KERNEL_TYPE="tdx"
 	export KATA_BUILD_QEMU_TYPE="tdx"
@@ -156,7 +156,7 @@ case "${CI_JOB}" in
 		export TEE_TYPE="tdx"
 		export KATA_BUILD_KERNEL_TYPE="tdx"
 		export KATA_BUILD_QEMU_TYPE="tdx"
-		export AA_KBC="eaa_kbc"
+		export AA_KBC="cc_kbc"
 	elif [[ "${CI_JOB}" =~ _SE_ ]]; then
 		if grep -q 'prot_virt=1' /proc/cmdline && grep -Eq '^facilities.* 158 .*' /proc/cpuinfo; then
 			export TEE_TYPE="se"

--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -83,7 +83,7 @@ build_image_for_cc () {
 		if [ "${TEE_TYPE}" == "tdx" ] && [ "${KATA_HYPERVISOR}" == "qemu" ]; then
 			# Cloud Hypervisor is still using `offline_fs_kbc`, so it has to
 			# use the generic image.  QEMU, on the other hand, is using
-			# `eaa_kbc` and it requires the `tdx-rootfs-image`.
+			# `cc_kbc` and it requires the `tdx-rootfs-image`.
 			build_static_artifact_and_install "tdx-rootfs-image"
 		elif [ "${TEE_TYPE}" == "se" ]; then
 			build_static_artifact_and_install "rootfs-initrd"

--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -266,16 +266,18 @@ setup_offline_fs_kbc_signature_files_in_guest() {
 	cp_to_guest_img "etc" "${SHARED_FIXTURES_DIR}/offline-fs-kbc/$(uname -m)/aa-offline_fs_kbc-resources.json"
 }
 
-setup_eaa_kbc_signature_files_in_guest() {
+setup_cc_kbc_signature_files_in_guest() {
 	# Enable signature verification via kata-configuration by removing the param that disables it
 	remove_kernel_param "agent.enable_signature_verification"
 
 	# Set-up required files in guest image
 	setup_common_signature_files_in_guest
 
-	# EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+	# CC KBC is specified as: cc_kbc::http://host_ip:port/, and 60000 is the default port used
 	# by the service, as well as the one configured in the Kata Containers rootfs.
-	add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+	CC_KBS_IP=${CC_KBS_IP:-"$(hostname -I | awk '{print $1}')"}
+	CC_KBS_PORT=${CC_KBS_PORT:-"60000"}
+	add_kernel_params "agent.aa_kbc_params=cc_kbc::http://${CC_KBS_IP}:${CC_KBS_PORT}/"
 }
 
 setup_cosign_signatures_files() {
@@ -295,10 +297,13 @@ setup_cosign_signatures_files() {
 			add_kernel_params "agent.aa_kbc_params=offline_fs_kbc::null"
 			cp_to_guest_img "etc" "${SHARED_FIXTURES_DIR}/cosign/offline-fs-kbc/aa-offline_fs_kbc-resources.json"
 			;;
-		"eaa_kbc")
-			# EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+		"cc_kbc")
+			# CC KBC is specified as: cc_kbc::host_ip:port, and 60000 is the default port used
 			# by the service, as well as the one configured in the Kata Containers rootfs.
-			add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+
+			CC_KBS_IP=${CC_KBS_IP:-"$(hostname -I | awk '{print $1}')"}
+			CC_KBS_PORT=${CC_KBS_PORT:-"60000"}
+			add_kernel_params "agent.aa_kbc_params=cc_kbc::http://${CC_KBS_IP}:${CC_KBS_PORT}/"
 			;;
 		*)
 			;;
@@ -310,8 +315,8 @@ setup_signature_files() {
 		"offline_fs_kbc")
 			setup_offline_fs_kbc_signature_files_in_guest
 			;;
-		"eaa_kbc")
-			setup_eaa_kbc_signature_files_in_guest
+		"cc_kbc")
+			setup_cc_kbc_signature_files_in_guest
 			;;
 		*)
 			;;

--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -185,10 +185,12 @@ assert_logs_contain() {
 @test "$test_tag Test pull an unencrypted unsigned image from an authenticated registry with correct credentials" {
 	if [ "${AA_KBC}" = "offline_fs_kbc" ]; then
 		setup_credentials_files "quay.io/kata-containers/confidential-containers-auth"
-	elif [ "${AA_KBC}" = "eaa_kbc" ]; then
-		# EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+	elif [ "${AA_KBC}" = "cc_kbc" ]; then
+		# CC KBC is specified as: cc_kbc::http://host_ip:port/, and 60000 is the default port used
 		# by the service, as well as the one configured in the Kata Containers rootfs.
-		add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+		CC_KBS_IP=${CC_KBS_IP:-"$(hostname -I | awk '{print $1}')"}
+		CC_KBS_PORT=${CC_KBS_PORT:-"60000"}
+		add_kernel_params "agent.aa_kbc_params=cc_kbc::http://${CC_KBS_IP}:${CC_KBS_PORT}/"
 	fi
 
 	pod_config="$(new_pod_config "${image_authenticated}")"
@@ -198,7 +200,7 @@ assert_logs_contain() {
 }
 
 @test "$test_tag Test cannot pull an image from an authenticated registry with incorrect credentials" {
-	if [ "${AA_KBC}" = "eaa_kbc" ]; then
+	if [ "${AA_KBC}" = "cc_kbc" ]; then
 		skip "As the test requires changing verdictd configuration and restarting its service"
 	fi
 

--- a/integration/kubernetes/confidential/agent_image_encrypted.bats
+++ b/integration/kubernetes/confidential/agent_image_encrypted.bats
@@ -37,10 +37,12 @@ setup() {
 @test "$test_tag Test can pull an encrypted image inside the guest with decryption key" {
     if [ "${AA_KBC}" = "offline_fs_kbc" ]; then
         setup_decryption_files_in_guest
-    elif [ "${AA_KBC}" = "eaa_kbc" ]; then
-        # EAA KBC is specified as: eaa_kbc::host_ip:port, and 50000 is the default port used
+    elif [ "${AA_KBC}" = "cc_kbc" ]; then
+        # CC KBC is specified as: cc_kbc::http://host_ip:port/, and 60000 is the default port used
         # by the service, as well as the one configured in the Kata Containers rootfs.
-        add_kernel_params "agent.aa_kbc_params=eaa_kbc::$(hostname -I | awk '{print $1}'):50000"
+	CC_KBS_IP=${CC_KBS_IP:-"$(hostname -I | awk '{print $1}')"}
+	CC_KBS_PORT=${CC_KBS_PORT:-"60000"}
+	add_kernel_params "agent.aa_kbc_params=cc_kbc::http://${CC_KBS_IP}:${CC_KBS_PORT}/"
     fi
     kubernetes_create_ssh_demo_pod
 

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -83,7 +83,7 @@ checkout_doc_repo_dir() {
 
 kubernetes_create_ssh_demo_pod() {
 	checkout_doc_repo_dir
-	[ "${AA_KBC:-}" == "eaa_kbc" ] && sed -i 's#katadocker/ccv0-ssh#katadocker/ssh-demo-eaa-kbc#g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
+	[ "${AA_KBC:-}" == "cc_kbc" ] && sed -i 's#docker.io/katadocker/ccv0-ssh#ghcr.io/confidential-containers/test-container:encrypted#g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
 	kubectl apply -f "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml" && pod=$(kubectl get pods -o jsonpath='{.items..metadata.name}') && kubectl wait --timeout=120s --for=condition=ready pods/$pod
 	kubectl get pod $pod
 }


### PR DESCRIPTION
CoCo v0.5.0 will release general CC_KBC with TDX support, we will also to use cc_kbc for TDX CI

Fixes: #5581
Depends-on: github.com/kata-containers/kata-containers#6520
Depends-on: github.com/kata-containers/kata-containers#6404