### PR TITLE
spell: update spelling dictionary

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -107,3 +107,8 @@ WIP/AB	# Work In Progress
 WRT/AB	# With Respect To
 XIP/AB
 YAML/AB
+irq/AB
+mmio/AB
+APIC
+msg/AB
+UDS

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -128,3 +128,5 @@ whitespace
 workflow/A
 Xeon/A
 yaml
+upcall
+Upcall


### PR DESCRIPTION
Add commonly used words like mmio, APIC, upcall to Kata CI spelling check.

fixes: #5715