### PR TITLE
stability: Update stressng dockerfile

### DIFF
--- a/stability/stressng_dockerfile/Dockerfile
+++ b/stability/stressng_dockerfile/Dockerfile
@@ -7,6 +7,8 @@ FROM ubuntu:20.04
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends sudo build-essential curl && \
 	apt-get remove -y unattended-upgrades && \


### PR DESCRIPTION
This PR updates the stressng dockerfile in order to avoid that when installing the packages we have an interactive mode.

Fixes #5657