### PR TITLE
ci-setup-env-ubuntu: Install devmapper & clang

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -28,6 +28,7 @@ declare -A minimal_packages=( \
 	[spell-check]="hunspell hunspell-en-gb hunspell-en-us pandoc" \
 	[xml_validator]="libxml2-utils" \
 	[yaml_validator]="yamllint" \
+	[guest_component]="libdevmapper-dev clang" \
 )
 
 declare -A packages=( \


### PR DESCRIPTION
After image-rs added the image-block-device integrity check using dm-verity a new dependency is now needed, so install that.

Refer the following PR for more information:
https://github.com/confidential-containers/guest-components/pull/270