### PR TITLE
check-spelling: Add gh project

### DIFF
--- a/cmd/check-spelling/data/main.txt
+++ b/cmd/check-spelling/data/main.txt
@@ -36,6 +36,7 @@ ethernet
 filename/AB
 filesystem/AB
 freeform
+gh
 goroutine/AB
 hostname/AB
 hotplug/ACD


### PR DESCRIPTION
Add gh to the dictionary as the project is references in the release process doc

Fixes: #5792