### PR TITLE
vfio: Match 'Virtio 1.0 network device' device name

### DIFF
--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -33,7 +33,7 @@ cleanup() {
 }
 
 host_pci_addr() {
-	lspci -D | grep "Ethernet controller" | grep "Virtio network device" | tail -1 | cut -d' ' -f1
+	lspci -D | grep "Ethernet controller" | grep "Virtio.*network device" | tail -1 | cut -d' ' -f1
 }
 
 get_vfio_path() {


### PR DESCRIPTION
The PCI device entry for the modern virtio net device has been updated (https://pci-ids.ucw.cz/read/PC/1af4/1041), so make the matching less strict to find the new device. This hits VMs using an updated pci device database.

Fixes: #6790