### PR TITLE
ci/openshift-ci: Enable selinux in CI runs

### DIFF
--- a/.ci/openshift-ci/cluster/deployments/relabel_selinux.yaml
+++ b/.ci/openshift-ci/cluster/deployments/relabel_selinux.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: relabel-selinux-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: restorecon
+  template:
+    metadata:
+      labels:
+        app: restorecon
+    spec:
+      serviceAccountName: kata-deploy-sa
+      hostPID: true
+      containers:
+        - name: relabel-selinux-container
+          image: alpine
+          securityContext:
+            privileged: true
+          command: ["/bin/sh", "-c", "
+            set -e;
+            echo Starting the relabel;
+            nsenter --target 1 --mount bash -xc '
+                for ENTRY in \
+                    \"/(.*/)?opt/kata/bin(/.*)?\" \
+                    \"/(.*/)?opt/kata/runtime-rs/bin(/.*)?\" \
+                    \"/(.*/)?opt/kata/share/kata-.*(/.*)?(/.*)?\" \
+                    \"/(.*/)?opt/kata/share/ovmf(/.*)?\" \
+                    \"/(.*/)?opt/kata/share/tdvf(/.*)?\" \
+                    \"/(.*/)?opt/kata/libexec(/.*)?\";
+                do
+                    semanage fcontext -a -t qemu_exec_t \"$ENTRY\" || { echo \"Error in semanage command\"; exit 1; }
+                done;
+                restorecon -v -R /opt/kata || { echo \"Error in restorecon command\"; exit 1; }
+            ';
+            echo NSENTER_FINISHED_WITH: $?;
+            sleep infinity"]

--- a/.ci/openshift-ci/cluster/install_kata.sh
+++ b/.ci/openshift-ci/cluster/install_kata.sh
@@ -181,3 +181,11 @@ if [ ${SELINUX_PERMISSIVE} == "yes" ]; then
 	# The new SELinux configuration will trigger another reboot.
 	wait_for_reboot
 fi
+
+# FIXME: Remove when https://github.com/kata-containers/kata-containers/pull/8417 is resolved
+# Selinux context is currently not handled by kata-deploy
+oc apply -f ${deployments_dir}/relabel_selinux.yaml
+( for I in $(seq 30); do
+	sleep 10
+	oc logs -n kube-system ds/relabel-selinux-daemonset | grep "NSENTER_FINISHED_WITH:" && exit
+done ) || { echo "Selinux relabel failed, check the logs"; exit -1; }

--- a/.ci/openshift-ci/test.sh
+++ b/.ci/openshift-ci/test.sh
@@ -19,7 +19,7 @@ export PATH=/tmp/shared:$PATH
 oc version || die "Test cluster is unreachable"
 
 info "Install and configure kata into the test cluster"
-export SELINUX_PERMISSIVE="yes"
+export SELINUX_PERMISSIVE="no"
 ${script_dir}/cluster/install_kata.sh || die "Failed to install kata-containers"
 
 info "Run test suite: $suite"


### PR DESCRIPTION
as kata-deploy does not currently handles selinux, this requires manual relabel of the /opt/kata folder where custom binaries are deployed.

Fixes: https://github.com/kata-containers/tests/issues/5802