### PR TITLE
ci: stability: Disable soak parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,15 +69,15 @@ sgx:
 	bash -f functional/sgx/run.sh
 
 stability:
-	cd stability && \
-	ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
+	# cd stability && \
+	# ITERATIONS=2 MAX_CONTAINERS=20 ./soak_parallel_rm.sh
 	cd stability && ./hypervisor_stability_kill_test.sh
 
 stability-baremetal:
 	bash -f stability/stressng.sh
 	bash -f stability/scability_test.sh 100 10
 
-# If hypervisor is dragonball, the default path to keep pod info is /run/kata. Meanwhile, there is 
+# If hypervisor is dragonball, the default path to keep pod info is /run/kata. Meanwhile, there is
 # no independent hypervisor process for dragonball, so disale hypervisor_stability_kill_test.sh
 dragonball-stability:
 	mkdir -p /etc/kata-containers && \


### PR DESCRIPTION
The soak parallel tests are failing on `CCv0` PRs and I noticed that they are currently commented on it `main`
https://github.com/kata-containers/kata-containers/blob/1280f8534375fa7320b37cb4dba200d371412e9b/tests/stability/gha-run.sh#L20 so, comment them here to match as this is a dead-end code path and we don't want to spend lots of time debugging it.

Depends-on: github.com/kata-containers/kata-containers#8173