### PR TITLE
docs: Add Tensorflow documentation

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -12,6 +12,7 @@ Cassandra/B
 ccloudvm/B
 codecov/B
 containerd/B
+cnn/B
 cri-o/B
 CRI-O/B
 DevStack/B
@@ -87,6 +88,7 @@ SQLite/B
 SUSE/B
 Sysbench/B
 systemd/B
+tf/B
 TravisCI/B
 Tokio/B
 Vexxhost/B

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -111,6 +111,13 @@ Test relating to measure reading and writing against clusters.
 
 For further details see the [disk tests documentation](disk).
 
+### Machine Learning
+
+Tests relating with TensorFlow implementations of several popular
+convolutional models.
+
+For further details see the [machine learning tests documentation](machine_learning).
+
 ## Saving Results
 
 

--- a/metrics/machine_learning/README.md
+++ b/metrics/machine_learning/README.md
@@ -1,0 +1,16 @@
+# Kata Containers Tensorflow Metrics
+
+Kata Containers provides a series of performance tests using the
+TensorFlow reference benchmarks (tf_cnn_benchmarks).
+The tf_cnn_benchmarks containers TensorFlow implementations of several
+popular convolutional models.
+
+## Running the test
+
+Individual tests can be run by hand, for example:
+
+```
+$ cd metrics/machine_learning
+$ ./tensorflow.sh 25 60
+```
+


### PR DESCRIPTION
This PR adds the Tensorflow documentation as we already have Tensorflow
benchmark as part of the Kata Containers metrics.