### PR TITLE
e2e_conformance: Add support for runtime class

### DIFF
--- a/integration/kubernetes/e2e_conformance/run.sh
+++ b/integration/kubernetes/e2e_conformance/run.sh
@@ -27,6 +27,7 @@ RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 CRI_RUNTIME="${CRI_RUNTIME:-containerd}"
 MINIMAL_K8S_E2E="${MINIMAL_K8S_E2E:-false}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
+RUNTIME_CLASS="${RUNTIME_CLASS:-kata}"
 
 # Overall Sonobuoy timeout in minutes.
 WAIT_TIME=${WAIT_TIME:-180}


### PR DESCRIPTION
Add support to the run.sh which invokes deploy_webhook.sh to pass the custom runtimclass.

Fixes: #5669