### PR TITLE
install: adding packages required by latest qemu 8.2.1 build

### DIFF
--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -32,7 +32,7 @@ declare -A minimal_packages=( \
 
 declare -A packages=( \
 	[kata_containers_dependencies]="libtool automake autotools-dev autoconf bc libpixman-1-dev coreutils curl expect" \
-	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev ninja-build" \
+	[qemu_dependencies]="libcap-dev libattr1-dev libcap-ng-dev librbd-dev ninja-build python python-dev python3-venv" \
 	[kernel_dependencies]="libelf-dev flex" \
 	[crio_dependencies]="libglib2.0-dev libseccomp-dev libapparmor-dev libgpgme11-dev thin-provisioning-tools" \
 	[bison_binary]="bison" \


### PR DESCRIPTION
Builds with the latest qemu 8.2.1 are failing with a python venv and ensurepip error. Adding these packages as qemu dependencies should fix the issue.

Fixes: #5809

Python dependency packages pulled from here:
https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/static-build/qemu/Dockerfile

I believe @niteeshkd ran into this same issue in this PR:
https://github.com/kata-containers/kata-containers/pull/9086

Docker installation of packages updated in kata-containers, but looks like the `jenkins-ci-ARM-ubuntu-20.04-main` job installs the packages on bare-metal. Hence this PR.