### PR TITLE
tests/kubernetes: Correctly run cleanup_bare_metal_env.sh

### DIFF
--- a/integration/kubernetes/cleanup_env.sh
+++ b/integration/kubernetes/cleanup_env.sh
@@ -49,7 +49,7 @@ main () {
 
 	# if CI run in bare-metal, we need a set of extra clean
 	if [ "${BAREMETAL}" == true ] && [ -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" ]; then
-		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh ${keep_cni_bin}"
+		bash -f "${SCRIPT_PATH}/cleanup_bare_metal_env.sh" "${keep_cni_bin}"
 	fi
 
 	info "Check no kata processes are left behind after reseting kubernetes"


### PR DESCRIPTION
Correct the quoting so that we run the script correctly. It currently fails with:

bash: .../tests/integration/kubernetes/cleanup_bare_metal_env.sh false: No such file or directory

Fixes: #5525