### PR TITLE
vfio: Fix default port assignment

### DIFF
--- a/functional/vfio/run.sh
+++ b/functional/vfio/run.sh
@@ -188,6 +188,8 @@ setup_configuration_file() {
 	if [ -n "$MACHINE_TYPE" ]; then
 		if [ "$HYPERVISOR" = "qemu" ]; then
 			sed -i 's|^machine_type.*|machine_type = "'${MACHINE_TYPE}'"|g' "${kata_config_file}"
+			# Make sure we have set hot_plug_vfio to a reasonable value
+			sudo sed -i -e 's|^#hot_plug_vfio =.*$|hot_plug_vfio = "bridge-port"|' -e 's|^hot_plug_vfio = .*$|hot_plug_vfio = "bridge-port"|' "${kata_config_file}"
 		else
 			warn "Variable machine_type only applies to qemu. It will be ignored"
 		fi


### PR DESCRIPTION
Fix default port assignment with an explicit value in the TOML It was implicit before and now the runtime will bail out if we did not set it explicitly. Update the configuration and set it. This will make the intent more clear.

Fixes: #5726