### PR TITLE
CI: Install protobuf-compiler in the ci environment

### DIFF
--- a/.ci/jenkins_job_build.sh
+++ b/.ci/jenkins_job_build.sh
@@ -231,6 +231,8 @@ run_unit_test() {
 		sudo -E INSTALL_IN_GOPATH=false ./ci/install_yq.sh
 		echo "Install clang"
 		sudo -E apt-get install -y clang
+		echo "Install protobuf-compiler"
+		sudo -E apt-get install -y protobuf-compiler
 		echo "Installing libseccomp library from sources"
 		libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
 		gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)


### PR DESCRIPTION
To test PR kata-containers/kata-containers#8484, the compilation process for the kata-agent relies on protoc. The unit tests failed on arm64:
http://jenkins.katacontainers.io/job/kata-containers-2.0-ubuntu20.04-ARM-unit/3424/console.

Fixes: #5815