### PR TITLE
ci: Ignore license header check for *.bin files (main)

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -435,6 +435,7 @@ static_check_license_headers()
 			--exclude="*.md" \
 			--exclude="*.pb.go" \
 			--exclude="*pb_test.go" \
+			--exclude="*.bin" \
 			--exclude="*.png" \
 			--exclude="*.pub" \
 			--exclude="*.service" \


### PR DESCRIPTION
`*.bin` files are binary and cannot include a license or copyright header; skip them, similarly to other binary files (`*.jpg`, `*.png`, etc.).

Fixes: #5632

This PR was ported from branch CCv0 (original PR #5208) using:

```
git cherry-pick 5035fe8f199098658143e2526db42e1b73633d5a
```

and modifying the commit message to point to the new github issue.
