### PR TITLE
metrics: Update tensorflow Dockerfile

### DIFF
--- a/metrics/machine_learning/tensorflow_dockerfile/Dockerfile
+++ b/metrics/machine_learning/tensorflow_dockerfile/Dockerfile
@@ -8,6 +8,8 @@ FROM intel/intel-optimized-tensorflow:2.9.1
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends build-essential git && \
 	apt-get remove -y unattended-upgrades && \


### PR DESCRIPTION
This PR updates the Tensorflow Dockerfile in order to avoid that when installing the packages we have an interactive mode.

Fixes #5662