### PR TITLE
test-agent-shutdown: Fix false positive match

### DIFF
--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -1281,7 +1281,7 @@ validate_agent()
 	# Regular expression that describes possible agent failures
 	local regex="(slog::Fuse|Drain|Custom|serialization error|thread.*panicked|stack backtrace:)"
 
-	egrep -qi "$regex" "$log_file" && cat $log_file && die "Found agent error in log file: '$log_file'"
+	egrep -q "$regex" "$log_file" && cat $log_file && die "Found agent error in log file: '$log_file'"
 
 	local entry
 	entry=$(get_shutdown_test_type_entry "$shutdown_test_type" || true)

--- a/functional/tracing/test-agent-shutdown.sh
+++ b/functional/tracing/test-agent-shutdown.sh
@@ -1281,7 +1281,7 @@ validate_agent()
 	# Regular expression that describes possible agent failures
 	local regex="(slog::Fuse|Drain|Custom|serialization error|thread.*panicked|stack backtrace:)"
 
-	egrep -qi "$regex" "$log_file" && die "Found agent error in log file: '$log_file'"
+	egrep -qi "$regex" "$log_file" && cat $log_file && die "Found agent error in log file: '$log_file'"
 
 	local entry
 	entry=$(get_shutdown_test_type_entry "$shutdown_test_type" || true)
@@ -1301,7 +1301,7 @@ validate_agent()
 		# The message the agent writes to stderr just before it exits.
 		local done_msg="\<shutdown complete\>"
 
-		egrep -q "$done_msg" "$log_file" || die "missing agent shutdown message"
+		egrep -q "$done_msg" "$log_file" || (cat $log_file && die "missing agent shutdown message")
 	else
 		# We can only check for the shutdown message if the agent debug
 		# logs are available.

--- a/lib/error.sh
+++ b/lib/error.sh
@@ -143,6 +143,8 @@ show_stacktrace()
 # details of the environment (in YAML format), to help with debugging.
 dump_details()
 {
+	set +x
+
 	local err_line="${1:-}"
 	local err_func="${2:-}"
 	local err_path="${3:-}"


### PR DESCRIPTION
This PR adds two commts that will help to debug any future issue that we happen to have with the `test-agent-shutdown`, and fixes a false-positive that's been blocking github.com/kata-containers/kata-containers#6648 to be merged