### PR TITLE
Dict: add pio into Kata CI spelling check

### DIFF
--- a/cmd/check-spelling/data/acronyms.txt
+++ b/cmd/check-spelling/data/acronyms.txt
@@ -120,3 +120,4 @@ fdt
 gic
 msr
 cpuid
+pio


### PR DESCRIPTION
Add pio into acronyms.txt

fixes: #5722