### PR TITLE
ci: Fetch k8s gpg key from dl.k8s.io

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -29,7 +29,7 @@ if [ "$ID" == "ubuntu" ]; then
 EOF"
 
 	chronic sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list
-	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+	curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
 	chronic sudo -E apt update
 	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
 elif [[ "$ID" =~ ^(alinux|centos|fedora|rhel)$ ]]; then


### PR DESCRIPTION
The gpg key hosting at packages.cloud.google.com is known to fail regularly, and it is recommended[1] to use a different mirror for the gpg key. Switch to fetching apt gpg key from there, to reduce test failures.