### PR TITLE
ci: fix missing bc error during setup

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -21,8 +21,8 @@ sudo -E apt -y remove --purge man-db
 echo "Try to preemptively fix broken dependencies, if any"
 sudo -E apt --fix-broken install -y
 
-echo "Install chronic"
-sudo -E apt install -y moreutils
+echo "Install chronic and bc"
+sudo -E apt install -y moreutils bc
 
 declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-gb hunspell-en-us pandoc" \


### PR DESCRIPTION
Currently this script needs bc to run before installing dependencies.

Fixes: #5744