### PR TITLE
stability: Use variables defined in common for cassandra script

### DIFF
--- a/stability/cassandra_stress.sh
+++ b/stability/cassandra_stress.sh
@@ -21,21 +21,21 @@ function main() {
 
 	init_env
 	check_cmds "${cmds[@]}"
-	sudo -E docker pull "${DOCKER_IMAGE}"
-	sudo -E docker save -o "${DOCKER_IMAGE}.tar" "${DOCKER_IMAGE}"
-	sudo -E ctr i import "${DOCKER_IMAGE}.tar"
+	sudo -E "${DOCKER_EXE}" pull "${DOCKER_IMAGE}"
+	sudo -E "${DOCKER_EXE}" save -o "${DOCKER_IMAGE}.tar" "${DOCKER_IMAGE}"
+	sudo -E "${CTR_EXE}" i import "${DOCKER_IMAGE}.tar"
 
-	sudo -E ctr run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
-	sudo -E ctr t exec --exec-id 1 "${CONTAINER_NAME}" sh -c "${CMD}"
+	sudo -E "${CTR_EXE}" run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
+	sudo -E "${CTR_EXE}" t exec --exec-id 1 "${CONTAINER_NAME}" sh -c "${CMD}"
 	info "Write one million rows"
 	local WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1000000 -rate threads=50"
-	sudo -E ctr t exec --exec-id 2 "${CONTAINER_NAME}" sh -c "${WRITE_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id 2 "${CONTAINER_NAME}" sh -c "${WRITE_CMD}"
 	info "Load one row with default schema"
 	local CQL_WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1 c1=one -mode native cql3 -log file-create_schema.log"
-	sudo -E ctr t exec --exec-id 3 "${CONTAINER_NAME}" sh -c "${CQL_WRITE_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id 3 "${CONTAINER_NAME}" sh -c "${CQL_WRITE_CMD}"
 	info "Run a write workload using CQL"
 	local REAL_WRITE_CMD="./opt/cassandra/tools/bin/cassandra-stress write n=1000000 cl=one -mode native cql3 -schema keyspace='keyspace1' -log file=load_1M_rows.log"
-	sudo -E ctr t exec --exec-id 4 "${CONTAINER_NAME}" sh -c "${REAL_WRITE_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id 4 "${CONTAINER_NAME}" sh -c "${REAL_WRITE_CMD}"
 
 	clean_env_ctr
 }


### PR DESCRIPTION
This PR allow us to use variables that are already defined in the common script  in the cassandra script like DOCKER_EXE and
CTR_EXE to have uniformity across the tests.

Fixes #5641