### PR TITLE
CCv0: Add -w to iptables in configure_cc_containerd

### DIFF
--- a/integration/confidential/lib.sh
+++ b/integration/confidential/lib.sh
@@ -227,7 +227,7 @@ configure_cc_containerd() {
 	if ! waitForProcess 30 5 "sudo crictl info >/dev/null"; then
 		die "containerd seems not operational after reconfigured"
 	fi
-	sudo iptables -P FORWARD ACCEPT
+	sudo iptables -w -P FORWARD ACCEPT
 }
 
 #


### PR DESCRIPTION
Adding -w iptables will wait for the lock on the xtables to be released.

Fixes: #5765