### PR TITLE
static-checks: Switch to GET for URL checks

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -500,7 +500,8 @@ check_url()
 		curl_args+=("-u ${GITHUB_USER}:${GITHUB_TOKEN}")
 	fi
 
-	{ curl ${curl_args[*]} -sIL -A "${user_agent}" -H "Accept-Encoding: zstd, none, gzip, deflate" --max-time "$url_check_timeout_secs" \
+	# Some endpoints return 403 to HEAD but 200 for GET, so perform a GET but only read headers.
+	{ curl ${curl_args[*]} -sIL -X GET -A "${user_agent}" -H "Accept-Encoding: zstd, none, gzip, deflate" --max-time "$url_check_timeout_secs" \
 		--retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
 
 	# A transitory error, or the URL is incorrect,


### PR DESCRIPTION
Some endpoints block HEAD requests while allowing GET. To prevent false positives from url check, switch to using GET, but still only read the header.

Fixes: #6627