### PR TITLE
dict: add more spelling into kata-spell-check

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -107,3 +107,16 @@ WIP/AB	# Work In Progress
 WRT/AB	# With Respect To
 XIP/AB
 YAML/AB
+irq/AB
+mmio/AB
+APIC
+msg/AB
+UDS
+dbs # Dragonball Sandbox
+TDX
+tdx 
+mptable 
+fdt
+gic
+msr
+cpuid

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -128,3 +128,8 @@ whitespace
 workflow/A
 Xeon/A
 yaml
+upcall
+Upcall
+ioctl/A
+struct/A # struct in Rust
+Struct/A 


### PR DESCRIPTION
Add words like TDX, mptable, fdt and etc. to help enrich Kata spelling check.

fixes: #5719