### PR TITLE
tests: Image Cache Versioning

### DIFF
--- a/.ci/vfio_jenkins_job_build.sh
+++ b/.ci/vfio_jenkins_job_build.sh
@@ -203,7 +203,11 @@ pull_fedora_cloud_image() {
 	sudo mount "${loop}p2" /mnt
 
 	# add intel_iommu=on to the guest kernel command line
-	kernelopts="intel_iommu=on iommu=pt selinux=0 "
+	kernelopts="intel_iommu=on iommu=pt selinux=0"
+	entries=$(sudo ls /mnt/loader/entries/)
+	for entry in ${entries}; do
+		sudo sed -i '/^options /  s/$/ intel_iommu=on iommu=pt selinux=0 /g' /mnt/loader/entries/"${entry}"
+	done
 	sudo sed -i 's|kernelopts="|kernelopts="'"${kernelopts}"'|g' /mnt/grub2/grub.cfg
 	sudo sed -i 's|kernelopts=|kernelopts='"${kernelopts}"'|g' /mnt/grub2/grubenv
 

--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -295,6 +295,9 @@ main() {
 	host_pci=$(host_pci_addr)
 	[ -n "${host_pci}" ] || die "virtio ethernet controller PCI address not found"
 
+	cat /proc/cmdline | grep -q "intel_iommu=on" || \
+		die "intel_iommu=on not found in kernel cmdline"
+
 	sudo driverctl set-override "${host_pci}" vfio-pci
 
 	vfio_device="$(get_vfio_path "${host_pci}")"


### PR DESCRIPTION
Add a version to the image cache, otherwise the tests are going to use always the same image without rebuilding it, regardless the version set in fedora_version

Fixes: #5614

Fedora 34 removed the support for SELinux runtime disable.
See: https://fedoraproject.org/wiki/Changes/Remove_Support_For_SELinux_Runtime_Disable
Removing the offending code.

The cloud base image Fedora37 has a different partition layout
then the older ones like 32. Updating the mount and edit commands.

Remove the kernel setting forcing cgroupV1 and check for `intel_iommu=on` enabled in the kernel commandline.

