### PR TITLE
CC: Skip test pulling image inside guest temporarily for IBM SE

### DIFF
--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -61,6 +61,10 @@ setup() {
 }
 
 @test "$test_tag Test can pull an unencrypted image inside the guest" {
+	# See an issue at https://github.com/kata-containers/tests/issues/5781
+	if [ "${TEE_TYPE}" = "se" ]; then
+		skip "test until the containerd is updated to v1.7 for IBM Z Secure Execution"
+	fi
 	create_test_pod
 
 	echo "Check the image was not pulled in the host"


### PR DESCRIPTION
This PR is to skip a test `Test can pull an unencrypted image inside the guest` for IBM Z secure execution until the containerd is updated to `v1.7`.

Fixes: #5781

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>