### PR TITLE
checkspelling: Add new words for checkmetrics documentation

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -14,6 +14,8 @@ backtrace
 bootloader/AB
 centric/B
 checkbox/A
+checkmetrics/AB
+checktypes
 chipset/AB
 codebase
 commandline
@@ -51,6 +53,7 @@ iodepth/A
 ioengine/A
 iptables
 Itanium/AB
+json/AB
 kata
 Kat/AB		# "Kat Herding Team" :)
 keypair/A
@@ -60,11 +63,13 @@ logfile/A
 Longterm
 longterm
 loopback
+maxval
 memcpy/A
 mergeable
 metadata
 microcontroller/AB
 miniOS
+minval
 mmap/AB
 nack/AB
 namespace/ABCD


### PR DESCRIPTION
This PR adds new words to the checkspelling that are part of the checkmetrics documentation.

Fixes #5696

Depends-on:github.com/kata-containers/kata-containers#7173