### PR TITLE
metrics: Use CTR_EXE variable in cray script

### DIFF
--- a/metrics/disk/c-ray/cray.sh
+++ b/metrics/disk/c-ray/cray.sh
@@ -29,7 +29,7 @@ function main() {
 	check_cmds "${cmds[@]}"
 	check_ctr_images "$IMAGE" "$DOCKERFILE"
 
-	sudo -E ctr run --rm --runtime="${CTR_RUNTIME}" "${IMAGE}" test sh -c "${CMD}" > "${cray_file}"
+	sudo -E "${CTR_EXE}" run --rm --runtime="${CTR_RUNTIME}" "${IMAGE}" test sh -c "${CMD}" > "${cray_file}"
 	metrics_json_init
 	results=$(cat "${cray_file}" | grep seconds | awk '{print $3}' | head -n 1)
 	metrics_json_start_array


### PR DESCRIPTION
This PR replaces ctr for the CTR_EXE variable to have uniformity across the metrics scripts.

Fixes #5588