### PR TITLE
static-checks: Accept-encoding 'none' instead of 'br'

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -500,7 +500,7 @@ check_url()
 		curl_args+=("-u ${GITHUB_USER}:${GITHUB_TOKEN}")
 	fi
 
-	{ curl ${curl_args[*]} -sIL -A "${user_agent}" -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
+	{ curl ${curl_args[*]} -sIL -A "${user_agent}" -H "Accept-Encoding: zstd, none, gzip, deflate" --max-time "$url_check_timeout_secs" \
 		--retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
 
 	# A transitory error, or the URL is incorrect,


### PR DESCRIPTION
One of the links we check fails with a 502 due to 'br' being in the list. The PR where this happen is kata-containers/community#326.  Remove 'br' from the list. 'None' was missing from the list so let's add it too.

Fixes: #6627