### PR TITLE
stable-3.2 | ci: Ensure we have yq installed

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -227,6 +227,8 @@ run_unit_test() {
 		clone_katacontainers_repo
 
 		pushd "${GOPATH}/src/${katacontainers_repo}"
+		echo "Installing yq"
+		sudo -E INSTALL_IN_GOPATH=false ./ci/install_yq.sh
 		echo "Installing libseccomp library from sources"
 		libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
 		gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)


### PR DESCRIPTION
There was a recent change on the Kata Containers side that ended up breaking our CI here as yq is not automagically installed anymore.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
(cherry picked from commit 6bf08c833e3663cdff81e75b446325326bec500c)