### PR TITLE
ci: Switch to pkgs.k8s.io

### DIFF
--- a/.ci/install_kubernetes.sh
+++ b/.ci/install_kubernetes.sh
@@ -25,13 +25,13 @@ if [ "$ID" == "ubuntu" ]; then
 		sudo -E apt purge kubelet -y
 	fi
 	sudo bash -c "cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-	deb http://packages.cloud.google.com/apt/ kubernetes-xenial-unstable main
+	deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /
 EOF"
-
 	chronic sudo -E sed -i 's/^[ \t]*//' /etc/apt/sources.list.d/kubernetes.list
-	curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo apt-key add -
+	sudo mkdir -p /etc/apt/keyrings/ # For Ubuntu < 20.04
+	curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg -
 	chronic sudo -E apt update
-	chronic sudo -E apt install --allow-downgrades -y kubelet="$kubernetes_version" kubeadm="$kubernetes_version" kubectl="$kubernetes_version"
+	chronic sudo -E apt install --allow-downgrades -y kubelet kubeadm kubectl
 elif [[ "$ID" =~ ^(alinux|centos|fedora|rhel)$ ]]; then
 	if [ "$(command -v kubelet)" != "" ]; then
 		sudo -E yum autoremove kubelet -y

--- a/.ci/setup_env_ubuntu.sh
+++ b/.ci/setup_env_ubuntu.sh
@@ -12,6 +12,9 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 source "${cidir}/lib.sh"
 
 echo "Update apt repositories"
+# FIXME: workaround the case where the runner is pre-configured with a
+#        broken kubernetes repository.
+sudo -E rm -f /etc/apt/sources.list.d/kubernetes.list
 sudo -E apt update
 
 # Removing man-db, workflow's kept failing, fixes: #4480


### PR DESCRIPTION
The kubernetes repositories at packages.cloud.google.com have been removed as announced in [1]. Switch to the new infrastructure at pkgs.k8s.io. Use the latest available version (v1.29).

[1] https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/ .

Fixes #5811