### PR TITLE
license: avoid checking license for *.dtd file

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -443,6 +443,7 @@ static_check_license_headers()
 			--exclude="*.drawio" \
 			--exclude="*.toml" \
 			--exclude="*.txt" \
+			--exclude="*.dtd" \ 
 			--exclude="vendor/*" \
 			--exclude="VERSION" \
 			--exclude="kata_config_version" \


### PR DESCRIPTION
Since .dtd is used in Dragonball for aarch64 unit test and .dtd is a binary file so it could not be added apache 2.0 license line of code.

So we should avoid checking license for *.dtd file in our CI.

fixes: #5724