### PR TITLE
metrics: Add build arg with proxys for docker build command

### DIFF
--- a/metrics/lib/common.bash
+++ b/metrics/lib/common.bash
@@ -107,7 +107,7 @@ build_dockerfile_image()
 
 	if [ -f "$dockerfile_path" ]; then
 		echo "docker building $image"
-		if ! sudo "${DOCKER_EXE}" build --label "$image" --tag "${image}" -f "$dockerfile_path" "$dockerfile_dir"; then
+		if ! sudo "${DOCKER_EXE}" build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" --label "$image" --tag "${image}" -f "$dockerfile_path" "$dockerfile_dir"; then
 			die "Failed to docker build image $image"
 		fi
 		return 0


### PR DESCRIPTION
This PR adds the flag of --build-arg http_proxy and https_proxy for the docker build command to make it work when this is used behind a proxy.

Fixes #5638