### PR TITLE
ci: Switch to http kubernetes mirror

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -25,7 +25,7 @@ if [ "$ID" == "ubuntu" ]; then
 		sudo -E apt purge kubelet -y
 	fi
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-	deb http://apt.kubernetes.io/ kubernetes-xenial-unstable main
+	deb http://packages.cloud.google.com/apt/ kubernetes-xenial-unstable main
 EOF"
 
 	chronic sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
SEV tests regularly fail with this error message:

  Err:5 https://packages.cloud.google.com/apt kubernetes-xenial-unstable Release
    Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 142.250.189.174 443]

It is likely, that the issue is caused by a TLS MITM proxy, that does network scanning. If we switch to the http version of the mirror, we might have more luck. This is safe to do because the mirror is verified using gpg signatures.

Fixes: #7039