### PR TITLE
metrics: Fix tensorflow json results

### DIFF
--- a/metrics/machine_learning/tensorflow.sh
+++ b/metrics/machine_learning/tensorflow.sh
@@ -75,7 +75,6 @@ function nhwc_test() {
 EOF
 )"
 	metrics_json_add_array_element "$json"
-	metrics_json_end_array "Results"
 }
 
 function axelnet_test() {


### PR DESCRIPTION
This PR fixes the duplication of printing twice the nhwc tensorflow results in a json file.

Fixes #5635