### PR TITLE
vfio: Upgrade to newer version of fedora for vfio test

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -182,7 +182,7 @@ create_config_iso() {
 pull_fedora_cloud_image() {
 	fedora_img="$1"
 	fedora_img_cache="${fedora_img}.cache"
-	fedora_version=32
+	fedora_version=37
 
 	if [ ! -f "${fedora_img_cache}" ]; then
 		curl -sL "https://download.fedoraproject.org/pub/fedora/linux/releases/${fedora_version}/Cloud/${arch}/images/Fedora-Cloud-Base-${fedora_version}-1.6.${arch}.raw.xz" -o "${fedora_img_cache}.xz"


### PR DESCRIPTION
Try upgrading from version 32 to 37 for the cloud image used in the vfio test.

Fixes: #5612