### PR TITLE
versions: Update xurls version to 2.5.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -52,7 +52,7 @@ externals:
     description: |
       Tool used by the CI to check URLs in documents and code comments.
     url: "mvdan.cc/xurls/v2/cmd/xurls"
-    version: "v2.4.0"
+    version: "v2.5.0"
 
   go-md2man:
     description: "cri-o dependency used for building documentation"


### PR DESCRIPTION
This PR updates the xurls version to 2.5.0. This changes the following:
Add xurls -fix=all to replace URLs with temporary redirects as well 
xurls -fix now shows more detailed info on broken URLs 
xurls -fix now uses the method HEAD before falling back to GET
xurls -fix now provides a meaningful User-Agent header Add a xurls -version flag
Update lists of TLDs and schemes

Fixes #5659