### PR TITLE
ci/openshift-ci: Fix the smoke_test permissions

### DIFF
--- a/.ci/openshift-ci/smoke/http-server.yaml
+++ b/.ci/openshift-ci/smoke/http-server.yaml
@@ -18,4 +18,13 @@ spec:
         - containerPort: 8080
       command: ["python3"]
       args: [ "-m", "http.server", "8080"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
   runtimeClassName: kata-qemu

--- a/kata-webhook/deploy/webhook.yaml
+++ b/kata-webhook/deploy/webhook.yaml
@@ -41,6 +41,15 @@ spec:
             requests:
               cpu: "100m"
               memory: "250Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+                drop:
+                    - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+                type: RuntimeDefault
       volumes:
         - name: webhook-certs
           secret:

--- a/kata-webhook/webhook-check.sh
+++ b/kata-webhook/webhook-check.sh
@@ -57,6 +57,15 @@ check_working() {
 	      image: quay.io/prometheus/busybox:latest
 	      command: ["echo", "Hello Webhook"]
 	      imagePullPolicy: IfNotPresent
+	      securityContext:
+	        allowPrivilegeEscalation: false
+	        capabilities:
+	          drop:
+	            - ALL
+	        runAsNonRoot: true
+	        runAsUser: 1000
+	        seccompProfile:
+	          type: RuntimeDefault
 	EOF
 	local class_name=$(kubectl get -n ${WEBHOOK_NS} \
 		-o jsonpath='{.spec.runtimeClassName}' pod/${hello_pod})


### PR DESCRIPTION
Modify the smoke_test container securityContext to work well with OCP 4.14.

Fixes: https://github.com/kata-containers/tests/issues/5671

@wainersm this is also required in order to allow OCP 4.14 pipelines