### PR TITLE
ci: Remove uses of procenv

### DIFF
--- a/.ci/setup_env_alinux.sh
+++ b/.ci/setup_env_alinux.sh
@@ -66,7 +66,6 @@ declare -A packages=( \
 	[ostree]="ostree-devel" \
 	[metrics_dependencies]="bc jq" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \

--- a/.ci/setup_env_centos.sh
+++ b/.ci/setup_env_centos.sh
@@ -77,7 +77,6 @@ declare -A packages=( \
 	[ostree]="ostree-devel" \
 	[metrics_dependencies]="bc jq" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \

--- a/.ci/setup_env_fedora.sh
+++ b/.ci/setup_env_fedora.sh
@@ -31,7 +31,6 @@ declare -A packages=( \
 	[metrics_dependencies]="jq" \
 	[cri-containerd_dependencies]="libseccomp-devel btrfs-progs-devel libseccomp-static" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \

--- a/.ci/setup_env_rhel.sh
+++ b/.ci/setup_env_rhel.sh
@@ -42,7 +42,6 @@ declare -A packages=(
 	[metrics_dependencies]="jq" \
 	[cri-containerd_dependencies]="libseccomp-devel" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[libsystemd]="systemd-devel" \
 	[redis]="redis" \

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -42,7 +42,6 @@ declare -A packages=( \
 	[metrics_dependencies]="smem jq" \
 	[cri-containerd_dependencies]="btrfs-progs libseccomp-dev libapparmor-dev make gcc pkg-config" \
 	[crudini]="crudini" \
-	[procenv]="procenv" \
 	[haveged]="haveged" \
 	[libsystemd]="libsystemd-dev" \
 	[redis]="redis-server" \


### PR DESCRIPTION
Procenv has been regularly hanging in the teardown of vfio test, possibly since upgrading to fedora 37. The procenv output does not appear to be consumed or useful to anyone, so remove all traces of it.

Fixes: kata-containers/kata-containers#6790