### PR TITLE
ci.ocp: Improve the service-up detection

### DIFF
--- a/.ci/openshift-ci/run_smoke_test.sh
+++ b/.ci/openshift-ci/run_smoke_test.sh
@@ -57,14 +57,12 @@ else
 fi
 
 info "Wait for the HTTP server to respond"
-rm -f hello_msg.txt
-waitForProcess 60 1 "curl '${host}:${port}${hello_file}' -s -o hello_msg.txt"
-
-grep "${hello_msg}" hello_msg.txt > /dev/null
-test_status=$?
-if [ $test_status -eq 0 ]; then
+check_cmd="curl -vvv '${host}:${port}${hello_file}' 2>&1 | grep -q '$hello_msg'"
+if waitForProcess 60 1 "${check_cmd}"; then
+	test_status=0
 	info "HTTP server is working"
 else
+	test_status=1
 	info "HTTP server is unreachable"
 fi
 

--- a/.ci/openshift-ci/run_smoke_test.sh
+++ b/.ci/openshift-ci/run_smoke_test.sh
@@ -57,14 +57,26 @@ else
 fi
 
 info "Wait for the HTTP server to respond"
-check_cmd="curl -vvv '${host}:${port}${hello_file}' 2>&1 | grep -q '$hello_msg'"
+tempfile=$(mktemp)
+check_cmd="curl -vvv '${host}:${port}${hello_file}' 2>&1 | tee -a '$tempfile' | grep -q '$hello_msg'"
 if waitForProcess 60 1 "${check_cmd}"; then
 	test_status=0
 	info "HTTP server is working"
 else
 	test_status=1
+	echo "::error:: HTTP server not working"
+	echo "::group::Output of the \"curl -vvv '${host}:${port}${hello_file}'\""
+	cat "${tempfile}"
+	echo "::endgroup::"
+	echo "::group::Describe kube-system namespace"
+	oc describe -n kube-system all
+	echo "::endgroup::"
+	echo "::group::Descibe current namespace"
+	oc describe all
+	echo "::endgroup::"
 	info "HTTP server is unreachable"
 fi
+rm -f "$tempfile"
 
 # Delete the resources.
 #


### PR DESCRIPTION
waiting for the first response is not sufficient as OCP returns html page without error even when the route is not yet established describing the issue (why it doesn't reply with 500?). Waiting for the correct output should do better.