### PR TITLE
cc: install_kata_image: Update to the Aug 1st kata-containers merge

### DIFF
--- a/.ci/install_kata_image.sh
+++ b/.ci/install_kata_image.sh
@@ -24,7 +24,7 @@ build_image_for_cc () {
 		if [ "${TEE_TYPE}" != "sev" ] && [ "${TEE_TYPE}" != "snp" ]; then
 		  die "SEV and SNP are the only TEE types that supports initrd"
 		fi
-		build_static_artifact_and_install "sev-rootfs-initrd"
+		build_static_artifact_and_install "rootfs-initrd-sev"
 	else
 		[ "${osbuilder_distro:-ubuntu}" == "ubuntu" ] || \
 			die "The only supported image for Confidential Containers is Ubuntu"
@@ -33,7 +33,7 @@ build_image_for_cc () {
 			# Cloud Hypervisor is still using `offline_fs_kbc`, so it has to
 			# use the generic image.  QEMU, on the other hand, is using
 			# `cc_kbc` and it requires the `tdx-rootfs-image`.
-			build_static_artifact_and_install "tdx-rootfs-image"
+			build_static_artifact_and_install "rootfs-image-tdx"
 		elif [ "${TEE_TYPE}" == "se" ]; then
 			build_static_artifact_and_install "rootfs-initrd"
 		else

--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -178,7 +178,7 @@ function build_static_artifact_and_install() {
 	# Use different target for Confidential Containers.
 	if [ "${KATA_BUILD_CC:-no}" == "yes" ]; then
 		case ${artifact} in
-			"tdx-td-shim"|"sev-rootfs-initrd"|"tdx-rootfs-image"|"rootfs-image"|"rootfs-initrd"|"se-image"|"shim-v2")
+			"tdx-td-shim"|"rootfs-image"|"rootfs-initrd"|"se-image"|"shim-v2")
 				info "${make_target} is being used with the component from the CCv0 branch"
 				make_target="cc-${make_target}"
 				tarball="kata-static-cc-${artifact}.tar.xz"


### PR DESCRIPTION
A few names must be changed, as we're using those as close from the `main` as possible.

* sev-rootfs-initrd -> rootfs-initrd-sev
* tdx-rootfs-image -> rootfs-image-tdx

Depends-on: github.com/kata-containers/kata-containers#7513