### PR TITLE
qemu: Fix TDX build

### DIFF
--- a/.ci/install_qemu.sh
+++ b/.ci/install_qemu.sh
@@ -104,6 +104,7 @@ main() {
 
 	if [ "${KATA_BUILD_CC}" == "yes" ]; then
 		build_and_install_qemu_for_cc
+		return 0
 	fi
 
 	export qemu_type


### PR DESCRIPTION
We're currently getting the following error when building QEMU for TDX as part of our Jenkins CI:
```sh
11:57:40 [install_qemu.sh:64] INFO: qemu type 'tdx' not supported
11:57:41 Overview:
11:57:41
11:57:41 	Build and install QEMU for Kata Containers
11:57:41
11:57:41 Usage:
11:57:41
11:57:41 	install_qemu.sh [options]
11:57:41
11:57:41 Options:
11:57:41     -d          : Enable bash debug.
11:57:41     -h          : Display this help.
11:57:41     -t <qemu> : qemu type, such as tdx, vanilla.
11:57:41 [jenkins_job_build.sh:252] ERROR: ci/setup.sh
```

This is happening because we try to proceed building other artefacts after the build of QEMU for CC is done, while we should simply stop there.

Fixes: #5651
Depends-on: github.com/kata-containers/kata-containers#6919