### PR TITLE
docs: Include Pytorch benchmark metrics

### DIFF
--- a/cmd/check-spelling/data/projects.txt
+++ b/cmd/check-spelling/data/projects.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Intel Corporation
+# Copyright (c) 2019-2023 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -72,6 +72,7 @@ packagecloud/B
 Pandoc/B
 Podman/B
 PullApprove/B
+Pytorch/B
 QuickAssist/B
 R/B
 raytracer/B

--- a/metrics/machine_learning/README.md
+++ b/metrics/machine_learning/README.md
@@ -13,4 +13,17 @@ Individual tests can be run by hand, for example:
 $ cd metrics/machine_learning
 $ ./tensorflow.sh 25 60
 ```
+# Kata Containers Pytorch Metrics
 
+Kata Containers provides a series of performance tests using Pytorch
+benchmarks based on a suite of Python high performance computing
+benchmarks.
+
+## Running the Pytorch test
+
+Individual tests can be run by hand, for example:
+
+```
+$ cd metrics/machine_learning
+$ ./tensorflow.sh 40 100
+```


### PR DESCRIPTION
This PR includes Pytorch benchmark performance metrics that currently are part of the kata containers metrics scripts.

Fixes #5628