### PR TITLE
dict: add more words into kata-spell-check

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -112,3 +112,11 @@ mmio/AB
 APIC
 msg/AB
 UDS
+dbs # Dragonball Sandbox
+TDX
+tdx 
+mptable 
+fdt
+gic
+msr
+cpuid

--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -130,3 +130,6 @@ Xeon/A
 yaml
 upcall
 Upcall
+ioctl/A
+struct/A # struct in Rust
+Struct/A


### PR DESCRIPTION
Add words like TDX, mptable, fdt and etc. to help enrich Kata spelling check.

fixes: #5719