### PR TITLE
ci/openshift-ci: Use loop instead of curl --retry-all-errors

### DIFF
--- a/.ci/openshift-ci/run_smoke_test.sh
+++ b/.ci/openshift-ci/run_smoke_test.sh
@@ -56,7 +56,8 @@ else
     port=$(oc get service/http-server-service -o jsonpath='{.spec.ports[0].nodePort}')
 fi
 
-curl "${host}:${port}${hello_file}" -s -o hello_msg.txt --retry 60 --retry-delay 1 --retry-all-errors
+info "Wait for the HTTP server to respond"
+waitForProcess 60 1 "curl '${host}:${port}${hello_file}' -s -o hello_msg.txt"
 
 grep "${hello_msg}" hello_msg.txt > /dev/null
 test_status=$?

--- a/.ci/openshift-ci/run_smoke_test.sh
+++ b/.ci/openshift-ci/run_smoke_test.sh
@@ -57,6 +57,7 @@ else
 fi
 
 info "Wait for the HTTP server to respond"
+rm -f hello_msg.txt
 waitForProcess 60 1 "curl '${host}:${port}${hello_file}' -s -o hello_msg.txt"
 
 grep "${hello_msg}" hello_msg.txt > /dev/null


### PR DESCRIPTION
The --retry-all-errors argument is not supported on the CI runners, use a busy loop instead.