### PR TITLE
Sev ci fixes for `k8s_delete_all` and updating the simple-kbs

### DIFF
--- a/integration/kubernetes/confidential/sev.bats
+++ b/integration/kubernetes/confidential/sev.bats
@@ -28,10 +28,10 @@ load "${TESTS_REPO_DIR}/integration/kubernetes/confidential/lib.sh"
 
 # Delete all test services
 k8s_delete_all() {
-  for file in $(ls "${TEST_DIR}/*.yaml") ; do
-    # Removing extension to get the pod name
-    local pod_name="${file%.*}"
-    kubernetes_delete_by_yaml "${pod_name}" "${TEST_DIR}/${file}"
+  for file in $(find "${TEST_DIR}" -name "*.yaml"); do
+    # Removing prefix path and file extension to get the pod partial name
+    local pod_partial_name=$(basename "${file%.*}")
+    kubernetes_delete_by_yaml "${pod_partial_name}" "${file}"
   done
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -72,7 +72,7 @@ externals:
   simple-kbs:
     description: "Simple KBS that hosts key storage with release policies"
     url: "https://github.com/confidential-containers/simple-kbs.git"
-    tag: "0.1.1"
+    tag: "v0.1.3"
 
   sonobuoy:
     description: "Tool to run kubernetes e2e conformance tests"


### PR DESCRIPTION
bash (ls) regex in quotes was throwing errors and k8s services/pods were not getting cleaned up.
Service yamls weren't being deleted due to partial name including prefix file path, now trims using 'basename'.
Removed redundant TEST_DIR on the yaml file to be deleted.

The updated simple-kbs uses a openssl v3 supported rust docker image.

Fixes: #5760

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>