### PR TITLE
CI: Support cross-compilation for rust installation

### DIFF
--- a/.ci/kata-arch.sh
+++ b/.ci/kata-arch.sh
@@ -51,9 +51,10 @@ arch_to_rust()
 
 	if [ "${arch}" == "ppc64le" ]; then
 		arch="powerpc64le"
+		ARCH="${arch}"
 	fi
 
-	echo "${arch}"
+	[ "${CROSS_BUILD}" == "false" ] && echo "${arch}" || echo "${ARCH}"
 }
 
 # Convert architecture to the name used by the Linux kernel build system

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -15,6 +15,8 @@ export katacontainers_repo_git="https://${katacontainers_repo}.git"
 export katacontainers_repo_dir="${GOPATH}/src/${katacontainers_repo}"
 export kata_default_branch="${kata_default_branch:-main}"
 export CI_JOB="${CI_JOB:-}"
+export CROSS_BUILD="${CROSS_BUILD:-false}"
+export ARCH="${ARCH:-$(uname -m)}"
 
 # Name of systemd service for the throttler
 KATA_KSM_THROTTLER_JOB="kata-ksm-throttler"


### PR DESCRIPTION
This is to make `kata-arch.sh` return a given `ARCH` value when an environment variable `CROSS_BUILD` is set to true. It is necessary to add a proper rust toolchain target on a `x86_64` host machine.

Fixes: #5617

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>