### PR TITLE
CC | tests: Set io.containerd.cri.runtime-handler annotation

### DIFF
--- a/integration/kubernetes/confidential/agent_image.bats
+++ b/integration/kubernetes/confidential/agent_image.bats
@@ -164,7 +164,10 @@ setup() {
 
 	assert_pod_fail "${pod_config}"
 
-	assert_logs_contain "containerd" 'failed to resolve reference \\"quay.io/kata-containers/confidential-containers-auth:test\\": pulling from host quay.io failed with status code \[manifests test\]: 401 UNAUTHORIZED'
+	# The error will be different depending on the containerd version being used.
+	# The former assert is the one coming from containerd 1.6.x, while the latter is the cone coming from 1.7.x
+	assert_logs_contain "containerd" 'failed to resolve reference \\"quay.io/kata-containers/confidential-containers-auth:test\\": pulling from host quay.io failed with status code \[manifests test\]: 401 UNAUTHORIZED' || \
+		assert_logs_contain "containerd" 'failed to resolve reference \\"quay.io/kata-containers/confidential-containers-auth:test\\": unexpected status from HEAD request to https://quay.io/v2/kata-containers/confidential-containers-auth/manifests/test: 401 UNAUTHORIZED'
 }
 
 teardown() {

--- a/integration/kubernetes/confidential/fixtures/pod-config-secret.yaml.in
+++ b/integration/kubernetes/confidential/fixtures/pod-config-secret.yaml.in
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: secret-test-pod-cc
+  annotations:
+    io.containerd.cri.runtime-handler: $RUNTIMECLASS
 spec:
   runtimeClassName: $RUNTIMECLASS
   containers:

--- a/integration/kubernetes/confidential/fixtures/pod-config.yaml.in
+++ b/integration/kubernetes/confidential/fixtures/pod-config.yaml.in
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: busybox-cc
+  annotations:
+    io.containerd.cri.runtime-handler: $RUNTIMECLASS
 spec:
   runtimeClassName: $RUNTIMECLASS
   containers:

--- a/integration/kubernetes/confidential/fixtures/service.yaml.in
+++ b/integration/kubernetes/confidential/fixtures/service.yaml.in
@@ -24,6 +24,8 @@ spec:
     metadata:
       labels:
         app: "$NAME"
+      annotations:
+        io.containerd.cri.runtime-handler: "$RUNTIMECLASS"
     spec:
       runtimeClassName: "$RUNTIMECLASS"
       containers:

--- a/integration/kubernetes/confidential/lib.sh
+++ b/integration/kubernetes/confidential/lib.sh
@@ -67,13 +67,15 @@ retrieve_sandbox_id() {
 
 # Check out the doc repo if required
 checkout_doc_repo_dir() {
-    local doc_repo=github.com/confidential-containers/documentation
+    local doc_repo=github.com/confidential-containers/confidential-containers
     export doc_repo_dir="${GOPATH}/src/${doc_repo}"    
     mkdir -p $(dirname ${doc_repo_dir}) && sudo chown -R ${USER}:${USER} $(dirname ${doc_repo_dir})
     if [ ! -d "${doc_repo_dir}" ]; then
         git clone https://${doc_repo} "${doc_repo_dir}"
         # Update runtimeClassName from kata-cc to "$RUNTIMECLASS"
         sudo sed -i -e 's/\([[:blank:]]*runtimeClassName: \).*/\1'${RUNTIMECLASS:-kata}'/g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
+        # Update runtime-handler value for the "io.containerd.cri.runtime-handler" annotation to "$RUNTIMECLASS"
+        sudo sed -i -e 's/\([[:blank:]]*io.containerd.cri.runtime-handler: \).*/\1'${RUNTIMECLASS:-kata}'/g' "${doc_repo_dir}/demos/ssh-demo/k8s-cc-ssh.yaml"
         chmod 600 ${doc_repo_dir}/demos/ssh-demo/ccv0-ssh
     fi
 }


### PR DESCRIPTION
The CRI PullImage does not have a "runtime class" input, and this is being discussed at the kubernetes level on:
* https://github.com/kubernetes/enhancements/pull/4217
* https://github.com/kubernetes/kubernetes/pull/118907

For now, we're forced to pass the specific annotation to containerd.